### PR TITLE
Hardening/138.orionld contexts as https

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ add_definitions(-DLM_ON)
 add_definitions(-DORIONLD)
 
 add_definitions(-fPIC)
+add_definitions(-std=c++11)
 
 # Baseline compiler flags, any change here will affect all build types
 
@@ -86,7 +87,7 @@ ELSEIF (${DISTRO} MATCHES "Ubuntu_18.*")
 ELSEIF (${DISTRO} MATCHES "Debian_9.*")
  set (CMAKE_CXX_FLAGS "-Wall -Wno-unknown-pragmas -D_LARGEFILE64_SOURCE -D_GNU_SOURCE -Werror -Wno-deprecated-declarations -fno-var-tracking-assignments")
 ELSE()
-  set (CMAKE_CXX_FLAGS "-Wall -Wno-unknown-pragmas -D_LARGEFILE64_SOURCE -D_GNU_SOURCE -Werror -fno-var-tracking-assignments")
+  set (CMAKE_CXX_FLAGS "-Wall -Wno-unknown-pragmas -D_LARGEFILE64_SOURCE -D_GNU_SOURCE -Werror -Wno-deprecated-declarations -fno-var-tracking-assignments")
 ENDIF ()
 
 #

--- a/src/lib/orionld/context/orionldCoreContext.h
+++ b/src/lib/orionld/context/orionldCoreContext.h
@@ -39,7 +39,7 @@ extern "C"
 // ORIONLD_CORE_CONTEXT_URL -
 //
 #define ORIONLD_CORE_CONTEXT_URL (char*) \
-  "http://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
+  "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
 
 
 // -----------------------------------------------------------------------------

--- a/src/lib/orionld/serviceRoutines/orionldGetVersion.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetVersion.cpp
@@ -50,7 +50,7 @@ bool orionldGetVersion(ConnectionInfo* ciP)
 
   ciP->responseTree = kjObject(orionldState.kjsonP, NULL);
 
-  nodeP = kjString(orionldState.kjsonP, "branch", "hardening/137.toIx-in-func-test");
+  nodeP = kjString(orionldState.kjsonP, "branch", "hardening/138.orionld-contexts-as-https");
   kjChildAdd(ciP->responseTree, nodeP);
 
   nodeP = kjString(orionldState.kjsonP, "kbase version", kbaseVersion);

--- a/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
@@ -929,7 +929,7 @@ bool orionldPostEntities(ConnectionInfo* ciP)
 
       entityIdP->id        = idNodeP->value.s;
       entityIdP->type      = (typeNodeP != NULL)? typeNodeP->value.s : NULL;
-      entityIdP->isPattern = false;
+      entityIdP->isPattern = "false";
       entityIdP->creDate   = getCurrentTime();
       entityIdP->modDate   = getCurrentTime();
 

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -259,6 +259,9 @@ IF(${DISTRO} MATCHES "CentOS_6.*")
 ELSEIF(${DISTRO} MATCHES "Debian_8.*")
   # It seems that Debian 8.x doesn't like -mt libraries for unit tests... not sure about other Debian versions
   TARGET_LINK_LIBRARIES(unitTest ${STATIC_LIBS} ${BOOST} ${DYNAMIC_LIBS})
+ELSEIF(${DISTRO} MATCHES "Debian_9.*")
+  # Debian9 just like Debian8 doesn't like -mt libraries for unit tests
+  TARGET_LINK_LIBRARIES(unitTest ${STATIC_LIBS} ${BOOST} ${DYNAMIC_LIBS})
 ELSEIF(${DISTRO} MATCHES "Debian_.*")
   TARGET_LINK_LIBRARIES(unitTest ${STATIC_LIBS} ${BOOST_MT} ${DYNAMIC_LIBS})
 


### PR DESCRIPTION
* https for all contexts.
* Debian9 boost libs NOT MT.
Stupid bug false -> "false" (**not** detected by older compilers!!!).
