### PR TITLE
task/160.different-context-name-if-entity-created

### DIFF
--- a/src/lib/orionld/common/OrionldConnection.h
+++ b/src/lib/orionld/common/OrionldConnection.h
@@ -55,6 +55,8 @@ typedef struct OrionldConnectionState
   char*            tenant;
   char*            link;
   bool             useLinkHeader;
+  bool             linkToBeFreed;
+  bool             linkHeaderAdded;
   OrionldContext   inlineContext;
   OrionldContext*  contextP;
   ApiVersion       apiVersion;
@@ -64,6 +66,8 @@ typedef struct OrionldConnectionState
   KjNode*          geoCoordsP;
   int64_t          overriddenCreationDate;
   int64_t          overriddenModificationDate;
+  bool             entityCreated;                // If an entity is created, if complex context, it must be stored
+  char*            entityId;
 } OrionldConnectionState;
 
 

--- a/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
@@ -216,11 +216,15 @@ int orionldMhdConnectionInit
   //
   // 1. Prepare orionldState
   //
-  orionldState.requestNo      = requestNo;
-  orionldState.tenant         = (char*) "";
-  orionldState.kjsonP         = kjBufferCreate(&orionldState.kjson, &orionldState.kalloc);
-  orionldState.link           = NULL;
-  orionldState.useLinkHeader  = true;  // Service routines can set this value to 'false' to avoid having the Link HTTP Header in its output
+  orionldState.requestNo        = requestNo;
+  orionldState.tenant           = (char*) "";
+  orionldState.kjsonP           = kjBufferCreate(&orionldState.kjson, &orionldState.kalloc);
+  orionldState.link             = NULL;
+  orionldState.useLinkHeader    = true;  // Service routines can set this value to 'false' to avoid having the Link HTTP Header in its output
+  orionldState.entityCreated    = false;
+  orionldState.entityId         = NULL;
+  orionldState.linkToBeFreed    = false;
+  orionldState.linkHeaderAdded  = false;
 
   ciP->kjsonP = orionldState.kjsonP;  // FIXME: ciP->kjsonP is to BE REMOVED. orionldState.kjsonP should be used instead
 

--- a/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
@@ -396,23 +396,14 @@ int orionldMhdConnectionTreat(ConnectionInfo* ciP)
     //
     // Calling the SERVICE ROUTINE
     //
-    // FIXME - call service routine before creating the context in the Context Server.
-    //         Like that, the service routine can inform on whether an entity was created or not.
-    //         If created, then the context should be named "entity id".
-    //         If not created, the context should be named "urn:volatile:XX", XX being a running number
-    //         Also, if the service rouitine fails, no context should be made
-    //
     LM_T(LmtServiceRoutine, ("Calling Service Routine %s", ciP->serviceP->url));
     bool b = ciP->serviceP->serviceRoutine(ciP);
     LM_T(LmtServiceRoutine, ("service routine '%s' done", ciP->serviceP->url));
 
-    if ((ciP->responseTree != NULL) && (ciP->responseTree->value.firstChildP != NULL))
-      LM_T(LmtPayloadParse, ("Right after serviceRoutine, first child of response is: '%s'", ciP->responseTree->value.firstChildP->name));
-
     if ((b == true) && (contextToBeCreated == true))
     {
       //
-      // Creating the context in Context Server, if necessary
+      // Creating the context in Context Server
       //
 
       // The Context tree must be cloned, as it is created inside the thread's kjson
@@ -434,6 +425,13 @@ int orionldMhdConnectionTreat(ConnectionInfo* ciP)
       LM_TMP(("CONTEXT: orionldState.entityCreated == '%s'", FT(orionldState.entityCreated)));
       LM_TMP(("CONTEXT: orionldState.entityId      == '%s'", orionldState.entityId));
 
+      //
+      // If an Entity was created, then the context takes the entity id as name.
+      // Else, if it's just an update, the name of the context is urn:volatile:XX where XX is a running number.
+      //
+      // FIXME: This needs to be discussed in the Bindings document.
+      // FIXME: What about creation of Subscriptions? Should be treated the same. Context name == sub id
+      //
       if (orionldState.entityCreated == true)
       {
         unsigned int nb = snprintf(url, sizeof(url), "http://%s:%d/ngsi-ld/ex/v1/contexts/%s", hostname, portNo, orionldState.entityId);

--- a/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
@@ -917,6 +917,7 @@ bool orionldPostEntities(ConnectionInfo* ciP)
         return false;
       }
 
+
       //
       // If the entity already exists, an error should be returned
       //
@@ -934,9 +935,10 @@ bool orionldPostEntities(ConnectionInfo* ciP)
       entityIdP->creDate   = getCurrentTime();
       entityIdP->modDate   = getCurrentTime();
 
+      orionldState.entityId = idNodeP->value.s;
+
       continue;
     }
-
     // Entity TYPE
     else if (kNodeP == typeNodeP)
     {
@@ -1094,6 +1096,8 @@ bool orionldPostEntities(ConnectionInfo* ciP)
   }
 
   ciP->httpStatusCode = SccCreated;
+  orionldState.entityCreated = true;
+
   httpHeaderLocationAdd(ciP, "/ngsi-ld/v1/entities/", idNodeP->value.s);
 
   return true;

--- a/src/lib/rest/httpHeaderAdd.cpp
+++ b/src/lib/rest/httpHeaderAdd.cpp
@@ -25,6 +25,8 @@
 #include <string>
 #include <vector>
 
+#include "orionld/common/OrionldConnection.h"                  // orionldState
+
 #include "rest/ConnectionInfo.h"
 #include "rest/httpHeaderAdd.h"
 
@@ -73,6 +75,9 @@ void httpHeaderLinkAdd(ConnectionInfo* ciP, const char* _url)
   unsigned int     urlLen;
   bool             freeLinkP = false;
 
+  if (orionldState.linkHeaderAdded == true)
+    return;
+
   LM_TMP(("LINK: Setting Link header to URI: '%s'", _url));
 
   // If no context URL is given, the default context is used
@@ -118,5 +123,7 @@ void httpHeaderLinkAdd(ConnectionInfo* ciP, const char* _url)
 
   if (freeLinkP == true)
     free(linkP);
+
+  orionldState.linkHeaderAdded = true;
 }
 #endif

--- a/test/functionalTest/cases/0000_ngsild/ngsild_big_context.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_big_context.test
@@ -75,7 +75,7 @@ echo
 =============================================================================
 HTTP/1.1 201 Created
 Content-Length: 0
-Link: <http://IP:PORT/ngsi-ld/ex/v1/contexts/urn:volatile:1>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <http://IP:PORT/ngsi-ld/ex/v1/contexts/urn:ngsi-ld:AirQualityObserved:RZ:Obsv4567>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Location: /ngsi-ld/v1/entities/urn:ngsi-ld:AirQualityObserved:RZ:Obsv4567
 Date: REGEX(.*)
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_complex_context_creation_and_service.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_complex_context_creation_and_service.test
@@ -71,7 +71,7 @@ echo
 
 echo "02. Obtain the context from the Link header"
 echo "==========================================="
-orionCurl --url /ngsi-ld/ex/v1/contexts/urn:volatile:1
+orionCurl --url /ngsi-ld/ex/v1/contexts/http://a.b.c/entity/E1
 echo
 echo
 
@@ -81,7 +81,7 @@ echo
 =====================================================================================================================
 HTTP/1.1 201 Created
 Content-Length: 0
-Link: <http://IP:PORT/ngsi-ld/ex/v1/contexts/urn:volatile:1>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <http://IP:PORT/ngsi-ld/ex/v1/contexts/http://a.b.c/entity/E1>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Location: /ngsi-ld/v1/entities/http://a.b.c/entity/E1
 Date: REGEX(.*)
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_contexts_case_3.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_contexts_case_3.test
@@ -111,7 +111,7 @@ echo
 ================================================================================
 HTTP/1.1 201 Created
 Content-Length: 0
-Link: <http://IP:PORT/ngsi-ld/ex/v1/contexts/urn:volatile:1>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <http://IP:PORT/ngsi-ld/ex/v1/contexts/http://a.b.c/entity/E3>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Location: /ngsi-ld/v1/entities/http://a.b.c/entity/E3
 Date: REGEX(.*)
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_create_and_retreive_array_context.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_create_and_retreive_array_context.test
@@ -55,7 +55,7 @@ echo
 =====================================================
 HTTP/1.1 201 Created
 Content-Length: 0
-Link: <http://IP:PORT/ngsi-ld/ex/v1/contexts/urn:volatile:1>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <http://IP:PORT/ngsi-ld/ex/v1/contexts/http://a.b.c/E1>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Location: /ngsi-ld/v1/entities/http://a.b.c/E1
 Date: REGEX(.*)
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation.test
@@ -296,7 +296,7 @@ Date: REGEX(.*)
 ======================================================
 HTTP/1.1 201 Created
 Content-Length: 0
-Link: <http://IP:PORT/ngsi-ld/ex/v1/contexts/urn:volatile:3>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <http://IP:PORT/ngsi-ld/ex/v1/contexts/http://a.b.c/entity/E6>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Location: /ngsi-ld/v1/entities/http://a.b.c/entity/E6
 Date: REGEX(.*)
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_context_as_vector_of_uris.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_context_as_vector_of_uris.test
@@ -70,7 +70,7 @@ echo
 =======================================================================
 HTTP/1.1 201 Created
 Content-Length: 0
-Link: <http://IP:PORT/ngsi-ld/ex/v1/contexts/urn:volatile:1>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <http://IP:PORT/ngsi-ld/ex/v1/contexts/urn:ngsi-ld:T:12:13:14>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Location: /ngsi-ld/v1/entities/urn:ngsi-ld:T:12:13:14
 Date: REGEX(.*)
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_inline_context.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_inline_context.test
@@ -127,7 +127,7 @@ echo
 ==============================================================================================================================================================
 HTTP/1.1 201 Created
 Content-Length: 0
-Link: <http://IP:PORT/ngsi-ld/ex/v1/contexts/urn:volatile:1>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <http://IP:PORT/ngsi-ld/ex/v1/contexts/http://a.b.c/entity/E1>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Location: /ngsi-ld/v1/entities/http://a.b.c/entity/E1
 Date: REGEX(.*)
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0043.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0043.test
@@ -140,7 +140,7 @@ echo
 ================================================================================
 HTTP/1.1 201 Created
 Content-Length: 0
-Link: <http://IP:PORT/ngsi-ld/ex/v1/contexts/urn:volatile:1>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <http://IP:PORT/ngsi-ld/ex/v1/contexts/urn:ngsi-ld:AgriCrop:df72dc57-1eb9-42a3-88a9-8647ecc954b4>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Location: /ngsi-ld/v1/entities/urn:ngsi-ld:AgriCrop:df72dc57-1eb9-42a3-88a9-8647ecc954b4
 Date: REGEX(.*)
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0044.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0044.test
@@ -126,7 +126,7 @@ echo
 ==========================================================================
 HTTP/1.1 201 Created
 Content-Length: 0
-Link: <http://IP:PORT/ngsi-ld/ex/v1/contexts/urn:volatile:1>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <http://IP:PORT/ngsi-ld/ex/v1/contexts/urn:ngsi-ld:AgriCrop:df72dc57-1eb9-42a3-88a9-8647ecc954b4>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Location: /ngsi-ld/v1/entities/urn:ngsi-ld:AgriCrop:df72dc57-1eb9-42a3-88a9-8647ecc954b4
 Date: REGEX(.*)
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0065.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0065.test
@@ -87,7 +87,7 @@ Date: REGEX(.*)
 ==========================================================================
 HTTP/1.1 201 Created
 Content-Length: 0
-Link: <http://IP:PORT/ngsi-ld/ex/v1/contexts/urn:volatile:1>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <http://IP:PORT/ngsi-ld/ex/v1/contexts/urn:ngsi-ld:Room:Room1>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Location: /ngsi-ld/v1/entities/urn:ngsi-ld:Room:Room1
 Date: REGEX(.*)
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_notification_with_observedAt.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_notification_with_observedAt.test
@@ -134,7 +134,7 @@ echo
 ===========================================
 HTTP/1.1 201 Created
 Content-Length: 0
-Link: <http://IP:PORT/ngsi-ld/ex/v1/contexts/urn:volatile:1>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <http://IP:PORT/ngsi-ld/ex/v1/contexts/urn:ngsi-ld:Vehicle:A4568>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Location: /ngsi-ld/v1/entities/urn:ngsi-ld:Vehicle:A4568
 Date: REGEX(.*)
 


### PR DESCRIPTION
* Contexts created when creating entities get the entity ID as context name
* Other contexts get a name like `urn:volatile:XX` where XX is a running number.