### PR TITLE
Fixed a bug introduced in a prevoius PR (dateCreated/Modified)

### DIFF
--- a/src/lib/apiTypesV2/Entity.cpp
+++ b/src/lib/apiTypesV2/Entity.cpp
@@ -118,7 +118,7 @@ std::string Entity::render
     else
     {
       // If found - modify it?
-      creDateAttrP->numberValue = creDate;
+      // creDateAttrP->numberValue = creDate;
     }
   }
   if ((modDate != 0) && (uriParamOptions[DATE_MODIFIED] || (std::find(attrsFilter.begin(), attrsFilter.end(), DATE_MODIFIED) != attrsFilter.end())))
@@ -134,7 +134,7 @@ std::string Entity::render
     else
     {
       // If found - modify it?
-      modDateAttrP->numberValue = modDate;
+      // modDateAttrP->numberValue = modDate;
     }
   }
 

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -1881,7 +1881,7 @@ static void setDateCreatedAttribute(ContextElementResponse* notifyCerP)
     else
     {
       // If found - modify it?
-      creDateAttrP->numberValue = notifyCerP->contextElement.entityId.creDate;
+      // creDateAttrP->numberValue = notifyCerP->contextElement.entityId.creDate;
     }
   }
 }
@@ -1907,7 +1907,7 @@ static void setDateModifiedAttribute(ContextElementResponse* notifyCerP)
     else
     {
       // If found - modify it?
-      modDateAttrP->numberValue = notifyCerP->contextElement.entityId.modDate;
+      // modDateAttrP->numberValue = notifyCerP->contextElement.entityId.modDate;
     }
   }
 }
@@ -1945,12 +1945,10 @@ static void setDateCreatedMetadata(ContextElementResponse* notifyCerP)
       {
         Metadata* mdP = new Metadata(NGSI_MD_DATECREATED, DATE_TYPE, caP->creDate);
         caP->metadataVector.push_back(mdP);
-        LM_TMP(("KZ: Added a DATECREATED metadata to a notification"));
       }
       else
       {
         dateCreatedMetadataP->numberValue = caP->creDate;
-        LM_TMP(("KZ: Modified the metadata '%s' to %lu", NGSI_MD_DATECREATED, dateCreatedMetadataP->numberValue));
       }
     }
   }
@@ -1993,7 +1991,6 @@ static void setDateModifiedMetadata(ContextElementResponse* notifyCerP)
       else
       {
         dateModifiedMetadataP->numberValue = caP->modDate;
-        LM_TMP(("KZ: Modified the metadata '%s' to %lu", NGSI_MD_DATEMODIFIED, dateModifiedMetadataP->numberValue));
       }
     }
   }

--- a/src/lib/orionld/serviceRoutines/orionldGetVersion.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetVersion.cpp
@@ -50,7 +50,7 @@ bool orionldGetVersion(ConnectionInfo* ciP)
 
   ciP->responseTree = kjObject(orionldState.kjsonP, NULL);
 
-  nodeP = kjString(orionldState.kjsonP, "branch", "hardening/functests_with_dates_that_often_fail");
+  nodeP = kjString(orionldState.kjsonP, "branch", "bug/entity_dates_overridden_by_user");
   kjChildAdd(ciP->responseTree, nodeP);
 
   nodeP = kjString(orionldState.kjsonP, "kbase version", kbaseVersion);


### PR DESCRIPTION
The commit https://github.com/FIWARE/context.Orion-LD/pull/48/commits/90f21ab52016cd0ad1ea8044e4ba86b55e46dea4 made the functest entity_dates_overridden_by_user.test fail.
This PR modifies slightly was was added in that commit and the functest that failed is now A-OK.
