### PR TITLE
Hardening/157.contexts in responses

### DIFF
--- a/src/lib/orionld/common/OrionldConnection.h
+++ b/src/lib/orionld/common/OrionldConnection.h
@@ -53,6 +53,8 @@ typedef struct OrionldConnectionState
   KAlloc           kalloc;
   char             kallocBuffer[8 * 1024];
   char*            tenant;
+  char*            link;
+  bool             useLinkHeader;
   OrionldContext   inlineContext;
   OrionldContext*  contextP;
   ApiVersion       apiVersion;

--- a/src/lib/orionld/kjTree/kjTreeFromQueryContextResponseWithAttrList.cpp
+++ b/src/lib/orionld/kjTree/kjTreeFromQueryContextResponseWithAttrList.cpp
@@ -33,7 +33,6 @@ extern "C"
 #include "logMsg/traceLevels.h"                                // Lmt*
 
 #include "rest/ConnectionInfo.h"                               // ConnectionInfo
-#include "rest/httpHeaderAdd.h"                                // httpHeaderAdd, httpHeaderLinkAdd
 #include "ngsi10/QueryContextResponse.h"                       // QueryContextResponse
 
 #include "orionld/common/orionldErrorResponse.h"               // OrionldResponseErrorType, orionldErrorResponse
@@ -292,7 +291,7 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
     //
     // FIXME: Use kjTreeFromContextAttribute() !!!
     //
-    // ContextAttribute* contextAttrP = NULL;
+    ContextAttribute* atContextAttributeP = NULL;
 
     for (unsigned int aIx = 0; aIx < ceP->contextAttributeVector.size(); aIx++)
     {
@@ -302,7 +301,7 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
 
       if (strcmp(attrName, "@context") == 0)
       {
-        // contextAttrP = aP;
+        atContextAttributeP = aP;
         continue;
       }
 
@@ -564,59 +563,38 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
     }
 
 
-#if 0
-    //
-    // FIXME: the Link HTTP header should NEVER be returned
     //
     // If no context inside attribute list, then the default context has been used
     //
-    if (contextAttrP == NULL)
+    if (atContextAttributeP == NULL)
     {
       if (ciP->httpHeaders.acceptJsonld == true)
       {
         nodeP = kjString(orionldState.kjsonP, "@context", orionldDefaultContext.url);
         kjChildAdd(top, nodeP);
       }
-      else
-        httpHeaderLinkAdd(ciP, &orionldDefaultContext, NULL);
+      // NOTE: HTTP Link header is added ONLY in orionldMhdConnectionTreat
     }
     else
     {
-      if (ciP->httpHeaders.acceptJsonld == false)
+      // NOTE: HTTP Link header is added ONLY in orionldMhdConnectionTreat
+      if (ciP->httpHeaders.acceptJsonld == true)
       {
-        if (contextAttrP->valueType == orion::ValueTypeString)
+        if (atContextAttributeP->valueType == orion::ValueTypeString)
         {
-          OrionldContext context = { (char*) contextAttrP->stringValue.c_str(), NULL, OrionldUserContext, false, NULL };
-          httpHeaderLinkAdd(ciP, &context, NULL);
-        }
-        else
-        {
-          // FIXME: Implement Context-Servicing for orionld
-          //
-          // If we get here, the context is compound, and can't be returned in the Link HTTP Header.
-          // We now need to create a context in the broker, able to serve it, and in the Link HTTP Header
-          // return this Link
-          //
-          httpHeaderLinkAdd(ciP, NULL, NULL);
-        }
-      }
-      else
-      {
-        if (contextAttrP->valueType == orion::ValueTypeString)
-        {
-          nodeP = kjString(orionldState.kjsonP, "@context", contextAttrP->stringValue.c_str());
+          nodeP = kjString(orionldState.kjsonP, "@context", atContextAttributeP->stringValue.c_str());
           kjChildAdd(top, nodeP);
         }
-        else if (contextAttrP->compoundValueP != NULL)
+        else if (atContextAttributeP->compoundValueP != NULL)
         {
-          if (contextAttrP->compoundValueP->valueType == orion::ValueTypeVector)
+          if (atContextAttributeP->compoundValueP->valueType == orion::ValueTypeVector)
           {
             nodeP = kjArray(orionldState.kjsonP, "@context");
             kjChildAdd(top, nodeP);
 
-            for (unsigned int ix = 0; ix < contextAttrP->compoundValueP->childV.size(); ix++)
+            for (unsigned int ix = 0; ix < atContextAttributeP->compoundValueP->childV.size(); ix++)
             {
-              orion::CompoundValueNode*  compoundP     = contextAttrP->compoundValueP->childV[ix];
+              orion::CompoundValueNode*  compoundP     = atContextAttributeP->compoundValueP->childV[ix];
               KjNode*                    contextItemP  = kjString(orionldState.kjsonP, NULL, compoundP->stringValue.c_str());
               kjChildAdd(nodeP, contextItemP);
             }
@@ -634,7 +612,6 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
         }
       }
     }
-#endif
   }
 
   return root;

--- a/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
@@ -216,9 +216,11 @@ int orionldMhdConnectionInit
   //
   // 1. Prepare orionldState
   //
-  orionldState.requestNo = requestNo;
-  orionldState.tenant    = (char*) "";
-  orionldState.kjsonP    = kjBufferCreate(&orionldState.kjson, &orionldState.kalloc);
+  orionldState.requestNo      = requestNo;
+  orionldState.tenant         = (char*) "";
+  orionldState.kjsonP         = kjBufferCreate(&orionldState.kjson, &orionldState.kalloc);
+  orionldState.link           = NULL;
+  orionldState.useLinkHeader  = true;  // Service routines can set this value to 'false' to avoid having the Link HTTP Header in its output
 
   ciP->kjsonP = orionldState.kjsonP;  // FIXME: ciP->kjsonP is to BE REMOVED. orionldState.kjsonP should be used instead
 

--- a/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
@@ -344,18 +344,16 @@ int orionldMhdConnectionTreat(ConnectionInfo* ciP)
 
       if ((contextNodeP != NULL) && (contextNodeP->value.firstChildP->type != KjString) && (ciP->httpHeaders.acceptJsonld == false) && (ciP->httpHeaders.acceptJson == true))
       {
-      LM_TMP(("Here"));
-        char* url = (char*) malloc(1024);
-        char* details;
+        const int  sz  = 1024;
+        char*      url = (char*) malloc(sz);
+        char*      details;
 
-      LM_TMP(("Here"));
         if (url == NULL)
           LM_X(1, ("Out of memory trying to allocate 1024 bytes for a volatile context"));
 
-        snprintf(url, 1024, "http:localhost:1026//ngsi-ld/ex/v1/contexts/urn:volatile:%d", volatileContextNo);
+        snprintf(url, sz, "http:localhost:1026//ngsi-ld/ex/v1/contexts/urn:volatile:%d", volatileContextNo);
         ++volatileContextNo;
 
-      LM_TMP(("Here"));
         if (orionldContextAppend(url, contextNodeP, OrionldUserContext, &details) == NULL)
         {
           orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to create context", details, OrionldDetailsString);
@@ -363,16 +361,15 @@ int orionldMhdConnectionTreat(ConnectionInfo* ciP)
           goto respond;
         }
 
-      LM_TMP(("Here"));
         orionldState.link = url;
       }
     }
 
-      LM_TMP(("Here"));
     if (contextNodeP == NULL)
       LM_T(LmtContext, ("No @context in payload"));
 
-    //(ciP->httpHeaders.acceptJsonld == false)
+
+    //
     // ContentType Check
     //
     if (contentTypeCheck(ciP, contextNodeP, &errorTitle, &details) == false)
@@ -391,13 +388,11 @@ int orionldMhdConnectionTreat(ConnectionInfo* ciP)
     }
 
 
-    LM_TMP(("Here. contextNodeP at: %p", contextNodeP));
     //
     // If Accept: application/ld+json is not present, and the context is complex, then error
     //
     if ((contextNodeP != NULL) && (ciP->httpHeaders.acceptJsonld == false) && (contextNodeP->type != KjString))
     {
-      LM_TMP(("Here"));
       LM_E(("Complex context but application/ld+json not accepted - this is not acceptable"));
       orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Unacceptable contents", "Complex context but application/ld+json not accepted", OrionldDetailsString);
       ciP->httpStatusCode = SccBadRequest;

--- a/src/lib/orionld/serviceRoutines/orionldGetSubscription.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetSubscription.cpp
@@ -26,7 +26,7 @@
 #include "logMsg/traceLevels.h"                                  // Lmt*
 
 #include "rest/ConnectionInfo.h"                                 // ConnectionInfo
-#include "rest/httpHeaderAdd.h"                                  // httpHeaderAdd, httpHeaderLinkAdd
+#include "rest/httpHeaderAdd.h"                                  // httpHeaderAdd
 #include "mongoBackend/mongoGetSubscriptions.h"                  // mongoGetLdSubscription
 #include "orionld/common/orionldErrorResponse.h"                 // orionldErrorResponseCreate
 #include "orionld/common/OrionldConnection.h"                    // orionldState
@@ -62,14 +62,6 @@ bool orionldGetSubscription(ConnectionInfo* ciP)
   // Transform to KjNode tree
   ciP->httpStatusCode = SccOk;
   ciP->responseTree   = kjTreeFromSubscription(ciP, &subscription);
-
-  if (ciP->httpHeaders.acceptJsonld == false)  // @context in Link header
-  {
-    if (subscription.ldContext != "")
-      httpHeaderLinkAdd(ciP, NULL, subscription.ldContext.c_str());
-    else
-      httpHeaderLinkAdd(ciP, &orionldDefaultContext, NULL);
-  }
 
   return true;
 }

--- a/src/lib/orionld/serviceRoutines/orionldGetVersion.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetVersion.cpp
@@ -67,5 +67,7 @@ bool orionldGetVersion(ConnectionInfo* ciP)
   orionldState.kjsonP->stringBeforeColon = (char*) "";
   orionldState.kjsonP->stringAfterColon  = (char*) " ";
 
+  orionldState.useLinkHeader = false;  // We don't want the Link header for version requests
+
   return true;
 }

--- a/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
@@ -34,7 +34,7 @@ extern "C"
 
 #include "common/globals.h"                                    // parse8601Time
 #include "rest/ConnectionInfo.h"                               // ConnectionInfo
-#include "rest/httpHeaderAdd.h"                                // httpHeaderLocationAdd, httpHeaderLinkAdd
+#include "rest/httpHeaderAdd.h"                                // httpHeaderLocationAdd
 #include "orionTypes/OrionValueType.h"                         // orion::ValueType
 #include "orionTypes/UpdateActionType.h"                       // ActionType
 #include "parse/CompoundValueNode.h"                           // CompoundValueNode

--- a/src/lib/orionld/serviceRoutines/orionldPostEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntity.cpp
@@ -30,7 +30,6 @@
 #include "ngsi10/UpdateContextRequest.h"                       // UpdateContextRequest
 #include "ngsi10/UpdateContextResponse.h"                      // UpdateContextResponse
 #include "rest/ConnectionInfo.h"                               // ConnectionInfo
-#include "rest/httpHeaderAdd.h"                                // httpHeaderLinkAdd
 #include "orionld/common/CHECK.h"                              // CHECK
 #include "orionld/common/SCOMPARE.h"                           // SCOMPAREx
 #include "orionld/common/orionldErrorResponse.h"               // orionldErrorResponseCreate
@@ -194,7 +193,6 @@ bool orionldPostEntity(ConnectionInfo* ciP)
   }
 
   ciP->httpStatusCode = SccNoContent;
-  httpHeaderLinkAdd(ciP, orionldState.contextP, NULL);
 
   return true;
 }

--- a/src/lib/orionld/serviceRoutines/orionldPostSubscriptions.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostSubscriptions.cpp
@@ -36,7 +36,7 @@ extern "C"
 #include "common/globals.h"                                    // parse8601Time
 #include "rest/OrionError.h"                                   // OrionError
 #include "rest/ConnectionInfo.h"                               // ConnectionInfo
-#include "rest/httpHeaderAdd.h"                                // httpHeaderAdd, httpHeaderLinkAdd, httpHeaderLocationAdd
+#include "rest/httpHeaderAdd.h"                                // httpHeaderLocationAdd
 #include "apiTypesV2/HttpInfo.h"                               // HttpInfo
 #include "apiTypesV2/Subscription.h"                           // Subscription
 #include "apiTypesV2/EntID.h"                                  // EntID
@@ -836,7 +836,6 @@ bool orionldPostSubscriptions(ConnectionInfo* ciP)
 
   ciP->httpStatusCode = SccCreated;
   httpHeaderLocationAdd(ciP, "/ngsi-ld/v1/subscriptions/", subId.c_str());
-  httpHeaderLinkAdd(ciP, orionldState.contextP, NULL);
 
   return true;
 }

--- a/src/lib/rest/httpHeaderAdd.h
+++ b/src/lib/rest/httpHeaderAdd.h
@@ -58,7 +58,7 @@ struct OrionldContext;
 //
 // httpHeaderLinkAdd -
 //
-extern void httpHeaderLinkAdd(ConnectionInfo* ciP, OrionldContext* _contextP, const char* _url);
+extern void httpHeaderLinkAdd(ConnectionInfo* ciP, const char* _url);
 
 #endif  // ORIONLD
 #endif  // SRC_LIB_REST_HTTPHEADERADD_H_

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -585,7 +585,11 @@ int httpHeaderGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, const cha
     headerP->servicePathReceived = true;
   }
 #ifdef ORIONLD
-  else if (strcasecmp(key.c_str(), HTTP_LINK) == 0)               headerP->link = value;
+  else if (strcasecmp(key.c_str(), HTTP_LINK) == 0)
+  {
+    headerP->link     = value;  // FIXME: To Be Removed - use orionldState.link instead
+    orionldState.link = (char*) value;
+  }
 #endif
   else
   {

--- a/test/functionalTest/cases/0000_ngsild/ngsild-issue34-relationship-object-as-array.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild-issue34-relationship-object-as-array.test
@@ -113,6 +113,7 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 173
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_@value_@type.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_@value_@type.test
@@ -248,6 +248,7 @@ echo
 HTTP/1.1 400 Bad Request
 Content-Length: 106
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -262,6 +263,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 105
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -276,6 +278,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 106
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -290,6 +293,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 130
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -304,6 +308,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 131
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -318,6 +323,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 142
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -332,6 +338,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 125
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -346,6 +353,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 187
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -378,6 +386,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 170
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -399,6 +408,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 141
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_GET_with_keyValues.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_GET_with_keyValues.test
@@ -106,6 +106,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 221
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -132,6 +133,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 128
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -151,6 +153,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 257
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [

--- a/test/functionalTest/cases/0000_ngsild/ngsild_GET_with_sysAttrs.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_GET_with_sysAttrs.test
@@ -90,6 +90,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 286
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -112,6 +113,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 286
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -134,6 +136,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 160
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_accept_header.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_accept_header.test
@@ -35,7 +35,7 @@ brokerStart CB 212-249
 # 02. Checking mongo content to see URL
 # 03. GET E1, with 'Accept: application/json' - see 'Content-Type: application/json'
 # 04. GET E1, with 'Accept: application/ld+json' - see 'Content-Type: application/ld+json'
-# 05. GET E1, without specific Accept MIME type (application/json is default - should it be for ngsi-ld requests?), see results like step 03
+# 05. GET E1, without specific Accept MIME type (application/json is default), see results like step 03
 #
 
 echo "01. Create Entity E1 with context as a string"
@@ -72,8 +72,8 @@ echo
 echo
 
 
-echo "05. GET E1, without specific Accept MIME type (application/json is default - should it be for ngsi-ld requests?), see results like step 03"
-echo "=========================================================================================================================================="
+echo "05. GET E1, without specific Accept MIME type (application/json is default), see results like step 03"
+echo "====================================================================================================="
 orionCurl --url /ngsi-ld/v1/entities/http://a.b.c/entity/E1
 echo
 echo
@@ -117,6 +117,7 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 42
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -128,21 +129,23 @@ Date: REGEX(.*)
 04. GET E1, with 'Accept: application/ld+json' - see 'Content-Type: application/ld+json'
 ========================================================================================
 HTTP/1.1 200 OK
-Content-Length: 42
+Content-Length: 149
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
 {
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld",
     "id": "http://a.b.c/entity/E1",
     "type": "A"
 }
 
 
-05. GET E1, without specific Accept MIME type (application/json is default - should it be for ngsi-ld requests?), see results like step 03
-==========================================================================================================================================
+05. GET E1, without specific Accept MIME type (application/json is default), see results like step 03
+=====================================================================================================
 HTTP/1.1 200 OK
 Content-Length: 42
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_accept_header_missing.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_accept_header_missing.test
@@ -73,6 +73,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 110
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_add_and_modify_attr.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_add_and_modify_attr.test
@@ -109,6 +109,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 124
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -135,6 +136,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 178
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_add_attr.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_add_attr.test
@@ -109,6 +109,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 124
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -135,6 +136,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 240
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_attribute_deletion.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_attribute_deletion.test
@@ -104,6 +104,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 223
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -138,6 +139,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 166
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -160,6 +162,7 @@ Date: REGEX(.*)
 HTTP/1.1 404 Not Found
 Content-Length: 140
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_bad_verb_with_unsupported_url_path.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_bad_verb_with_unsupported_url_path.test
@@ -56,6 +56,7 @@ echo
 HTTP/1.1 404 Not Found
 Content-Length: 122
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_big_integer.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_big_integer.test
@@ -86,6 +86,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 116
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_content_type_and_context.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_content_type_and_context.test
@@ -39,9 +39,9 @@ brokerStart CB 212-249
 # 06. Content-Type: application/ld+json + context in HTTP Header - see error
 # 07. Content-Type: application/ld+json + context in HTTP Header + context in payload - see error
 #
-# 08. GET Entity from step 01 - see correct URI Expansion (matching Default URL @context)
-# 09. GET Entity from step 04 - see correct URI Expansion (matching @context in payload)
-# 10. GET Entity from step 05 - see correct URI Expansion (matching @context in HTTP Header)
+# 08. GET Entity from step 01 - see correct URI Expansion (matching Default URL @context in payload)
+# 09. GET Entity from step 04 - see correct URI Expansion (matching @context in Link header)
+# 10. GET Entity from step 05 - see correct URI Expansion (matching @context in payload)
 #
 
 
@@ -129,22 +129,22 @@ echo
 echo
 
 
-echo "08. GET Entity from step 01 - see correct URI Expansion (matching Default URL @context)"
-echo "======================================================================================="
+echo "08. GET Entity from step 01 - see correct URI Expansion (matching Default URL @context in payload)"
+echo "=================================================================================================="
 orionCurl --url /ngsi-ld/v1/entities/http://a.b.c/entity/E1 -H "Accept: application/ld+json"
 echo
 echo
 
 
-echo "09. GET Entity from step 04 - see correct URI Expansion (matching @context in payload)"
-echo "======================================================================================"
+echo "09. GET Entity from step 04 - see correct URI Expansion (matching @context in Link header)"
+echo "=========================================================================================="
 orionCurl --url /ngsi-ld/v1/entities/http://a.b.c/entity/E4
 echo
 echo
 
 
-echo "10. GET Entity from step 05 - see correct URI Expansion (matching @context in HTTP Header)"
-echo "=========================================================================================="
+echo "10. GET Entity from step 05 - see correct URI Expansion (matching @context in payload)"
+echo "======================================================================================"
 orionCurl --url /ngsi-ld/v1/entities/http://a.b.c/entity/E5 -H "Accept: application/ld+json"
 echo
 echo
@@ -165,6 +165,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 189
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -179,6 +180,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 191
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -211,6 +213,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 203
 Content-Type: application/json
+Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -225,6 +228,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 203
 Content-Type: application/json
+Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -234,24 +238,26 @@ Date: REGEX(.*)
 }
 
 
-08. GET Entity from step 01 - see correct URI Expansion (matching Default URL @context)
-=======================================================================================
+08. GET Entity from step 01 - see correct URI Expansion (matching Default URL @context in payload)
+==================================================================================================
 HTTP/1.1 200 OK
-Content-Length: 42
+Content-Length: 149
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
 {
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld",
     "id": "http://a.b.c/entity/E1",
     "type": "A"
 }
 
 
-09. GET Entity from step 04 - see correct URI Expansion (matching @context in payload)
-======================================================================================
+09. GET Entity from step 04 - see correct URI Expansion (matching @context in Link header)
+==========================================================================================
 HTTP/1.1 200 OK
 Content-Length: 42
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -260,14 +266,15 @@ Date: REGEX(.*)
 }
 
 
-10. GET Entity from step 05 - see correct URI Expansion (matching @context in HTTP Header)
-==========================================================================================
+10. GET Entity from step 05 - see correct URI Expansion (matching @context in payload)
+======================================================================================
 HTTP/1.1 200 OK
-Content-Length: 107
+Content-Length: 214
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
 {
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld",
     "http://example.org/P100": {
         "type": "Property",
         "value": 100.0

--- a/test/functionalTest/cases/0000_ngsild/ngsild_context_errors.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_context_errors.test
@@ -153,6 +153,7 @@ echo
 HTTP/1.1 400 Bad Request
 Content-Length: 132
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -167,6 +168,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 132
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_context_in_header_or_payload_when_entity_has_a_context.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_context_in_header_or_payload_when_entity_has_a_context.test
@@ -102,6 +102,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 287
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [
@@ -125,7 +126,7 @@ Date: REGEX(.*)
 03. GET all entities using application/ld+json - see context in payload
 =======================================================================
 HTTP/1.1 200 OK
-Content-Length: 287
+Content-Length: 400
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -141,7 +142,8 @@ Date: REGEX(.*)
         "object": "urn:ngsi-ld:T2:6789"
       },
       "observedAt": "2018-12-04T12:00:00Z"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 
@@ -152,6 +154,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 257
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -173,7 +176,7 @@ Date: REGEX(.*)
 05. GET the entity using application/ld+json - see context in payload
 =====================================================================
 HTTP/1.1 200 OK
-Content-Length: 257
+Content-Length: 368
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -188,7 +191,8 @@ Date: REGEX(.*)
       "object": "urn:ngsi-ld:T2:6789"
     },
     "observedAt": "2018-12-04T12:00:00Z"
-  }
+  },
+  "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
 }
 
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_context_in_header_or_payload_when_entity_has_no_context.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_context_in_header_or_payload_when_entity_has_no_context.test
@@ -101,6 +101,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 287
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [
@@ -124,7 +125,7 @@ Date: REGEX(.*)
 03. GET all entities using application/ld+json - see context in payload
 =======================================================================
 HTTP/1.1 200 OK
-Content-Length: 287
+Content-Length: 400
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -140,7 +141,8 @@ Date: REGEX(.*)
         "object": "urn:ngsi-ld:T2:6789"
       },
       "observedAt": "2018-12-04T12:00:00Z"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 
@@ -151,6 +153,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 257
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -172,7 +175,7 @@ Date: REGEX(.*)
 05. GET the entity using application/ld+json - see context in payload
 =====================================================================
 HTTP/1.1 200 OK
-Content-Length: 257
+Content-Length: 368
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -187,7 +190,8 @@ Date: REGEX(.*)
       "object": "urn:ngsi-ld:T2:6789"
     },
     "observedAt": "2018-12-04T12:00:00Z"
-  }
+  },
+  "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
 }
 
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get.test
@@ -182,7 +182,7 @@ Date: REGEX(.*)
 05. GET all entities of type T, see E1 and E3
 =============================================
 HTTP/1.1 200 OK
-Content-Length: 255
+Content-Length: 481
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -193,7 +193,8 @@ Date: REGEX(.*)
     "A1": {
       "type": "Property",
       "value": "E1"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -201,7 +202,8 @@ Date: REGEX(.*)
     "A1": {
       "type": "Property",
       "value": "E3"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 
@@ -210,7 +212,7 @@ Date: REGEX(.*)
 06. GET all entities of type T2, see E2 and E4
 ==============================================
 HTTP/1.1 200 OK
-Content-Length: 257
+Content-Length: 483
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -221,7 +223,8 @@ Date: REGEX(.*)
     "A1": {
       "type": "Property",
       "value": "E2"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E4",
@@ -229,7 +232,8 @@ Date: REGEX(.*)
     "A1": {
       "type": "Property",
       "value": "E4"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 
@@ -238,7 +242,7 @@ Date: REGEX(.*)
 07. GET all entities with id E1, see entity E1 only
 ===================================================
 HTTP/1.1 200 OK
-Content-Length: 129
+Content-Length: 242
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -249,7 +253,8 @@ Date: REGEX(.*)
     "A1": {
       "type": "Property",
       "value": "E1"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 
@@ -258,7 +263,7 @@ Date: REGEX(.*)
 08. GET all entities with id E.*, see all four entities
 =======================================================
 HTTP/1.1 200 OK
-Content-Length: 509
+Content-Length: 961
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -269,7 +274,8 @@ Date: REGEX(.*)
     "A1": {
       "type": "Property",
       "value": "E1"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E2",
@@ -277,7 +283,8 @@ Date: REGEX(.*)
     "A1": {
       "type": "Property",
       "value": "E2"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -285,7 +292,8 @@ Date: REGEX(.*)
     "A1": {
       "type": "Property",
       "value": "E3"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E4",
@@ -293,7 +301,8 @@ Date: REGEX(.*)
     "A1": {
       "type": "Property",
       "value": "E4"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_eq.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_eq.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A equal to 2018-11-23T08:00:00.00Z - see E3
 ======================================================================================
 HTTP/1.1 200 OK
-Content-Length: 149
+Content-Length: 262
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A": {
       "type": "TemporalProperty",
       "value": 1542960000.000000
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_greater_than.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_greater_than.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A > 2018-11-21T08:00:00.00Z - see E3
 ===============================================================================
 HTTP/1.1 200 OK
-Content-Length: 149
+Content-Length: 262
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A": {
       "type": "TemporalProperty",
       "value": 1542960000.000000
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_greater_than_or_equal.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_greater_than_or_equal.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A >= 2018-11-21T08:00:00.00Z - see E1 and E3
 =======================================================================================
 HTTP/1.1 200 OK
-Content-Length: 295
+Content-Length: 521
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A": {
       "type": "TemporalProperty",
       "value": 1542787200.000000
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -168,7 +169,8 @@ Date: REGEX(.*)
     "A": {
       "type": "TemporalProperty",
       "value": 1542960000.000000
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_less_than.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_less_than.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A < 2018-11-22T08:00:00.00Z - see E1
 ===============================================================================
 HTTP/1.1 200 OK
-Content-Length: 149
+Content-Length: 262
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A": {
       "type": "TemporalProperty",
       "value": 1542787200.000000
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_less_than_or_equal.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_less_than_or_equal.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A <= 2018-11-25T08:00:00.00Z - see E1 and E3
 =======================================================================================
 HTTP/1.1 200 OK
-Content-Length: 295
+Content-Length: 521
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A": {
       "type": "TemporalProperty",
       "value": 1542787200.000000
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -168,7 +169,8 @@ Date: REGEX(.*)
     "A": {
       "type": "TemporalProperty",
       "value": 1542960000.000000
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_not_eq.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_not_eq.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A not equal to 2018-11-23T08:00:00.00Z - see E1
 ==========================================================================================
 HTTP/1.1 200 OK
-Content-Length: 149
+Content-Length: 262
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A": {
       "type": "TemporalProperty",
       "value": 1542787200.000000
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_bool_attr_doesnt_exist.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_bool_attr_doesnt_exist.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that does not have an attribute A - see E2 and E4
 ======================================================================
 HTTP/1.1 200 OK
-Content-Length: 258
+Content-Length: 484
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A2": {
       "type": "Property",
       "value": true
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E4",
@@ -168,7 +169,8 @@ Date: REGEX(.*)
     "A2": {
       "type": "Property",
       "value": false
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_bool_attr_eq.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_bool_attr_eq.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A equal to false - see E3
 ====================================================================
 HTTP/1.1 200 OK
-Content-Length: 129
+Content-Length: 242
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": false
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_bool_attr_exists.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_bool_attr_exists.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A - see E1 and E3
 ============================================================
 HTTP/1.1 200 OK
-Content-Length: 254
+Content-Length: 480
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": true
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -168,7 +169,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": false
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_bool_attr_not_eq.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_bool_attr_not_eq.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A2 not equal to false - see E2
 =========================================================================
 HTTP/1.1 200 OK
-Content-Length: 130
+Content-Length: 243
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A2": {
       "type": "Property",
       "value": true
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_doesnt_exist.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_doesnt_exist.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that does not have an attribute A - see E2 and E4
 ======================================================================
 HTTP/1.1 200 OK
-Content-Length: 265
+Content-Length: 491
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A2": {
       "type": "Property",
       "value": 2.000000
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E4",
@@ -168,7 +169,8 @@ Date: REGEX(.*)
     "A2": {
       "type": "Property",
       "value": 4.000000
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_eq.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_eq.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A equal to 3 - see E3
 ================================================================
 HTTP/1.1 200 OK
-Content-Length: 132
+Content-Length: 245
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": 3.000000
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_exists.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_exists.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A - see E1 and E3
 ============================================================
 HTTP/1.1 200 OK
-Content-Length: 261
+Content-Length: 487
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": 1.000000
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -168,7 +169,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": 3.000000
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_greater_than.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_greater_than.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A > 2 - see E3
 =========================================================
 HTTP/1.1 200 OK
-Content-Length: 132
+Content-Length: 245
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": 3.000000
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_greater_than_or_equal.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_greater_than_or_equal.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A >= 3 - see E3
 ==========================================================
 HTTP/1.1 200 OK
-Content-Length: 132
+Content-Length: 245
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": 3.000000
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_less_than.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_less_than.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A < 2 - see E1
 =========================================================
 HTTP/1.1 200 OK
-Content-Length: 132
+Content-Length: 245
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": 1.000000
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_less_than_or_equal.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_less_than_or_equal.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A <= 3 - see E1 and E3
 =================================================================
 HTTP/1.1 200 OK
-Content-Length: 261
+Content-Length: 487
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": 1.000000
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -168,7 +169,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": 3.000000
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_list.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_list.test
@@ -175,7 +175,7 @@ Date: REGEX(.*)
 06. GET all entities that has an attribute A == 1 or 3 - see E1 and E3
 ======================================================================
 HTTP/1.1 200 OK
-Content-Length: 261
+Content-Length: 487
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -186,7 +186,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": 1.000000
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -194,7 +195,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": 3.000000
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_not_eq.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_not_eq.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A2 not equal to 4 - see E2
 =====================================================================
 HTTP/1.1 200 OK
-Content-Length: 134
+Content-Length: 247
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A2": {
       "type": "Property",
       "value": 2.000000
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_range.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_range.test
@@ -175,7 +175,7 @@ Date: REGEX(.*)
 06. GET all entities that has an attribute A == 1 to 3 - see E1 and E3
 ======================================================================
 HTTP/1.1 200 OK
-Content-Length: 261
+Content-Length: 487
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -186,7 +186,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": 1.000000
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -194,7 +195,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": 3.000000
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_doesnt_exist.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_doesnt_exist.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that does not have an attribute A - see E2 and E4
 ======================================================================
 HTTP/1.1 200 OK
-Content-Length: 255
+Content-Length: 481
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A2": {
       "type": "Property",
       "value": "2"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E4",
@@ -168,7 +169,8 @@ Date: REGEX(.*)
     "A2": {
       "type": "Property",
       "value": "4"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_eq.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_eq.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A equal to "3" - see E3
 ==================================================================
 HTTP/1.1 200 OK
-Content-Length: 127
+Content-Length: 240
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": "3"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_exists.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_exists.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A - see E1 and E3
 ============================================================
 HTTP/1.1 200 OK
-Content-Length: 251
+Content-Length: 477
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": "1"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -168,7 +169,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": "3"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_greater_than.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_greater_than.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A > "1" - see E3
 ===========================================================
 HTTP/1.1 200 OK
-Content-Length: 127
+Content-Length: 240
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": "3"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_greater_than_or_equal.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_greater_than_or_equal.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A >= "1" - see E1 and E3
 ===================================================================
 HTTP/1.1 200 OK
-Content-Length: 251
+Content-Length: 477
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": "1"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -168,7 +169,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": "3"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_less_than.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_less_than.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A < "3" - see E1
 ===========================================================
 HTTP/1.1 200 OK
-Content-Length: 127
+Content-Length: 240
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": "1"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_less_than_or_equal.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_less_than_or_equal.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A <= "3" - see E1 and E3
 ===================================================================
 HTTP/1.1 200 OK
-Content-Length: 251
+Content-Length: 477
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": "1"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -168,7 +169,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": "3"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_list.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_list.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A in list '1','2','5' - see E1
 =========================================================================
 HTTP/1.1 200 OK
-Content-Length: 127
+Content-Length: 240
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": "1"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_not_eq.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_not_eq.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A not equal to "3" - see E1
 ======================================================================
 HTTP/1.1 200 OK
-Content-Length: 127
+Content-Length: 240
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": "1"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_pattern.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_pattern.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A matching 'one' - see E1
 ====================================================================
 HTTP/1.1 200 OK
-Content-Length: 131
+Content-Length: 244
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": "1one1"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_range.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_range.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A in list '1' to '5' - see E1 and E3
 ===============================================================================
 HTTP/1.1 200 OK
-Content-Length: 251
+Content-Length: 477
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -160,7 +160,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": "1"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -168,7 +169,8 @@ Date: REGEX(.*)
     "A": {
       "type": "Property",
       "value": "3"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_attrs_and_without_any_context.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_attrs_and_without_any_context.test
@@ -93,6 +93,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 367
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_attrs_uri_param_attr_list.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_attrs_uri_param_attr_list.test
@@ -204,7 +204,7 @@ Date: REGEX(.*)
 05. GET all entities with attr A1, see E1 only
 ==============================================
 HTTP/1.1 200 OK
-Content-Length: 132
+Content-Length: 245
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -215,7 +215,8 @@ Date: REGEX(.*)
     "A1": {
       "type": "Property",
       "value": "E1/A1"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 
@@ -224,7 +225,7 @@ Date: REGEX(.*)
 06. GET all entities with attr A1 and A5, see E1 and E4
 =======================================================
 HTTP/1.1 200 OK
-Content-Length: 261
+Content-Length: 487
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -235,7 +236,8 @@ Date: REGEX(.*)
     "A1": {
       "type": "Property",
       "value": "E1/A1"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E4",
@@ -243,7 +245,8 @@ Date: REGEX(.*)
     "A5": {
       "type": "Property",
       "value": "E4/A5"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 
@@ -252,7 +255,7 @@ Date: REGEX(.*)
 07. GET all entities with attr A2 and A6, see E1 and E2
 =======================================================
 HTTP/1.1 200 OK
-Content-Length: 261
+Content-Length: 487
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -263,7 +266,8 @@ Date: REGEX(.*)
     "A2": {
       "type": "Property",
       "value": "E1/A2"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E2",
@@ -271,7 +275,8 @@ Date: REGEX(.*)
     "A2": {
       "type": "Property",
       "value": "E2/A2"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 
@@ -280,7 +285,7 @@ Date: REGEX(.*)
 08. GET all entities with attr A2, A3 and A4, see all four entities
 ===================================================================
 HTTP/1.1 200 OK
-Content-Length: 655
+Content-Length: 1107
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -291,7 +296,8 @@ Date: REGEX(.*)
     "A2": {
       "type": "Property",
       "value": "E1/A2"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E2",
@@ -303,7 +309,8 @@ Date: REGEX(.*)
     "A3": {
       "type": "Property",
       "value": "E2/A3"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -315,7 +322,8 @@ Date: REGEX(.*)
     "A4": {
       "type": "Property",
       "value": "E3/A4"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E4",
@@ -323,7 +331,8 @@ Date: REGEX(.*)
     "A4": {
       "type": "Property",
       "value": "E4/A4"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 
@@ -332,7 +341,7 @@ Date: REGEX(.*)
 09. GET all entities with attr A2, A3, see E1, E2 and E3
 ========================================================
 HTTP/1.1 200 OK
-Content-Length: 458
+Content-Length: 797
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -343,7 +352,8 @@ Date: REGEX(.*)
     "A2": {
       "type": "Property",
       "value": "E1/A2"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E2",
@@ -355,7 +365,8 @@ Date: REGEX(.*)
     "A3": {
       "type": "Property",
       "value": "E2/A3"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -363,7 +374,8 @@ Date: REGEX(.*)
     "A3": {
       "type": "Property",
       "value": "E3/A3"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_attrs_uri_param_entity_without_any_matching_attrs.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_attrs_uri_param_entity_without_any_matching_attrs.test
@@ -83,13 +83,14 @@ Date: REGEX(.*)
 02. GET /ngsi-ld/v1/entities/http://a.b.c/entity/E1 with URI param 'attrs' set to 'A3' - see E1 but without any attributes
 ==========================================================================================================================
 HTTP/1.1 200 OK
-Content-Length: 52
+Content-Length: 163
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
 {
   "id": "http://a.b.c/entity/E1",
-  "type": "T"
+  "type": "T",
+  "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
 }
 
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_attrs_uri_param_just_one_attr.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_attrs_uri_param_just_one_attr.test
@@ -181,7 +181,7 @@ Date: REGEX(.*)
 05. GET all entities with attr A1, see E1 only
 ==============================================
 HTTP/1.1 200 OK
-Content-Length: 132
+Content-Length: 245
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -192,7 +192,8 @@ Date: REGEX(.*)
     "A1": {
       "type": "Property",
       "value": "E1/A1"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 
@@ -201,7 +202,7 @@ Date: REGEX(.*)
 06. GET all entities with attr A2, see E1 and E2
 ================================================
 HTTP/1.1 200 OK
-Content-Length: 261
+Content-Length: 487
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -212,7 +213,8 @@ Date: REGEX(.*)
     "A2": {
       "type": "Property",
       "value": "E1/A2"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E2",
@@ -220,7 +222,8 @@ Date: REGEX(.*)
     "A2": {
       "type": "Property",
       "value": "E2/A2"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_uri_param_id_list.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_uri_param_id_list.test
@@ -164,7 +164,7 @@ Date: REGEX(.*)
 05. GET entities with id E2 or E4 - see E2 and E4
 =================================================
 HTTP/1.1 200 OK
-Content-Length: 257
+Content-Length: 483
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -175,7 +175,8 @@ Date: REGEX(.*)
     "A1": {
       "type": "Property",
       "value": "E2"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E4",
@@ -183,7 +184,8 @@ Date: REGEX(.*)
     "A1": {
       "type": "Property",
       "value": "E4"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 
@@ -192,7 +194,7 @@ Date: REGEX(.*)
 06. GET entities with id E1 or E5 - see E1
 ==========================================
 HTTP/1.1 200 OK
-Content-Length: 129
+Content-Length: 242
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -203,7 +205,8 @@ Date: REGEX(.*)
     "A1": {
       "type": "Property",
       "value": "E1"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_uri_param_type_list.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_uri_param_type_list.test
@@ -172,7 +172,7 @@ Date: REGEX(.*)
 05. GET entities with type T - see E1
 =====================================
 HTTP/1.1 200 OK
-Content-Length: 129
+Content-Length: 242
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -183,7 +183,8 @@ Date: REGEX(.*)
     "A1": {
       "type": "Property",
       "value": "E1"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 
@@ -192,7 +193,7 @@ Date: REGEX(.*)
 06. GET entities with type T2 or T3 or T4 - see E2, E3 and E4
 =============================================================
 HTTP/1.1 200 OK
-Content-Length: 384
+Content-Length: 723
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -203,7 +204,8 @@ Date: REGEX(.*)
     "A1": {
       "type": "Property",
       "value": "E2"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -211,7 +213,8 @@ Date: REGEX(.*)
     "A1": {
       "type": "Property",
       "value": "E3"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E4",
@@ -219,7 +222,8 @@ Date: REGEX(.*)
     "A1": {
       "type": "Property",
       "value": "E4"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 
@@ -228,7 +232,7 @@ Date: REGEX(.*)
 07. GET entities with type T2 or T1 - see E2
 ============================================
 HTTP/1.1 200 OK
-Content-Length: 130
+Content-Length: 243
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -239,7 +243,8 @@ Date: REGEX(.*)
     "A1": {
       "type": "Property",
       "value": "E2"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation.test
@@ -241,6 +241,7 @@ echo
 HTTP/1.1 400 Bad Request
 Content-Length: 109
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -283,6 +284,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 132
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -320,6 +322,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 153
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -334,6 +337,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 115
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -348,6 +352,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 119
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -362,6 +367,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 163
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -376,6 +382,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 168
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -390,6 +397,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 167
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_context_as_vector_of_uris.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_context_as_vector_of_uris.test
@@ -108,7 +108,7 @@ bye
 03. GET entity
 ==============
 HTTP/1.1 200 OK
-Content-Length: 132
+Content-Length: 243
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -118,7 +118,8 @@ Date: REGEX(.*)
   "DateProp": {
     "type": "Property",
     "value": "2018-12-04T12:00:00"
-  }
+  },
+  "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
 }
 
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_empty_entity.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_empty_entity.test
@@ -68,6 +68,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 42
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_ld_single_uri.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_ld_single_uri.test
@@ -82,7 +82,7 @@ Date: REGEX(.*)
 02. GET entity
 ==============
 HTTP/1.1 200 OK
-Content-Length: 344
+Content-Length: 455
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -106,7 +106,8 @@ Date: REGEX(.*)
   "R1": {
     "type": "Relationship",
     "object": "urn:ngsi-ld:T2:6789"
-  }
+  },
+  "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
 }
 
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_ld_single_uri_and_datetime_property_inline.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_ld_single_uri_and_datetime_property_inline.test
@@ -170,7 +170,7 @@ bye
 03. GET entity
 ==============
 HTTP/1.1 200 OK
-Content-Length: 475
+Content-Length: 586
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -201,7 +201,8 @@ Date: REGEX(.*)
   "R1": {
     "type": "Relationship",
     "object": "urn:ngsi-ld:T2:6789"
-  }
+  },
+  "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
 }
 
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_geoproperty.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_geoproperty.test
@@ -129,6 +129,7 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 212
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_property.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_property.test
@@ -72,6 +72,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 111
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_property_DateTime.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_property_DateTime.test
@@ -116,6 +116,7 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 177
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_property_observedAt.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_property_observedAt.test
@@ -118,6 +118,7 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 156
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_property_one_relationship.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_property_one_relationship.test
@@ -122,6 +122,7 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 190
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_property_property.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_property_property.test
@@ -127,6 +127,7 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 228
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_property_relationship.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_property_relationship.test
@@ -127,6 +127,7 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 246
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_property_unitCode.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_property_unitCode.test
@@ -118,6 +118,7 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 135
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_relationship_observedAt.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_relationship_observedAt.test
@@ -118,6 +118,7 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 173
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_relationship_property.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_relationship_property.test
@@ -122,6 +122,7 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 198
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_relationship_relationship.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_relationship_relationship.test
@@ -122,6 +122,7 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 222
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_parse_error_in_payload.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_parse_error_in_payload.test
@@ -56,6 +56,7 @@ echo
 HTTP/1.1 400 Bad Request
 Content-Length: 150
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_twice_error_report.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_twice_error_report.test
@@ -80,6 +80,7 @@ Date: REGEX(.*)
 HTTP/1.1 409 Conflict
 Content-Length: 126
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_delete.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_delete.test
@@ -87,7 +87,7 @@ Date: REGEX(.*)
 02. GET E1
 ==========
 HTTP/1.1 200 OK
-Content-Length: 110
+Content-Length: 221
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -97,7 +97,8 @@ Date: REGEX(.*)
   "name": {
     "type": "Property",
     "value": "1"
-  }
+  },
+  "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
 }
 
 
@@ -115,6 +116,7 @@ Date: REGEX(.*)
 HTTP/1.1 404 Not Found
 Content-Length: 134
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_deletion.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_deletion.test
@@ -129,13 +129,14 @@ bye
 03. GET the entity
 ==================
 HTTP/1.1 200 OK
-Content-Length: 52
+Content-Length: 163
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
 {
   "id": "urn:ngsi-ld:T:12:13:14",
-  "type": "T"
+  "type": "T",
+  "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
 }
 
 
@@ -168,6 +169,7 @@ Date: REGEX(.*)
 HTTP/1.1 404 Not Found
 Content-Length: 166
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_double_creation.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_double_creation.test
@@ -96,11 +96,12 @@ Date: REGEX(.*)
 02. GET /ngsi-ld/v1/entities/E1
 ===============================
 HTTP/1.1 200 OK
-Content-Length: 86
+Content-Length: 193
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
 {
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld",
     "id": "http://a.b.c/entity/E1",
     "name": {
         "type": "Property",
@@ -115,6 +116,7 @@ Date: REGEX(.*)
 HTTP/1.1 409 Conflict
 Content-Length: 126
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -127,11 +129,12 @@ Date: REGEX(.*)
 04. GET /ngsi-ld/v1/entities/E1, making sure step 02 didn't modify anything
 ===========================================================================
 HTTP/1.1 200 OK
-Content-Length: 86
+Content-Length: 193
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
 {
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld",
     "id": "http://a.b.c/entity/E1",
     "name": {
         "type": "Property",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_get.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_get.test
@@ -121,7 +121,7 @@ Date: REGEX(.*)
 03. GET E1, see default context, pretty-print with 4 spaces
 ===========================================================
 HTTP/1.1 200 OK
-Content-Length: 131
+Content-Length: 244
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -131,7 +131,8 @@ Date: REGEX(.*)
     "name": {
         "type": "Property",
         "value": "John 6"
-    }
+    },
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
 }
 
 
@@ -139,7 +140,7 @@ Date: REGEX(.*)
 04. GET E2, see test context, pretty-print with default number of spaces (2)
 ============================================================================
 HTTP/1.1 200 OK
-Content-Length: 115
+Content-Length: 226
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -149,7 +150,8 @@ Date: REGEX(.*)
   "name": {
     "type": "Property",
     "value": "John 6"
-  }
+  },
+  "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
 }
 
 
@@ -157,11 +159,11 @@ Date: REGEX(.*)
 05. GET E2, but without prettyPrint
 ===================================
 HTTP/1.1 200 OK
-Content-Length: 86
+Content-Length: 193
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
-{"id":"http://a.b.c/entity/E2","type":"A","name":{"type":"Property","value":"John 6"}}
+{"id":"http://a.b.c/entity/E2","type":"A","name":{"type":"Property","value":"John 6"},"@context":"https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"}
 
 
 06. Attempt to GET non-existing E3, see 404 not Found
@@ -169,6 +171,7 @@ Date: REGEX(.*)
 HTTP/1.1 404 Not Found
 Content-Length: 134
 Content-Type: application/json
+Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_get_with_attrs.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_get_with_attrs.test
@@ -88,6 +88,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 235
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_get_with_correct_alias_replacement.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_get_with_correct_alias_replacement.test
@@ -110,7 +110,7 @@ bye
 03. GET E1, see short name for 'name', not its long name
 ========================================================
 HTTP/1.1 200 OK
-Content-Length: 115
+Content-Length: 226
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -120,7 +120,8 @@ Date: REGEX(.*)
   "name": {
     "type": "Property",
     "value": "John 1"
-  }
+  },
+  "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
 }
 
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_get_with_mismatch_in_type_due_to_contexts.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_get_with_mismatch_in_type_due_to_contexts.test
@@ -124,6 +124,7 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 2
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []

--- a/test/functionalTest/cases/0000_ngsild/ngsild_error_reject_entity_if_attribute_type_not_recognized.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_error_reject_entity_if_attribute_type_not_recognized.test
@@ -55,6 +55,7 @@ echo
 HTTP/1.1 400 Bad Request
 Content-Length: 116
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_error_reject_entity_if_context_in_json_payload.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_error_reject_entity_if_context_in_json_payload.test
@@ -52,6 +52,7 @@ echo
 HTTP/1.1 400 Bad Request
 Content-Length: 191
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_error_reject_entity_if_jsonld_link_header_is_provided_with_jsonld_payload.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_error_reject_entity_if_jsonld_link_header_is_provided_with_jsonld_payload.test
@@ -51,6 +51,7 @@ echo
 HTTP/1.1 400 Bad Request
 Content-Length: 203
 Content-Type: application/json
+Link: <http://a.b.c/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_error_reject_entity_if_no_context_in_jsonld_payload.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_error_reject_entity_if_no_context_in_jsonld_payload.test
@@ -51,6 +51,7 @@ echo
 HTTP/1.1 400 Bad Request
 Content-Length: 189
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_error_reject_entity_if_property_value_is_null.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_error_reject_entity_if_property_value_is_null.test
@@ -55,6 +55,7 @@ echo
 HTTP/1.1 400 Bad Request
 Content-Length: 163
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_error_reject_entity_if_property_without_value.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_error_reject_entity_if_property_without_value.test
@@ -55,6 +55,7 @@ echo
 HTTP/1.1 400 Bad Request
 Content-Length: 161
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_error_reject_entity_if_relationship_object_is_null.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_error_reject_entity_if_relationship_object_is_null.test
@@ -55,6 +55,7 @@ echo
 HTTP/1.1 400 Bad Request
 Content-Length: 221
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_error_reject_entity_if_relationship_without_object.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_error_reject_entity_if_relationship_without_object.test
@@ -55,6 +55,7 @@ echo
 HTTP/1.1 400 Bad Request
 Content-Length: 166
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_error_reject_entity_whose_id_is_not_a_uri.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_error_reject_entity_whose_id_is_not_a_uri.test
@@ -51,6 +51,7 @@ echo
 HTTP/1.1 400 Bad Request
 Content-Length: 120
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_geoqueries-error-handling.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_geoqueries-error-handling.test
@@ -205,6 +205,7 @@ echo
 HTTP/1.1 400 Bad Request
 Content-Length: 198
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -219,6 +220,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 202
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -233,6 +235,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 182
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -247,6 +250,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 167
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -261,6 +265,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 191
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -275,6 +280,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 196
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -289,6 +295,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 158
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -303,6 +310,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 130
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -317,6 +325,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 139
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -331,6 +340,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 139
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -345,6 +355,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 131
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_geoqueries-point.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_geoqueries-point.test
@@ -171,6 +171,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 2
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []
@@ -181,6 +182,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 438
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [
@@ -234,6 +236,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 145
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [
@@ -259,6 +262,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 146
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [
@@ -284,6 +288,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 149
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [
@@ -309,6 +314,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 293
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [

--- a/test/functionalTest/cases/0000_ngsild/ngsild_geoqueries-polygon.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_geoqueries-polygon.test
@@ -157,6 +157,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 223
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [
@@ -202,6 +203,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 2
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []
@@ -212,6 +214,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 136
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [
@@ -237,6 +240,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 2
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []

--- a/test/functionalTest/cases/0000_ngsild/ngsild_incompatible_accept_for_complex_contexts.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_incompatible_accept_for_complex_contexts.test
@@ -134,6 +134,7 @@ echo
 HTTP/1.1 400 Bad Request
 Content-Length: 157
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -148,6 +149,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 157
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -162,6 +164,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 157
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -176,6 +179,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 157
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -190,6 +194,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 157
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -204,6 +209,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 157
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -218,6 +224,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 157
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_inline_context.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_inline_context.test
@@ -137,6 +137,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 306
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -166,6 +167,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 230
 Content-Type: application/json
+Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0019.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0019.test
@@ -201,6 +201,7 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 517
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0023.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0023.test
@@ -85,6 +85,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 50
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -98,6 +99,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 50
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -109,11 +111,12 @@ Date: REGEX(.*)
 04. GET the entity with Accept header application/ld+json => application/ld+json mime type
 ==========================================================================================
 HTTP/1.1 200 OK
-Content-Length: 50
+Content-Length: 157
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
 {
+    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld",
     "id": "urn:ngsi-ld:Vehicle:V233",
     "type": "Vehicle"
 }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0027.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0027.test
@@ -54,6 +54,7 @@ echo
 HTTP/1.1 404 Not Found
 Content-Length: 127
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0028.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0028.test
@@ -104,6 +104,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 315
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0029.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0029.test
@@ -70,6 +70,7 @@ echo
 HTTP/1.1 400 Bad Request
 Content-Length: 112
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -85,6 +86,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 123
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -100,6 +102,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 123
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -115,6 +118,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 111
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0031.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0031.test
@@ -48,6 +48,7 @@ echo
 HTTP/1.1 404 Not Found
 Content-Length: 145
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0032.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0032.test
@@ -94,6 +94,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 401
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0043.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0043.test
@@ -150,6 +150,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 2777
 Content-Type: application/json
+Link: <https://raw.githubusercontent.com/GSMADeveloper/NGSI-LD-Entities/master/examples/Agri-Crop-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0060.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0060.test
@@ -98,6 +98,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 152
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0067.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0067.test
@@ -98,6 +98,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 256
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -132,6 +133,7 @@ Date: REGEX(.*)
 HTTP/1.1 404 Not Found
 Content-Length: 149
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_18_default_context_when_no_context.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_18_default_context_when_no_context.test
@@ -67,13 +67,14 @@ Date: REGEX(.*)
 02. GET the entity and see the DEFAULT context
 ==============================================
 HTTP/1.1 200 OK
-Content-Length: 60
+Content-Length: 171
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
 {
   "id": "urn:ngsi-ld:Vehicle:V233",
-  "type": "Vehicle"
+  "type": "Vehicle",
+  "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
 }
 
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_list_subscriptions.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_list_subscriptions.test
@@ -386,6 +386,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 13301
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [
@@ -1277,6 +1278,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 3326
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [
@@ -1508,6 +1510,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 3326
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [

--- a/test/functionalTest/cases/0000_ngsild/ngsild_metadata_with_compound_value.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_metadata_with_compound_value.test
@@ -129,6 +129,7 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 145
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_modify_attr.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_modify_attr.test
@@ -105,6 +105,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 124
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -131,6 +132,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 124
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_observedAt.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_observedAt.test
@@ -82,6 +82,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 182
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [
@@ -103,6 +104,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 160
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_one_tenant.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_one_tenant.test
@@ -106,6 +106,7 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 42
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -119,6 +120,7 @@ Date: REGEX(.*)
 HTTP/1.1 404 Not Found
 Content-Length: 120
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_property_with_compound_value.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_property_with_compound_value.test
@@ -117,6 +117,7 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 103
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_query-by-condition-over-object.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_query-by-condition-over-object.test
@@ -109,6 +109,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 519
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [
@@ -159,6 +160,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 519
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [

--- a/test/functionalTest/cases/0000_ngsild/ngsild_query_condition_over_compound_value.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_query_condition_over_compound_value.test
@@ -147,6 +147,7 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 282
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [
@@ -174,6 +175,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 282
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [
@@ -201,6 +203,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 3
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []
@@ -212,6 +215,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 3
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []

--- a/test/functionalTest/cases/0000_ngsild/ngsild_query_condition_over_deep_compound_value.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_query_condition_over_deep_compound_value.test
@@ -90,6 +90,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 316
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [
@@ -120,6 +121,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 3
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []

--- a/test/functionalTest/cases/0000_ngsild/ngsild_query_condition_over_object.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_query_condition_over_object.test
@@ -84,6 +84,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 421
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [

--- a/test/functionalTest/cases/0000_ngsild/ngsild_query_condition_over_observedAt.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_query_condition_over_observedAt.test
@@ -225,6 +225,7 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 3
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []
@@ -236,6 +237,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 826
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [
@@ -287,6 +289,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 826
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [
@@ -338,6 +341,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 3
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []

--- a/test/functionalTest/cases/0000_ngsild/ngsild_query_condition_over_property_of_property.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_query_condition_over_property_of_property.test
@@ -201,6 +201,7 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 826
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [

--- a/test/functionalTest/cases/0000_ngsild/ngsild_query_entities_geo_test_js.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_query_entities_geo_test_js.test
@@ -131,6 +131,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 438
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [

--- a/test/functionalTest/cases/0000_ngsild/ngsild_query_with_type_mismatch.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_query_with_type_mismatch.test
@@ -213,6 +213,7 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 2
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription-with-geo-point.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription-with-geo-point.test
@@ -89,6 +89,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 408
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription-with-geo-polygon.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription-with-geo-polygon.test
@@ -89,6 +89,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 471
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_create.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_create.test
@@ -395,6 +395,7 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 820
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -506,6 +507,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 153
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -520,6 +522,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 160
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -534,6 +537,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 145
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_create_auto_sub_id.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_create_auto_sub_id.test
@@ -181,6 +181,7 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 846
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_creation_errors.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_creation_errors.test
@@ -402,6 +402,7 @@ echo
 HTTP/1.1 400 Bad Request
 Content-Length: 155
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -416,6 +417,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 160
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -430,6 +432,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 117
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -444,6 +447,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 126
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -458,6 +462,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 145
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_delete.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_delete.test
@@ -146,6 +146,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 820
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -268,6 +269,7 @@ Date: REGEX(.*)
 HTTP/1.1 404 Not Found
 Content-Length: 145
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_reject_if_entities_empty.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_reject_if_entities_empty.test
@@ -81,6 +81,7 @@ echo
 HTTP/1.1 400 Bad Request
 Content-Length: 117
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_reject_if_no_notification_parameters.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_reject_if_no_notification_parameters.test
@@ -124,6 +124,7 @@ echo
 HTTP/1.1 400 Bad Request
 Content-Length: 133
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -138,6 +139,7 @@ Date: REGEX(.*)
 HTTP/1.1 400 Bad Request
 Content-Length: 127
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_reject_if_watched_attributes_empty.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_reject_if_watched_attributes_empty.test
@@ -95,6 +95,7 @@ echo
 HTTP/1.1 400 Bad Request
 Content-Length: 126
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_tenants.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_tenants.test
@@ -170,6 +170,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 44
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [
@@ -185,6 +186,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 44
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 [

--- a/test/functionalTest/cases/0000_ngsild/ngsild_tests_01.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_tests_01.test
@@ -140,6 +140,7 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 329
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_unsupported_content_type.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_unsupported_content_type.test
@@ -52,6 +52,7 @@ echo
 HTTP/1.1 415 Unsupported Media Type
 Content-Length: 186
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_url_parse.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_url_parse.test
@@ -229,6 +229,7 @@ echo
 HTTP/1.1 200 OK
 Content-Length: 2
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []
@@ -239,6 +240,7 @@ Date: REGEX(.*)
 HTTP/1.1 404 Not Found
 Content-Length: 120
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -253,6 +255,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 2
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []
@@ -263,6 +266,7 @@ Date: REGEX(.*)
 HTTP/1.1 404 Not Found
 Content-Length: 110
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -277,6 +281,7 @@ Date: REGEX(.*)
 HTTP/1.1 501 Not Implemented
 Content-Length: 148
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -291,6 +296,7 @@ Date: REGEX(.*)
 HTTP/1.1 501 Not Implemented
 Content-Length: 142
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -305,6 +311,7 @@ Date: REGEX(.*)
 HTTP/1.1 404 Not Found
 Content-Length: 103
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -328,6 +335,7 @@ Date: REGEX(.*)
 HTTP/1.1 404 Not Found
 Content-Length: 141
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -351,6 +359,7 @@ Date: REGEX(.*)
 HTTP/1.1 501 Not Implemented
 Content-Length: 148
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -365,6 +374,7 @@ Date: REGEX(.*)
 HTTP/1.1 404 Not Found
 Content-Length: 141
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -379,6 +389,7 @@ Date: REGEX(.*)
 HTTP/1.1 501 Not Implemented
 Content-Length: 137
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -393,6 +404,7 @@ Date: REGEX(.*)
 HTTP/1.1 501 Not Implemented
 Content-Length: 144
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -407,6 +419,7 @@ Date: REGEX(.*)
 HTTP/1.1 404 Not Found
 Content-Length: 180
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -421,6 +434,7 @@ Date: REGEX(.*)
 HTTP/1.1 404 Not Found
 Content-Length: 176
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -435,6 +449,7 @@ Date: REGEX(.*)
 HTTP/1.1 404 Not Found
 Content-Length: 141
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -449,6 +464,7 @@ Date: REGEX(.*)
 HTTP/1.1 501 Not Implemented
 Content-Length: 145
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -463,6 +479,7 @@ Date: REGEX(.*)
 HTTP/1.1 404 Not Found
 Content-Length: 114
 Content-Type: application/json
+Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {


### PR DESCRIPTION
* Link HTTP header added in one place only: orionldMhdConnectionTreat()
* Fixed #95 
* Creating "volatile" contexts if necessary
