### PR TITLE
Added a functest for issue #34

### DIFF
--- a/test/functionalTest/cases/0000_ngsild/ngsild-issue34-relationship-object-as-array.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild-issue34-relationship-object-as-array.test
@@ -1,0 +1,136 @@
+# Copyright 2019 FIWARE Foundation
+#
+# This file is part of OrionLD Context Broker.
+#
+# OrionLD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# OrionLD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# support at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Relationship Attribute with object as an array
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+brokerStart CB 0-255 --prettyPrint
+
+--SHELL--
+
+#
+# 01. POST /ngsi-ld/v1/entities with a relationship that has an object that is an array of URIs
+# 02. Check contents in database
+# 03. GET entity
+#
+
+echo "01. POST /ngsi-ld/v1/entities with One Property and One Relationship"
+echo "===================================================================="
+payload='{
+  "id": "urn:ngsi-ld:T:12:13:14",
+  "type": "T",
+  "AR1": {
+    "type": "Relationship",
+    "object": [ "urn:ngsi-ld:T:1234", "urn:ngsi-ld:T:5678" ]
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities -X POST --payload "$payload"
+echo
+echo
+
+
+echo "02. Check contents in database"
+echo "=============================="
+mongoCmd2 ftest "db.entities.findOne()"
+echo
+echo
+
+
+echo "03. GET entity"
+echo "=============="
+orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:T:12:13:14?prettyPrint=yes&spaces=2' --noPayloadCheck
+echo
+echo
+
+
+--REGEXPECT--
+01. POST /ngsi-ld/v1/entities with One Property and One Relationship
+====================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:T:12:13:14
+Date: REGEX(.*)
+
+
+
+02. Check contents in database
+==============================
+MongoDB shell version REGEX(.*)
+connecting to: REGEX(.*)
+MongoDB server version: REGEX(.*)
+{
+	"_id" : {
+		"id" : "urn:ngsi-ld:T:12:13:14",
+		"type" : "http://example.org/ngsi-ld/default/T",
+		"servicePath" : "/"
+	},
+	"attrNames" : [
+		"http://example.org/ngsi-ld/default/AR1"
+	],
+	"attrs" : {
+		"http://example=org/ngsi-ld/default/AR1" : {
+			"type" : "Relationship",
+			"creDate" : REGEX(.*),
+			"modDate" : REGEX(.*),
+			"value" : [
+				"urn:ngsi-ld:T:1234",
+				"urn:ngsi-ld:T:5678"
+			],
+			"mdNames" : [ ]
+		}
+	},
+	"creDate" : REGEX(.*),
+	"modDate" : REGEX(.*),
+	"lastCorrelator" : ""
+}
+bye
+
+
+03. GET entity
+==============
+HTTP/1.1 200 OK
+Content-Length: 173
+Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+{
+  "id": "urn:ngsi-ld:T:12:13:14",
+  "type": "T",
+  "AR1": {
+    "type": "Relationship",
+    "object": [
+      "urn:ngsi-ld:T:1234",
+      "urn:ngsi-ld:T:5678"
+    ]
+  }
+}
+
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
Issue #34 states that the broker doesn't accept `object` of a relationship attribute to have an Array as value.
Seems the test was done with an outdated broker (or before this feature was actually implemented).
This PR adds a functest that assures that all is OK and ensures it will stay OK.