### PR TITLE
Task/167.more stuff from connection info to orionld state

### DIFF
--- a/src/lib/orionld/common/orionldErrorResponse.cpp
+++ b/src/lib/orionld/common/orionldErrorResponse.cpp
@@ -34,7 +34,7 @@ extern "C"
 #include "rest/ConnectionInfo.h"                               // ConnectionInfo
 #include "orionld/context/orionldCoreContext.h"                // orionldDefaultUrl
 #include "orionld/context/orionldContextItemLookup.h"          // orionldContextItemLookup
-#include "orionld/common/OrionldConnection.h"                  // orionldState
+#include "orionld/common/orionldState.h"                       // orionldState
 #include "orionld/common/orionldErrorResponse.h"               // Own interface
 
 
@@ -74,8 +74,8 @@ void orionldErrorResponseCreate
 {
   LM_T(LmtErrorResponse, ("Creating error response: %s (%s)", title, details));
 
-  KjNode* typeP     = kjString(ciP->kjsonP, "type",    errorTypeStringV[errorType]);
-  KjNode* titleP    = kjString(ciP->kjsonP, "title",   title);
+  KjNode* typeP     = kjString(orionldState.kjsonP, "type",    errorTypeStringV[errorType]);
+  KjNode* titleP    = kjString(orionldState.kjsonP, "title",   title);
   KjNode* detailsP;
 
   if ((details != NULL) && (details[0] != 0))
@@ -102,16 +102,16 @@ void orionldErrorResponseCreate
       }
     }
 
-    detailsP = kjString(ciP->kjsonP, "details", contextDetails);
+    detailsP = kjString(orionldState.kjsonP, "details", contextDetails);
   }
   else
   {
-    detailsP = kjString(ciP->kjsonP, "details", "no details");
+    detailsP = kjString(orionldState.kjsonP, "details", "no details");
   }
 
-  ciP->responseTree = kjObject(ciP->kjsonP, NULL);
+  orionldState.responseTree = kjObject(orionldState.kjsonP, NULL);
 
-  kjChildAdd(ciP->responseTree, typeP);
-  kjChildAdd(ciP->responseTree, titleP);
-  kjChildAdd(ciP->responseTree, detailsP);
+  kjChildAdd(orionldState.responseTree, typeP);
+  kjChildAdd(orionldState.responseTree, titleP);
+  kjChildAdd(orionldState.responseTree, detailsP);
 }

--- a/src/lib/orionld/common/orionldState.cpp
+++ b/src/lib/orionld/common/orionldState.cpp
@@ -32,6 +32,7 @@ extern "C"
 #include "logMsg/logMsg.h"                                     // LM_*
 #include "logMsg/traceLevels.h"                                // Lmt*
 
+#include "orionld/context/orionldContextFree.h"                // orionldContextFree
 #include "orionld/common/OrionldConnection.h"                  // OrionldConnectionState
 
 
@@ -86,7 +87,7 @@ void orionldStateInit(void)
   orionldState.errorAttributeArrayP        = orionldState.errorAttributeArray;
   orionldState.errorAttributeArraySize     = sizeof(orionldState.errorAttributeArray);
   orionldState.errorAttributeArrayUsed     = 0;
-
+  orionldState.contextToBeFreed            = false;
   bzero(orionldState.errorAttributeArray, sizeof(orionldState.errorAttributeArray));
   orionldState.uriParamOptions.noOverwrite = false;
 }
@@ -110,6 +111,12 @@ void orionldStateRelease(void)
     free(orionldState.errorAttributeArrayP);
     orionldState.errorAttributeArrayP = NULL;
   }
+
+#if 0
+  // This part crashes the broker in a few functests ...
+  if ((orionldState.contextP != NULL) && (orionldState.contextToBeFreed == true))
+    orionldContextFree(orionldState.contextP);
+#endif
 }
 
 

--- a/src/lib/orionld/common/orionldState.cpp
+++ b/src/lib/orionld/common/orionldState.cpp
@@ -74,6 +74,8 @@ void orionldStateInit(void)
   //        Should not be necessary - look it up
   //        If I bzero orionldState, I get a SIGSEGV inside kjson ...
   //
+  bzero(orionldState.errorAttributeArray, sizeof(orionldState.errorAttributeArray));
+
   orionldState.requestNo                   = requestNo;
   orionldState.tenant                      = (char*) "";
   orionldState.kjsonP                      = kjBufferCreate(&orionldState.kjson, &orionldState.kalloc);
@@ -88,8 +90,9 @@ void orionldStateInit(void)
   orionldState.errorAttributeArraySize     = sizeof(orionldState.errorAttributeArray);
   orionldState.errorAttributeArrayUsed     = 0;
   orionldState.contextToBeFreed            = false;
-  bzero(orionldState.errorAttributeArray, sizeof(orionldState.errorAttributeArray));
   orionldState.uriParamOptions.noOverwrite = false;
+  orionldState.prettyPrintSpaces           = 2;
+  orionldState.prettyPrint                 = false;
 }
 
 

--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -33,6 +33,7 @@ extern "C"
 #include "common/globals.h"                                    // ApiVersion
 #include "orionld/context/OrionldContext.h"                    // OrionldContext
 
+struct OrionLdRestService;
 
 
 // -----------------------------------------------------------------------------
@@ -70,6 +71,7 @@ typedef struct OrionldConnectionState
   bool                    linkHeaderAdded;
   OrionldContext          inlineContext;
   OrionldContext*         contextP;
+  bool                    contextToBeFreed;
   ApiVersion              apiVersion;
   int                     requestNo;
   KjNode*                 locationAttributeP;
@@ -85,6 +87,10 @@ typedef struct OrionldConnectionState
   char                    errorAttributeArray[512];
   int                     errorAttributeArrayUsed;
   int                     errorAttributeArraySize;
+  OrionLdRestService*     serviceP;
+  char*                   wildcard[2];
+  char*                   urlPath;
+  char*                   verbString;
 } OrionldConnectionState;
 
 

--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -64,6 +64,10 @@ typedef struct OrionldConnectionState
   Kjson*                  kjsonP;
   KAlloc                  kalloc;
   char                    kallocBuffer[8 * 1024];
+  KjNode*                 requestTree;
+  KjNode*                 responseTree;
+  char*                   responsePayload;
+  bool                    responsePayloadAllocated;
   char*                   tenant;
   char*                   link;
   bool                    useLinkHeader;
@@ -91,6 +95,8 @@ typedef struct OrionldConnectionState
   char*                   wildcard[2];
   char*                   urlPath;
   char*                   verbString;
+  bool                    prettyPrint;
+  char                    prettyPrintSpaces;
 } OrionldConnectionState;
 
 

--- a/src/lib/orionld/context/orionldContextCreateFromUrl.cpp
+++ b/src/lib/orionld/context/orionldContextCreateFromUrl.cpp
@@ -74,7 +74,7 @@ OrionldContext* orionldContextCreateFromUrl(ConnectionInfo* ciP, const char* url
   if (contextP == NULL)
   {
     LM_E(("orionldContextCreateFromTree: %s", *detailsPP));
-    ciP->contextToBeFreed = false;
+    orionldState.contextToBeFreed = false;
     ciP->httpStatusCode = SccBadRequest;
     return NULL;
   }
@@ -85,7 +85,7 @@ OrionldContext* orionldContextCreateFromUrl(ConnectionInfo* ciP, const char* url
     LM_E(("orionldContextDownloadAndParse: %s", *detailsPP));
     free(contextP->url);
     free(contextP);
-    ciP->contextToBeFreed = false;
+    orionldState.contextToBeFreed = false;
     ciP->httpStatusCode = SccBadRequest;
     return NULL;
   }
@@ -100,7 +100,7 @@ OrionldContext* orionldContextCreateFromUrl(ConnectionInfo* ciP, const char* url
   else
     LM_E(("contextP->tree->value.firstChildP: %p", contextP->tree->value.firstChildP));
 
-  ciP->contextToBeFreed = true;
+  orionldState.contextToBeFreed = false;
   LM_T(LmtContextList, ("Context is to be inserted into the common context list, so, it needs to be cloned"));
 
   // <DEBUG>

--- a/src/lib/orionld/context/orionldContextCreateFromUrl.cpp
+++ b/src/lib/orionld/context/orionldContextCreateFromUrl.cpp
@@ -35,7 +35,7 @@ extern "C"
 
 #include "rest/ConnectionInfo.h"                               // ConnectionInfo
 
-#include "orionld/common/OrionldConnection.h"                  // orionldState
+#include "orionld/common/orionldState.h"                       // orionldState
 #include "orionld/common/urlCheck.h"                           // urlCheck
 #include "orionld/context/orionldContextList.h"                // orionldContextListSemTake/Give
 #include "orionld/context/orionldContextLookup.h"              // orionldContextLookup

--- a/src/lib/orionld/context/orionldContextTreat.cpp
+++ b/src/lib/orionld/context/orionldContextTreat.cpp
@@ -131,7 +131,7 @@ bool orionldContextTreat
       return false;
     }
 
-    ciP->contextToBeFreed = false;                  // context has been added to public list - must not be freed
+    orionldState.contextToBeFreed = false;                  // context has been added to public list - must not be freed
   }
   else if (contextNodeP->type == KjArray)
   {
@@ -179,7 +179,7 @@ bool orionldContextTreat
     // The context containing a vector of X context strings (URLs) must be freed
     // The downloaded contexts though are added to the public list and will not be freed)
     //
-    ciP->contextToBeFreed = true;
+    orionldState.contextToBeFreed = true;
 
     for (KjNode* contextArrayItemP = contextNodeP->value.firstChildP; contextArrayItemP != NULL; contextArrayItemP = contextArrayItemP->next)
     {

--- a/src/lib/orionld/kjTree/kjTreeFromContextContextAttribute.cpp
+++ b/src/lib/orionld/kjTree/kjTreeFromContextContextAttribute.cpp
@@ -32,8 +32,9 @@ extern "C"
 #include "parseArgs/baStd.h"                                   // BA_FT - for debugging only
 #include "logMsg/logMsg.h"                                     // LM_*
 #include "logMsg/traceLevels.h"                                // Lmt*
-
 #include "rest/ConnectionInfo.h"                               // ConnectionInfo
+
+#include "orionld/common/orionldState.h"                       // orionldState
 #include "orionld/kjTree/kjTreeFromContextContextAttribute.h"  // Own interface
 
 
@@ -50,12 +51,12 @@ extern "C"
 //
 KjNode* kjTreeFromContextContextAttribute(ConnectionInfo* ciP, ContextAttribute* caP, char** detailsP)
 {
-  KjNode* topNodeP = kjObject(ciP->kjsonP, NULL);
+  KjNode* topNodeP = kjObject(orionldState.kjsonP, NULL);
 
   if (caP->valueType == orion::ValueTypeString)
   {
     LM_T(LmtContext, ("It's a String!"));
-    KjNode* stringNodeP = kjString(ciP->kjsonP, "@context", caP->stringValue.c_str());
+    KjNode* stringNodeP = kjString(orionldState.kjsonP, "@context", caP->stringValue.c_str());
     LM_T(LmtContext, ("The string is: '%s'", stringNodeP->value.s));
 
     kjChildAdd(topNodeP, stringNodeP);
@@ -63,7 +64,7 @@ KjNode* kjTreeFromContextContextAttribute(ConnectionInfo* ciP, ContextAttribute*
   else if (caP->compoundValueP->valueType == orion::ValueTypeVector)
   {
     LM_T(LmtContext, ("It's an Array!"));
-    KjNode* arrayNodeP = kjArray(ciP->kjsonP, "@context");
+    KjNode* arrayNodeP = kjArray(orionldState.kjsonP, "@context");
 
     kjChildAdd(topNodeP, arrayNodeP);
 
@@ -79,7 +80,7 @@ KjNode* kjTreeFromContextContextAttribute(ConnectionInfo* ciP, ContextAttribute*
         return NULL;
       }
 
-      KjNode* itemNodeP = kjString(ciP->kjsonP, NULL, compoundP->stringValue.c_str());
+      KjNode* itemNodeP = kjString(orionldState.kjsonP, NULL, compoundP->stringValue.c_str());
       kjChildAdd(arrayNodeP, itemNodeP);
       LM_T(LmtContext, ("Added array item '%s' to context", itemNodeP->value.s));
     }
@@ -87,7 +88,7 @@ KjNode* kjTreeFromContextContextAttribute(ConnectionInfo* ciP, ContextAttribute*
   else if (caP->compoundValueP->valueType == orion::ValueTypeObject)
   {
     LM_T(LmtContext, ("It's an Object!"));
-    KjNode* objectNodeP = kjObject(ciP->kjsonP, "@context");
+    KjNode* objectNodeP = kjObject(orionldState.kjsonP, "@context");
 
     kjChildAdd(topNodeP, objectNodeP);
 
@@ -103,7 +104,7 @@ KjNode* kjTreeFromContextContextAttribute(ConnectionInfo* ciP, ContextAttribute*
         return NULL;
       }
 
-      KjNode* itemNodeP = kjString(ciP->kjsonP, compoundP->name.c_str(), compoundP->stringValue.c_str());
+      KjNode* itemNodeP = kjString(orionldState.kjsonP, compoundP->name.c_str(), compoundP->stringValue.c_str());
       kjChildAdd(objectNodeP, itemNodeP);
 
       LM_T(LmtContext, ("Added object member '%s' == '%s' to context", itemNodeP->name, itemNodeP->value.s));

--- a/src/lib/orionld/kjTree/kjTreeFromContextContextAttribute.cpp
+++ b/src/lib/orionld/kjTree/kjTreeFromContextContextAttribute.cpp
@@ -26,6 +26,7 @@ extern "C"
 {
 #include "kjson/KjNode.h"                                      // KjNode
 #include "kjson/kjBuilder.h"                                   // kjObject, kjString, kjBoolean, ...
+#include "kjson/kjFree.h"                                      // kjFree
 }
 
 #include "parseArgs/baStd.h"                                   // BA_FT - for debugging only

--- a/src/lib/orionld/kjTree/kjTreeFromQueryContextResponse.cpp
+++ b/src/lib/orionld/kjTree/kjTreeFromQueryContextResponse.cpp
@@ -122,10 +122,10 @@ KjNode* kjTreeFromQueryContextResponse(ConnectionInfo* ciP, bool oneHit, bool ke
   //
   if ((oneHit == false) && (responseP->contextElementResponseVector.size() == 0))
   {
-    ciP->responseTree = kjArray(orionldState.kjsonP, NULL);
+    orionldState.responseTree = kjArray(orionldState.kjsonP, NULL);
     ciP->httpStatusCode = SccOk;
 
-    return ciP->responseTree;
+    return orionldState.responseTree;
   }
 
 
@@ -145,7 +145,7 @@ KjNode* kjTreeFromQueryContextResponse(ConnectionInfo* ciP, bool oneHit, bool ke
     if (responseP->errorCode.code == SccContextElementNotFound)
       ciP->httpStatusCode = responseP->errorCode.code;
 
-    return ciP->responseTree;
+    return orionldState.responseTree;
   }
 
   int hits = responseP->contextElementResponseVector.size();
@@ -154,12 +154,12 @@ KjNode* kjTreeFromQueryContextResponse(ConnectionInfo* ciP, bool oneHit, bool ke
   {
     if (oneHit == false)
     {
-      ciP->responseTree = kjArray(orionldState.kjsonP, NULL);
+      orionldState.responseTree = kjArray(orionldState.kjsonP, NULL);
     }
     else
-      ciP->responseTree = NULL;
+      orionldState.responseTree = NULL;
 
-    return ciP->responseTree;
+    return orionldState.responseTree;
   }
   else if ((hits > 1) && (oneHit == true))  // More than one hit - not possible!
   {
@@ -580,13 +580,13 @@ KjNode* kjTreeFromQueryContextResponse(ConnectionInfo* ciP, bool oneHit, bool ke
           else
           {
             orionldErrorResponseCreate(ciP, OrionldInternalError, "invalid context", "inline contexts not supported - wait it's coming ...", OrionldDetailsString);
-            return ciP->responseTree;
+            return orionldState.responseTree;
           }
         }
         else
         {
           orionldErrorResponseCreate(ciP, OrionldInternalError, "invalid context", "not a string nor an array", OrionldDetailsString);
-          return ciP->responseTree;
+          return orionldState.responseTree;
         }
       }
     }

--- a/src/lib/orionld/kjTree/kjTreeFromQueryContextResponse.cpp
+++ b/src/lib/orionld/kjTree/kjTreeFromQueryContextResponse.cpp
@@ -163,7 +163,7 @@ KjNode* kjTreeFromQueryContextResponse(ConnectionInfo* ciP, bool oneHit, bool ke
   }
   else if ((hits > 1) && (oneHit == true))  // More than one hit - not possible!
   {
-    orionldErrorResponseCreate(ciP, OrionldInternalError, "More than one hit", ciP->wildcard[0], OrionldDetailsEntity);
+    orionldErrorResponseCreate(ciP, OrionldInternalError, "More than one hit", orionldState.wildcard[0], OrionldDetailsEntity);
     return NULL;
   }
 

--- a/src/lib/orionld/kjTree/kjTreeFromQueryContextResponseWithAttrList.cpp
+++ b/src/lib/orionld/kjTree/kjTreeFromQueryContextResponseWithAttrList.cpp
@@ -123,7 +123,7 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
   }
   else if ((hits > 1) && (oneHit == true))  // More than one hit - not possible!
   {
-    orionldErrorResponseCreate(ciP, OrionldInternalError, "More than one hit", ciP->wildcard[0], OrionldDetailsEntity);
+    orionldErrorResponseCreate(ciP, OrionldInternalError, "More than one hit", orionldState.wildcard[0], OrionldDetailsEntity);
     return NULL;
   }
 

--- a/src/lib/orionld/kjTree/kjTreeFromQueryContextResponseWithAttrList.cpp
+++ b/src/lib/orionld/kjTree/kjTreeFromQueryContextResponseWithAttrList.cpp
@@ -37,7 +37,7 @@ extern "C"
 
 #include "orionld/common/orionldErrorResponse.h"               // OrionldResponseErrorType, orionldErrorResponse
 #include "orionld/common/httpStatusCodeToOrionldErrorType.h"   // httpStatusCodeToOrionldErrorType
-#include "orionld/common/OrionldConnection.h"                  // orionldState
+#include "orionld/common/orionldState.h"                       // orionldState
 #include "orionld/common/numberToDate.h"                       // numberToDate
 #include "orionld/common/SCOMPARE.h"                           // SCOMPAREx
 #include "common/string.h"                                     // FT
@@ -86,9 +86,9 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
   //
   if ((oneHit == false) && (responseP->contextElementResponseVector.size() == 0))
   {
-    ciP->responseTree = kjArray(orionldState.kjsonP, NULL);
+    orionldState.responseTree = kjArray(orionldState.kjsonP, NULL);
     ciP->httpStatusCode = SccOk;
-    return ciP->responseTree;
+    return orionldState.responseTree;
   }
 
   //
@@ -107,7 +107,7 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
     if (responseP->errorCode.code == SccContextElementNotFound)
       ciP->httpStatusCode = responseP->errorCode.code;
 
-    return ciP->responseTree;
+    return orionldState.responseTree;
   }
 
   int hits = responseP->contextElementResponseVector.size();
@@ -115,11 +115,11 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
   if (hits == 0)  // No hit
   {
     if (oneHit == false)
-      ciP->responseTree = kjArray(orionldState.kjsonP, NULL);
+      orionldState.responseTree = kjArray(orionldState.kjsonP, NULL);
     else
-      ciP->responseTree = NULL;
+      orionldState.responseTree = NULL;
 
-    return ciP->responseTree;
+    return orionldState.responseTree;
   }
   else if ((hits > 1) && (oneHit == true))  // More than one hit - not possible!
   {
@@ -602,13 +602,13 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
           else
           {
             orionldErrorResponseCreate(ciP, OrionldInternalError, "invalid context", "inline contexts not supported - wait it's coming ...", OrionldDetailsString);
-            return ciP->responseTree;
+            return orionldState.responseTree;
           }
         }
         else
         {
           orionldErrorResponseCreate(ciP, OrionldInternalError, "invalid context", "not a string nor an array", OrionldDetailsString);
-          return ciP->responseTree;
+          return orionldState.responseTree;
         }
       }
     }

--- a/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
@@ -205,7 +205,7 @@ int orionldMhdConnectionInit
   *con_cls = ciP;
 
   // Keep a pointer to the method/verb
-  ciP->verbString = (char*) method;
+  orionldState.verbString = (char*) method;
 
   //
   // Creating kjson environment for KJson parse and render
@@ -217,7 +217,6 @@ int orionldMhdConnectionInit
   //
   orionldStateInit();
 
-  ciP->kjsonP = orionldState.kjsonP;  // FIXME: ciP->kjsonP is to BE REMOVED. orionldState.kjsonP should be used instead
 
   // The 'connection', as given by MHD is very important. No responses can be sent without it
   ciP->connection = connection;
@@ -230,27 +229,27 @@ int orionldMhdConnectionInit
   ipAddressAndPort(ciP);
 
   // Save URL path in ConnectionInfo
-  ciP->urlPath = (char*) url;
+  orionldState.urlPath = (char*) url;
 
   //
   // Does the URL path end in a '/'?
   // If so, remove it.
   // If more than one, ERROR
   //
-  int urlLen = strlen(ciP->urlPath);
+  int urlLen = strlen(orionldState.urlPath);
 
-  if (ciP->urlPath[urlLen - 1] == '/')
+  if (orionldState.urlPath[urlLen - 1] == '/')
   {
     LM_T(LmtUriPath, ("URI PATH ends in SLASH - removing it"));
-    ciP->urlPath[urlLen - 1] = 0;
+    orionldState.urlPath[urlLen - 1] = 0;
     urlLen -= 1;
 
     // Now check for a second '/'
-    if (ciP->urlPath[urlLen - 1] == '/')
+    if (orionldState.urlPath[urlLen - 1] == '/')
     {
       LM_T(LmtUriPath, ("URI PATH ends in DOUBLE SLASH - flagging error"));
-      ciP->responsePayload  = (char*) doubleSlashPayload;
-      ciP->httpStatusCode   = SccBadRequest;
+      orionldState.responsePayload = (char*) doubleSlashPayload;
+      ciP->httpStatusCode          = SccBadRequest;
       return MHD_YES;
     }
   }
@@ -268,8 +267,8 @@ int orionldMhdConnectionInit
   // 4.  Check payload too big
   if (ciP->httpHeaders.contentLength > 2000000)
   {
-    ciP->responsePayload  = (char*) payloadTooLargePayload;
-    ciP->httpStatusCode   = SccBadRequest;
+    orionldState.responsePayload = (char*) payloadTooLargePayload;
+    ciP->httpStatusCode          = SccBadRequest;
     return MHD_YES;
   }
 
@@ -317,21 +316,21 @@ int orionldMhdConnectionInit
   //
   // 23. Format of response payload
   //
-  if (ciP->prettyPrint == true)
+  if (orionldState.prettyPrint == true)
   {
     // Human readable output
-    ciP->kjsonP->spacesPerIndent   = ciP->prettyPrintSpaces;
-    ciP->kjsonP->nlString          = (char*) "\n";
-    ciP->kjsonP->stringBeforeColon = (char*) "";
-    ciP->kjsonP->stringAfterColon  = (char*) " ";
+    orionldState.kjsonP->spacesPerIndent   = orionldState.prettyPrintSpaces;
+    orionldState.kjsonP->nlString          = (char*) "\n";
+    orionldState.kjsonP->stringBeforeColon = (char*) "";
+    orionldState.kjsonP->stringAfterColon  = (char*) " ";
   }
   else
   {
     // By default, no whitespace in output
-    ciP->kjsonP->spacesPerIndent   = 0;
-    ciP->kjsonP->nlString          = (char*) "";
-    ciP->kjsonP->stringBeforeColon = (char*) "";
-    ciP->kjsonP->stringAfterColon  = (char*) "";
+    orionldState.kjsonP->spacesPerIndent   = 0;
+    orionldState.kjsonP->nlString          = (char*) "";
+    orionldState.kjsonP->stringBeforeColon = (char*) "";
+    orionldState.kjsonP->stringAfterColon  = (char*) "";
   }
 
   //

--- a/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
@@ -219,8 +219,8 @@ int orionldMhdConnectionTreat(ConnectionInfo* ciP)
     // orionldMhdConnectionInit guarantees that a valid verb is used. I.e. POST, GET, DELETE or PATCH
     // orionldServiceLookup makes sure the URL supprts the verb
     //
-    ciP->serviceP = orionldServiceLookup(ciP, &orionldRestServiceV[ciP->verb]);
-    if (ciP->serviceP == NULL)
+    orionldState.serviceP = orionldServiceLookup(ciP, &orionldRestServiceV[ciP->verb]);
+    if (orionldState.serviceP == NULL)
     {
       if (orionldBadVerb(ciP) == true)
       {
@@ -388,9 +388,9 @@ int orionldMhdConnectionTreat(ConnectionInfo* ciP)
     //
     // Calling the SERVICE ROUTINE
     //
-    LM_T(LmtServiceRoutine, ("Calling Service Routine %s", ciP->serviceP->url));
-    bool b = ciP->serviceP->serviceRoutine(ciP);
-    LM_T(LmtServiceRoutine, ("service routine '%s' done", ciP->serviceP->url));
+    LM_T(LmtServiceRoutine, ("Calling Service Routine %s", orionldState.serviceP->url));
+    bool b = orionldState.serviceP->serviceRoutine(ciP);
+    LM_T(LmtServiceRoutine, ("service routine '%s' done", orionldState.serviceP->url));
 
     if ((b == true) && (contextToBeCreated == true))
     {

--- a/src/lib/orionld/rest/orionldServiceLookup.cpp
+++ b/src/lib/orionld/rest/orionldServiceLookup.cpp
@@ -22,12 +22,13 @@
 *
 * Author: Ken Zangelin
 */
-#include "logMsg/logMsg.h"                                // LM_*
-#include "logMsg/traceLevels.h"                           // Lmt*
+#include "logMsg/logMsg.h"                                     // LM_*
+#include "logMsg/traceLevels.h"                                // Lmt*
 
-#include "rest/ConnectionInfo.h"                          // ConnectionInfo
-#include "orionld/rest/OrionLdRestService.h"              // OrionLdRestService, ORION_LD_SERVICE_PREFIX_LEN
-#include "orionld/rest/orionldServiceLookup.h"            // Own interface
+#include "rest/ConnectionInfo.h"                               // ConnectionInfo
+#include "orionld/common/orionldState.h"                       // orionldState
+#include "orionld/rest/OrionLdRestService.h"                   // OrionLdRestService, ORION_LD_SERVICE_PREFIX_LEN
+#include "orionld/rest/orionldServiceLookup.h"                 // Own interface
 
 
 
@@ -159,19 +160,19 @@ OrionLdRestService* orionldServiceLookup(ConnectionInfo* ciP, OrionLdRestService
               {
                 LM_T(LmtServiceLookup, ("******************* %s matches", serviceP->url));
 
-                ciP->wildcard[0] = &ciP->urlPath[serviceP->charsBeforeFirstWildcard + ORION_LD_SERVICE_PREFIX_LEN];
+                orionldState.wildcard[0] = &ciP->urlPath[serviceP->charsBeforeFirstWildcard + ORION_LD_SERVICE_PREFIX_LEN];
 
                 // Destroying the incoming URL path, to extract the wildcard string
                 ciP->urlPath[sLen - serviceP->matchForSecondWildcardLen + ORION_LD_SERVICE_PREFIX_LEN] = 0;
-                LM_T(LmtServiceLookup, ("WILDCARD:  '%s'", ciP->wildcard[0]));
+                LM_T(LmtServiceLookup, ("WILDCARD:  '%s'", orionldState.wildcard[0]));
                 return serviceP;
               }
             }
             else
             {
               LM_T(LmtServiceLookup, ("******************* %s matches", serviceP->url));
-              ciP->wildcard[0] = &ciP->urlPath[serviceP->charsBeforeFirstWildcard + ORION_LD_SERVICE_PREFIX_LEN];
-              LM_T(LmtServiceLookup, ("WILDCARD:  '%s'", ciP->wildcard[0]));
+              orionldState.wildcard[0] = &ciP->urlPath[serviceP->charsBeforeFirstWildcard + ORION_LD_SERVICE_PREFIX_LEN];
+              LM_T(LmtServiceLookup, ("WILDCARD:  '%s'", orionldState.wildcard[0]));
               return serviceP;
             }
           }
@@ -195,13 +196,13 @@ OrionLdRestService* orionldServiceLookup(ConnectionInfo* ciP, OrionLdRestService
             LM_T(LmtServiceLookup, ("Second wildcard: %s", &matchP[serviceP->matchForSecondWildcardLen]));
             {
               LM_T(LmtServiceLookup, ("******************* %s matches", serviceP->url));
-              ciP->wildcard[0] = &ciP->urlPath[serviceP->charsBeforeFirstWildcard + ORION_LD_SERVICE_PREFIX_LEN];
-              ciP->wildcard[1] = &matchP[serviceP->matchForSecondWildcardLen];
+              orionldState.wildcard[0] = &ciP->urlPath[serviceP->charsBeforeFirstWildcard + ORION_LD_SERVICE_PREFIX_LEN];
+              orionldState.wildcard[1] = &matchP[serviceP->matchForSecondWildcardLen];
 
               // Destroying the incoming URL path, to extract first wildcard string
               *matchP = 0;
-              LM_T(LmtServiceLookup, ("First WILDCARD:  '%s'", ciP->wildcard[0]));
-              LM_T(LmtServiceLookup, ("Second WILDCARD: '%s'", ciP->wildcard[1]));
+              LM_T(LmtServiceLookup, ("First WILDCARD:  '%s'", orionldState.wildcard[0]));
+              LM_T(LmtServiceLookup, ("Second WILDCARD: '%s'", orionldState.wildcard[1]));
 
               return serviceP;
             }

--- a/src/lib/orionld/rest/orionldServiceLookup.cpp
+++ b/src/lib/orionld/rest/orionldServiceLookup.cpp
@@ -91,9 +91,9 @@ OrionLdRestService* orionldServiceLookup(ConnectionInfo* ciP, OrionLdRestService
   int cSums;
   int sLen;
 
-  LM_T(LmtServiceLookup, ("Looking up service routine for %s %s", verbName(ciP->verb), ciP->urlPath));
-  requestPrepare(ciP->urlPath, cSumV, &cSums, &sLen);
-  LM_T(LmtServiceLookup, ("Request prepared: strlen(%s): %d", ciP->urlPath, sLen));
+  LM_T(LmtServiceLookup, ("Looking up service routine for %s %s", verbName(ciP->verb), orionldState.urlPath));
+  requestPrepare(orionldState.urlPath, cSumV, &cSums, &sLen);
+  LM_T(LmtServiceLookup, ("Request prepared: strlen(%s): %d", orionldState.urlPath, sLen));
   LM_T(LmtServiceLookup, ("Request prepared: cSums: %d", cSums));
 
 #if 0
@@ -107,7 +107,7 @@ OrionLdRestService* orionldServiceLookup(ConnectionInfo* ciP, OrionLdRestService
   {
     OrionLdRestService* serviceP = &serviceV->serviceV[serviceIx];
 
-    LM_T(LmtServiceLookup, ("Comparing incoming '%s' to service '%s' (%d wildcards)", ciP->urlPath, serviceP->url, serviceP->wildcards));
+    LM_T(LmtServiceLookup, ("Comparing incoming '%s' to service '%s' (%d wildcards)", orionldState.urlPath, serviceP->url, serviceP->wildcards));
 
     if (serviceP->wildcards == 0)
     {
@@ -117,8 +117,8 @@ OrionLdRestService* orionldServiceLookup(ConnectionInfo* ciP, OrionLdRestService
         LM_T(LmtServiceLookup, ("No wildcard. strlens match. Comparing cSums[%d]: %d vs %d", sLen, serviceP->charsBeforeFirstWildcardSum, cSumV[sLen - 1]));
         if (serviceP->charsBeforeFirstWildcardSum == cSumV[sLen - 1])
         {
-          LM_T(LmtServiceLookup, ("Possible match. Not a complete strcmp of '%s' vs '%s'", &serviceP->url[ORION_LD_SERVICE_PREFIX_LEN], &ciP->urlPath[ORION_LD_SERVICE_PREFIX_LEN]));
-          if (strcmp(&serviceP->url[ORION_LD_SERVICE_PREFIX_LEN], &ciP->urlPath[ORION_LD_SERVICE_PREFIX_LEN]) == 0)
+          LM_T(LmtServiceLookup, ("Possible match. Not a complete strcmp of '%s' vs '%s'", &serviceP->url[ORION_LD_SERVICE_PREFIX_LEN], &orionldState.urlPath[ORION_LD_SERVICE_PREFIX_LEN]));
+          if (strcmp(&serviceP->url[ORION_LD_SERVICE_PREFIX_LEN], &orionldState.urlPath[ORION_LD_SERVICE_PREFIX_LEN]) == 0)
           {
             LM_T(LmtServiceLookup, ("******************* %s matches", serviceP->url));
             return serviceP;
@@ -135,8 +135,8 @@ OrionLdRestService* orionldServiceLookup(ConnectionInfo* ciP, OrionLdRestService
         LM_T(LmtServiceLookup, ("One wildcard. strlens OK. Comparing charsBeforeFirstWildcardSum: %d vs %d", serviceP->charsBeforeFirstWildcardSum, cSumV[serviceP->charsBeforeFirstWildcard - 1]));
         if (serviceP->charsBeforeFirstWildcardSum == cSumV[serviceP->charsBeforeFirstWildcard - 1])
         {
-          LM_T(LmtServiceLookup, ("One wildcard. Possible match. Parcial strcmp of '%s' vs '%s' (%d bytes)", &serviceP->url[ORION_LD_SERVICE_PREFIX_LEN], &ciP->urlPath[ORION_LD_SERVICE_PREFIX_LEN], serviceP->charsBeforeFirstWildcard));
-          if (strncmp(&serviceP->url[ORION_LD_SERVICE_PREFIX_LEN], &ciP->urlPath[ORION_LD_SERVICE_PREFIX_LEN], serviceP->charsBeforeFirstWildcard) == 0)
+          LM_T(LmtServiceLookup, ("One wildcard. Possible match. Parcial strcmp of '%s' vs '%s' (%d bytes)", &serviceP->url[ORION_LD_SERVICE_PREFIX_LEN], &orionldState.urlPath[ORION_LD_SERVICE_PREFIX_LEN], serviceP->charsBeforeFirstWildcard));
+          if (strncmp(&serviceP->url[ORION_LD_SERVICE_PREFIX_LEN], &orionldState.urlPath[ORION_LD_SERVICE_PREFIX_LEN], serviceP->charsBeforeFirstWildcard) == 0)
           {
             LM_T(LmtServiceLookup, ("One wildcard. Possible match. "));
             // Ending the same?
@@ -146,24 +146,24 @@ OrionLdRestService* orionldServiceLookup(ConnectionInfo* ciP, OrionLdRestService
 
               LM_T(LmtServiceLookup, ("***************************************************************"));
               LM_T(LmtServiceLookup, ("Comparing string ends"));
-              LM_T(LmtServiceLookup, ("Incoming URL Path: %s", ciP->urlPath));
+              LM_T(LmtServiceLookup, ("Incoming URL Path: %s", orionldState.urlPath));
               LM_T(LmtServiceLookup, ("Being compared to: %s", serviceP->url));
-              LM_T(LmtServiceLookup, ("sLen == %d (strlen of incoming URL '%s'", sLen, ciP->urlPath));
+              LM_T(LmtServiceLookup, ("sLen == %d (strlen of incoming URL '%s'", sLen, orionldState.urlPath));
               LM_T(LmtServiceLookup, ("Number of chars to compare: %d", serviceP->matchForSecondWildcardLen));
               LM_T(LmtServiceLookup, ("matchForSecondWildcardLen == %d", serviceP->matchForSecondWildcardLen));
               LM_T(LmtServiceLookup, ("Comparing string ends: index %d for Incoming URL Path", indexOfIncomingUrlPath));
               LM_T(LmtServiceLookup, ("Comparing string ends: string that the Service the Incoming URL Path is compared to: %s", serviceP->matchForSecondWildcard));
               LM_T(LmtServiceLookup, ("Comparing string ends: Number of chars in the string: %d", serviceP->matchForSecondWildcardLen));
-              LM_T(LmtServiceLookup, ("Comparing string ends: End of Incoming URL Path: %s", &ciP->urlPath[indexOfIncomingUrlPath]));
+              LM_T(LmtServiceLookup, ("Comparing string ends: End of Incoming URL Path: %s", &orionldState.urlPath[indexOfIncomingUrlPath]));
 
-              if (strncmp(&ciP->urlPath[indexOfIncomingUrlPath], serviceP->matchForSecondWildcard, serviceP->matchForSecondWildcardLen) == 0)
+              if (strncmp(&orionldState.urlPath[indexOfIncomingUrlPath], serviceP->matchForSecondWildcard, serviceP->matchForSecondWildcardLen) == 0)
               {
                 LM_T(LmtServiceLookup, ("******************* %s matches", serviceP->url));
 
-                orionldState.wildcard[0] = &ciP->urlPath[serviceP->charsBeforeFirstWildcard + ORION_LD_SERVICE_PREFIX_LEN];
+                orionldState.wildcard[0] = &orionldState.urlPath[serviceP->charsBeforeFirstWildcard + ORION_LD_SERVICE_PREFIX_LEN];
 
                 // Destroying the incoming URL path, to extract the wildcard string
-                ciP->urlPath[sLen - serviceP->matchForSecondWildcardLen + ORION_LD_SERVICE_PREFIX_LEN] = 0;
+                orionldState.urlPath[sLen - serviceP->matchForSecondWildcardLen + ORION_LD_SERVICE_PREFIX_LEN] = 0;
                 LM_T(LmtServiceLookup, ("WILDCARD:  '%s'", orionldState.wildcard[0]));
                 return serviceP;
               }
@@ -171,7 +171,7 @@ OrionLdRestService* orionldServiceLookup(ConnectionInfo* ciP, OrionLdRestService
             else
             {
               LM_T(LmtServiceLookup, ("******************* %s matches", serviceP->url));
-              orionldState.wildcard[0] = &ciP->urlPath[serviceP->charsBeforeFirstWildcard + ORION_LD_SERVICE_PREFIX_LEN];
+              orionldState.wildcard[0] = &orionldState.urlPath[serviceP->charsBeforeFirstWildcard + ORION_LD_SERVICE_PREFIX_LEN];
               LM_T(LmtServiceLookup, ("WILDCARD:  '%s'", orionldState.wildcard[0]));
               return serviceP;
             }
@@ -188,15 +188,15 @@ OrionLdRestService* orionldServiceLookup(ConnectionInfo* ciP, OrionLdRestService
         LM_T(LmtServiceLookup, ("Two wildcards. strlens OK. Comparing charsBeforeFirstWildcardSum: %d vs %d", serviceP->charsBeforeFirstWildcardSum, cSumV[serviceP->charsBeforeFirstWildcard - 1]));
         if (serviceP->charsBeforeFirstWildcardSum == cSumV[serviceP->charsBeforeFirstWildcard - 1])
         {
-          LM_T(LmtServiceLookup, ("Two wildcards. Possible match. Finding '%s' inside '%s'", serviceP->matchForSecondWildcard, &ciP->urlPath[ORION_LD_SERVICE_PREFIX_LEN]));
+          LM_T(LmtServiceLookup, ("Two wildcards. Possible match. Finding '%s' inside '%s'", serviceP->matchForSecondWildcard, &orionldState.urlPath[ORION_LD_SERVICE_PREFIX_LEN]));
           char* matchP;
-          if ((matchP = strstr(&ciP->urlPath[ORION_LD_SERVICE_PREFIX_LEN], serviceP->matchForSecondWildcard)) != NULL)
+          if ((matchP = strstr(&orionldState.urlPath[ORION_LD_SERVICE_PREFIX_LEN], serviceP->matchForSecondWildcard)) != NULL)
           {
             LM_T(LmtServiceLookup, ("Two wildcards. Found '%s' inside incoming URL - possible match", serviceP->matchForSecondWildcard));
             LM_T(LmtServiceLookup, ("Second wildcard: %s", &matchP[serviceP->matchForSecondWildcardLen]));
             {
               LM_T(LmtServiceLookup, ("******************* %s matches", serviceP->url));
-              orionldState.wildcard[0] = &ciP->urlPath[serviceP->charsBeforeFirstWildcard + ORION_LD_SERVICE_PREFIX_LEN];
+              orionldState.wildcard[0] = &orionldState.urlPath[serviceP->charsBeforeFirstWildcard + ORION_LD_SERVICE_PREFIX_LEN];
               orionldState.wildcard[1] = &matchP[serviceP->matchForSecondWildcardLen];
 
               // Destroying the incoming URL path, to extract first wildcard string

--- a/src/lib/orionld/serviceRoutines/orionldBadVerb.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldBadVerb.cpp
@@ -26,6 +26,7 @@
 #include "logMsg/traceLevels.h"                                // Lmt*
 
 #include "rest/ConnectionInfo.h"                               // ConnectionInfo
+#include "orionld/common/orionldState.h"                       // orionldState, orionldStateInit
 #include "orionld/rest/temporaryErrorPayloads.h"               // notFoundPayload
 #include "orionld/rest/orionldServiceInit.h"                   // orionldRestServiceV
 #include "orionld/rest/orionldServiceLookup.h"                 // orionldServiceLookup
@@ -42,8 +43,8 @@ bool orionldBadVerb(ConnectionInfo* ciP)
   uint16_t  bitmask = 0;
   bool      found   = false;
 
-  LM_T(LmtBadVerb, ("PATH: %s", ciP->urlPath));
-  LM_T(LmtBadVerb, ("VERB: %s", ciP->verbString));
+  LM_T(LmtBadVerb, ("PATH: %s", orionldState.urlPath));
+  LM_T(LmtBadVerb, ("VERB: %s", orionldState.verbString));
 
   //
   // There are nine verbs/methods, but only GET, POST, PATCH and DELETE are supported by ORIONLD

--- a/src/lib/orionld/serviceRoutines/orionldDeleteAttribute.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldDeleteAttribute.cpp
@@ -52,12 +52,12 @@ bool orionldDeleteAttribute(ConnectionInfo* ciP)
   char*   details;
   Entity  entity;
 
-  if ((strncmp(ciP->wildcard[1], "http://", 7) == 0) || (strncmp(ciP->wildcard[1], "https://", 8) == 0))
-    attrNameP = ciP->wildcard[1];
+  if ((strncmp(orionldState.wildcard[1], "http://", 7) == 0) || (strncmp(orionldState.wildcard[1], "https://", 8) == 0))
+    attrNameP = orionldState.wildcard[1];
   else
   {
     // Get the long name of the Context Attribute name
-    if (orionldUriExpand(orionldState.contextP, ciP->wildcard[1], longAttrName, sizeof(longAttrName), &details) == false)
+    if (orionldUriExpand(orionldState.contextP, orionldState.wildcard[1], longAttrName, sizeof(longAttrName), &details) == false)
     {
       orionldErrorResponseCreate(ciP, OrionldBadRequestData, details, type, OrionldDetailsAttribute);
       return false;
@@ -66,13 +66,13 @@ bool orionldDeleteAttribute(ConnectionInfo* ciP)
   }
 
   // Create and fill in attribute and entity
-  entity.id = ciP->wildcard[0];
+  entity.id = orionldState.wildcard[0];
 
   // Does the attribute to be deleted even exist?
-  if (mongoAttributeExists(ciP->wildcard[0], attrNameP, orionldState.tenant) == false)
+  if (mongoAttributeExists(orionldState.wildcard[0], attrNameP, orionldState.tenant) == false)
   {
     ciP->httpStatusCode = SccContextElementNotFound;
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Attribute Not Found", ciP->wildcard[1], OrionldDetailsAttribute);
+    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Attribute Not Found", orionldState.wildcard[1], OrionldDetailsAttribute);
     return false;
   }
 
@@ -81,7 +81,7 @@ bool orionldDeleteAttribute(ConnectionInfo* ciP)
   caP->name = attrNameP;
   entity.attributeVector.push_back(caP);
 
-  LM_T(LmtServiceRoutine, ("Deleting attribute '%s' of entity '%s'", ciP->wildcard[1], ciP->wildcard[0]));
+  LM_T(LmtServiceRoutine, ("Deleting attribute '%s' of entity '%s'", orionldState.wildcard[1], orionldState.wildcard[0]));
 
   UpdateContextRequest  ucr;
   UpdateContextResponse ucResponse;
@@ -100,7 +100,7 @@ bool orionldDeleteAttribute(ConnectionInfo* ciP)
 
   if (ciP->httpStatusCode != SccOk)
   {
-    orionldErrorResponseCreate(ciP, httpStatusCodeToOrionldErrorType(ciP->httpStatusCode), "DELETE /ngsi-ld/v1/entities/*/attrs/*", ciP->wildcard[0], OrionldDetailsString);
+    orionldErrorResponseCreate(ciP, httpStatusCodeToOrionldErrorType(ciP->httpStatusCode), "DELETE /ngsi-ld/v1/entities/*/attrs/*", orionldState.wildcard[0], OrionldDetailsString);
     ucr.release();
 
     return false;

--- a/src/lib/orionld/serviceRoutines/orionldDeleteEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldDeleteEntity.cpp
@@ -30,6 +30,7 @@
 
 #include "rest/ConnectionInfo.h"                               // ConnectionInfo
 #include "ngsi/ParseData.h"                                    // ParseData needed for postUpdateContext()
+#include "orionld/common/orionldState.h"                       // orionldState
 #include "orionld/common/orionldErrorResponse.h"               // orionldErrorResponseCreate
 #include "orionld/common/urlCheck.h"                           // urlCheck
 #include "orionld/common/urnCheck.h"                           // urnCheck
@@ -52,7 +53,7 @@ bool orionldDeleteEntity(ConnectionInfo* ciP)
   // Check that the Entity ID is a valid URI
   char* details;
 
-  if ((urlCheck(ciP->wildcard[0], &details) == false) && (urnCheck(ciP->wildcard[0], &details) == false))
+  if ((urlCheck(orionldState.wildcard[0], &details) == false) && (urnCheck(orionldState.wildcard[0], &details) == false))
   {
     orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid Entity ID", details, OrionldDetailsString);
     ciP->httpStatusCode = SccBadRequest;
@@ -60,7 +61,7 @@ bool orionldDeleteEntity(ConnectionInfo* ciP)
   }
 
   // Fill in entity with the entity-id from the URL
-  entity.id = ciP->wildcard[0];
+  entity.id = orionldState.wildcard[0];
 
   // Fill in the upcr field for postUpdateContext, with the entity and DELETE as action
   parseData.upcr.res.fill(&entity, ActionTypeDelete);
@@ -74,7 +75,7 @@ bool orionldDeleteEntity(ConnectionInfo* ciP)
   {
     OrionldResponseErrorType eType = (parseData.upcrs.res.oe.code == SccContextElementNotFound)? OrionldResourceNotFound : OrionldBadRequestData;
 
-    orionldErrorResponseCreate(ciP, eType, parseData.upcrs.res.oe.details.c_str(), ciP->wildcard[0], OrionldDetailsString);
+    orionldErrorResponseCreate(ciP, eType, parseData.upcrs.res.oe.details.c_str(), orionldState.wildcard[0], OrionldDetailsString);
     ciP->httpStatusCode = (parseData.upcrs.res.oe.code == SccContextElementNotFound)? SccContextElementNotFound : SccBadRequest;
 
     // Release allocated data

--- a/src/lib/orionld/serviceRoutines/orionldDeleteRegistration.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldDeleteRegistration.cpp
@@ -26,6 +26,7 @@
 #include "logMsg/traceLevels.h"                                   // Lmt*
 
 #include "rest/ConnectionInfo.h"                                  // ConnectionInfo
+#include "orionld/common/orionldState.h"                          // orionldState
 #include "orionld/common/orionldErrorResponse.h"                  // orionldErrorResponseCreate
 #include "orionld/serviceRoutines/orionldDeleteRegistration.h"    // Own Interface
 
@@ -39,7 +40,7 @@ bool orionldDeleteRegistration(ConnectionInfo* ciP)
 {
   LM_T(LmtServiceRoutine, ("In orionldDeleteRegistration"));
 
-  orionldErrorResponseCreate(ciP, OrionldBadRequestData, "not implemented - DELETE /ngsi-ld/v1/csourceRegistrations/*", ciP->wildcard[0], OrionldDetailsString);
+  orionldErrorResponseCreate(ciP, OrionldBadRequestData, "not implemented - DELETE /ngsi-ld/v1/csourceRegistrations/*", orionldState.wildcard[0], OrionldDetailsString);
 
   ciP->httpStatusCode = SccNotImplemented;
 

--- a/src/lib/orionld/serviceRoutines/orionldDeleteSubscription.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldDeleteSubscription.cpp
@@ -43,9 +43,9 @@ bool orionldDeleteSubscription(ConnectionInfo* ciP)
 {
   char* details;
 
-  if (mongoDeleteLdSubscription(ciP->wildcard[0], orionldState.tenant, &ciP->httpStatusCode, &details) == false)
+  if (mongoDeleteLdSubscription(orionldState.wildcard[0], orionldState.tenant, &ciP->httpStatusCode, &details) == false)
   {
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, details, ciP->wildcard[0], OrionldDetailsString);
+    orionldErrorResponseCreate(ciP, OrionldBadRequestData, details, orionldState.wildcard[0], OrionldDetailsString);
     return false;
   }
 

--- a/src/lib/orionld/serviceRoutines/orionldGetContext.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetContext.cpp
@@ -47,9 +47,9 @@ extern "C"
 //
 bool orionldGetContext(ConnectionInfo* ciP)
 {
-  LM_T(LmtServiceRoutine, ("In orionldGetContext - looking up context '%s'", ciP->wildcard[0]));
+  LM_T(LmtServiceRoutine, ("In orionldGetContext - looking up context '%s'", orionldState.wildcard[0]));
 
-  OrionldContext* contextP    = orionldContextLookup(ciP->wildcard[0]);
+  OrionldContext* contextP    = orionldContextLookup(orionldState.wildcard[0]);
   KjNode*         contextTree = NULL;
 
   orionldState.useLinkHeader = false;  // We don't want the Link header for context requests
@@ -63,7 +63,7 @@ bool orionldGetContext(ConnectionInfo* ciP)
     // OK, might be an entity context then ...
 
     QueryContextRequest   request;
-    EntityId              entityId(ciP->wildcard[0], "", "false", false);
+    EntityId              entityId(orionldState.wildcard[0], "", "false", false);
     QueryContextResponse  response;
 
     request.entityIdVector.push_back(&entityId);
@@ -96,7 +96,7 @@ bool orionldGetContext(ConnectionInfo* ciP)
 
     if (contextTree == NULL)
     {
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Context Not Found", ciP->wildcard[0], OrionldDetailsString);
+      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Context Not Found", orionldState.wildcard[0], OrionldDetailsString);
       ciP->httpStatusCode = SccContextElementNotFound;
       return false;
     }

--- a/src/lib/orionld/serviceRoutines/orionldGetContext.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetContext.cpp
@@ -34,7 +34,7 @@ extern "C"
 #include "rest/ConnectionInfo.h"                                 // ConnectionInfo
 #include "mongoBackend/mongoQueryContext.h"                      // mongoQueryContext
 #include "orionld/common/orionldErrorResponse.h"                 // orionldErrorResponseCreate
-#include "orionld/common/OrionldConnection.h"                    // orionldState
+#include "orionld/common/orionldState.h"                         // orionldState
 #include "orionld/context/orionldContextLookup.h"                // orionldContextLookup
 #include "orionld/kjTree/kjTreeFromContextContextAttribute.h"    // kjTreeFromContextContextAttribute
 #include "orionld/serviceRoutines/orionldGetContext.h"           // Own Interface
@@ -102,17 +102,17 @@ bool orionldGetContext(ConnectionInfo* ciP)
     }
   }
 
-  ciP->responseTree = kjObject(orionldState.kjsonP, "@context");
+  orionldState.responseTree = kjObject(orionldState.kjsonP, "@context");
   // NOTE: No need to free - as the kjObject is allocated in "orionldState.kjsonP", it gets deleted when the thread is reused.
 
-  if (ciP->responseTree == NULL)
+  if (orionldState.responseTree == NULL)
   {
     orionldErrorResponseCreate(ciP, OrionldBadRequestData, "kjObject failed", "out of memory?", OrionldDetailsString);
     ciP->httpStatusCode = SccReceiverInternalError;
     return false;
   }
 
-  ciP->responseTree->value.firstChildP = contextTree;
+  orionldState.responseTree->value.firstChildP = contextTree;
 
   return true;
 }

--- a/src/lib/orionld/serviceRoutines/orionldGetEntities.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntities.cpp
@@ -559,8 +559,8 @@ bool orionldGetEntities(ConnectionInfo* ciP)
   //
   // Transform QueryContextResponse to KJ-Tree
   //
-  ciP->httpStatusCode = SccOk;
-  ciP->responseTree   = kjTreeFromQueryContextResponse(ciP, false, keyValues, &parseData.qcrs.res);
+  ciP->httpStatusCode       = SccOk;
+  orionldState.responseTree = kjTreeFromQueryContextResponse(ciP, false, keyValues, &parseData.qcrs.res);
 
   return true;
 }

--- a/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
@@ -153,14 +153,14 @@ bool orionldGetEntity(ConnectionInfo* ciP)
     }
     *attrListEnd = 0;
 
-    ciP->responseTree = kjTreeFromQueryContextResponseWithAttrList(ciP, true, attrList, keyValues, &response);
+    orionldState.responseTree = kjTreeFromQueryContextResponseWithAttrList(ciP, true, attrList, keyValues, &response);
     free(attrList);
   }
   else
-    ciP->responseTree = kjTreeFromQueryContextResponse(ciP, true, keyValues, &response);
+    orionldState.responseTree = kjTreeFromQueryContextResponse(ciP, true, keyValues, &response);
 
 
-  if (ciP->responseTree == NULL)
+  if (orionldState.responseTree == NULL)
   {
     ciP->httpStatusCode = SccContextElementNotFound;
   }

--- a/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
@@ -59,17 +59,17 @@ bool orionldGetEntity(ConnectionInfo* ciP)
   bool                  keyValues = ciP->uriParamOptions[OPT_KEY_VALUES];
   QueryContextRequest   request;
   QueryContextResponse  response;
-  EntityId              entityId(ciP->wildcard[0], "", "false", false);
+  EntityId              entityId(orionldState.wildcard[0], "", "false", false);
   char*                 details;
 
-  LM_T(LmtServiceRoutine, ("In orionldGetEntity: %s", ciP->wildcard[0]));
+  LM_T(LmtServiceRoutine, ("In orionldGetEntity: %s", orionldState.wildcard[0]));
 
   request.entityIdVector.push_back(&entityId);
 
   //
-  // Make sure the ID (ciP->wildcard[0]) is a valid URI
+  // Make sure the ID (orionldState.wildcard[0]) is a valid URI
   //
-  if ((urlCheck(ciP->wildcard[0], &details) == false) && (urnCheck(ciP->wildcard[0], &details) == false))
+  if ((urlCheck(orionldState.wildcard[0], &details) == false) && (urnCheck(orionldState.wildcard[0], &details) == false))
   {
     LM_W(("Bad Input (Invalid Entity ID - Not a URL nor a URN)"));
     orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid Entity ID", "Not a URL nor a URN", OrionldDetailsString);

--- a/src/lib/orionld/serviceRoutines/orionldGetRegistration.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetRegistration.cpp
@@ -26,6 +26,7 @@
 #include "logMsg/traceLevels.h"                                // Lmt*
 
 #include "rest/ConnectionInfo.h"                               // ConnectionInfo
+#include "orionld/common/orionldState.h"                       // orionldState
 #include "orionld/common/orionldErrorResponse.h"               // orionldErrorResponseCreate
 #include "orionld/serviceRoutines/orionldGetRegistration.h"    // Own Interface
 
@@ -39,7 +40,7 @@ bool orionldGetRegistration(ConnectionInfo* ciP)
 {
   LM_T(LmtServiceRoutine, ("In orionldGetRegistration"));
 
-  orionldErrorResponseCreate(ciP, OrionldBadRequestData, "not implemented - GET /ngsi-ld/v1/csourceRegistrations/*", ciP->wildcard[0], OrionldDetailsString);
+  orionldErrorResponseCreate(ciP, OrionldBadRequestData, "not implemented - GET /ngsi-ld/v1/csourceRegistrations/*", orionldState.wildcard[0], OrionldDetailsString);
 
   ciP->httpStatusCode = SccNotImplemented;
 

--- a/src/lib/orionld/serviceRoutines/orionldGetSubscription.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetSubscription.cpp
@@ -49,13 +49,13 @@ bool orionldGetSubscription(ConnectionInfo* ciP)
   subscription.expires             = -1;  // 0?
   subscription.throttling          = -1;  // 0?
 
-  LM_T(LmtServiceRoutine, ("In orionldGetSubscription (%s)", ciP->wildcard[0]));
+  LM_T(LmtServiceRoutine, ("In orionldGetSubscription (%s)", orionldState.wildcard[0]));
   LM_TMP(("TENANT: %s", orionldState.tenant));
 
-  if (mongoGetLdSubscription(&subscription, ciP->wildcard[0], orionldState.tenant, &ciP->httpStatusCode, &details) != true)
+  if (mongoGetLdSubscription(&subscription, orionldState.wildcard[0], orionldState.tenant, &ciP->httpStatusCode, &details) != true)
   {
     LM_E(("mongoGetLdSubscription error: %s", details));
-    orionldErrorResponseCreate(ciP, OrionldResourceNotFound, details, ciP->wildcard[0], OrionldDetailsString);
+    orionldErrorResponseCreate(ciP, OrionldResourceNotFound, details, orionldState.wildcard[0], OrionldDetailsString);
     return false;
   }
 

--- a/src/lib/orionld/serviceRoutines/orionldGetSubscription.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetSubscription.cpp
@@ -60,8 +60,8 @@ bool orionldGetSubscription(ConnectionInfo* ciP)
   }
 
   // Transform to KjNode tree
-  ciP->httpStatusCode = SccOk;
-  ciP->responseTree   = kjTreeFromSubscription(ciP, &subscription);
+  ciP->httpStatusCode       = SccOk;
+  orionldState.responseTree = kjTreeFromSubscription(ciP, &subscription);
 
   return true;
 }

--- a/src/lib/orionld/serviceRoutines/orionldGetSubscriptions.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetSubscriptions.cpp
@@ -34,10 +34,10 @@ extern "C"
 #include "logMsg/traceLevels.h"                                // Lmt*
 
 #include "common/string.h"                                     // toString
-#include "orionld/common/OrionldConnection.h"                  // orionldState
 #include "rest/uriParamNames.h"                                // URI_PARAM_PAGINATION_OFFSET, URI_PARAM_PAGINATION_LIMIT
 #include "rest/ConnectionInfo.h"                               // ConnectionInfo
 #include "mongoBackend/mongoGetSubscriptions.h"                // mongoListSubscriptions
+#include "orionld/common/orionldState.h"                       // orionldState
 #include "orionld/common/orionldErrorResponse.h"               // orionldErrorResponseCreate
 #include "orionld/kjTree/kjTreeFromSubscription.h"             // kjTreeFromSubscription
 #include "orionld/serviceRoutines/orionldGetSubscriptions.h"   // Own Interface
@@ -64,13 +64,13 @@ bool orionldGetSubscriptions(ConnectionInfo* ciP)
     ciP->httpHeaderValue.push_back(toString(count));
   }
 
-  ciP->responseTree = kjArray(orionldState.kjsonP, NULL);
+  orionldState.responseTree = kjArray(orionldState.kjsonP, NULL);
 
   for (unsigned int ix = 0; ix < subVec.size(); ix++)
   {
     KjNode* subscriptionNodeP = kjTreeFromSubscription(ciP, &subVec[ix]);
 
-    kjChildAdd(ciP->responseTree, subscriptionNodeP);
+    kjChildAdd(orionldState.responseTree, subscriptionNodeP);
   }
 
   return true;

--- a/src/lib/orionld/serviceRoutines/orionldGetVersion.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetVersion.cpp
@@ -35,7 +35,7 @@ extern "C"
 #include "logMsg/traceLevels.h"                                // Lmt*
 
 #include "rest/ConnectionInfo.h"                               // ConnectionInfo
-#include "orionld/common/OrionldConnection.h"                  // orionldState
+#include "orionld/common/orionldState.h"                       // orionldState
 #include "orionld/common/branchName.h"                         // ORIONLD_BRANCH
 #include "orionld/serviceRoutines/orionldGetVersion.h"         // Own Interface
 
@@ -49,17 +49,17 @@ bool orionldGetVersion(ConnectionInfo* ciP)
 {
   KjNode* nodeP;
 
-  ciP->responseTree = kjObject(orionldState.kjsonP, NULL);
+  orionldState.responseTree = kjObject(orionldState.kjsonP, NULL);
 
   nodeP = kjString(orionldState.kjsonP, "branch", ORIONLD_BRANCH);
-  kjChildAdd(ciP->responseTree, nodeP);
+  kjChildAdd(orionldState.responseTree, nodeP);
 
   nodeP = kjString(orionldState.kjsonP, "kbase version", kbaseVersion);
-  kjChildAdd(ciP->responseTree, nodeP);
+  kjChildAdd(orionldState.responseTree, nodeP);
   nodeP = kjString(orionldState.kjsonP, "kalloc version", kallocVersion);
-  kjChildAdd(ciP->responseTree, nodeP);
+  kjChildAdd(orionldState.responseTree, nodeP);
   nodeP = kjString(orionldState.kjsonP, "kjson version", kjsonVersion);
-  kjChildAdd(ciP->responseTree, nodeP);
+  kjChildAdd(orionldState.responseTree, nodeP);
 
   // This request is ALWAYS returned with pretty-print
   orionldState.kjsonP->spacesPerIndent   = 2;

--- a/src/lib/orionld/serviceRoutines/orionldPatchAttribute.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchAttribute.cpp
@@ -51,7 +51,7 @@ bool orionldPatchAttribute(ConnectionInfo* ciP)
   }
 
   // Is the payload empty?
-  if (ciP->requestTree == NULL)
+  if (orionldState.requestTree == NULL)
   {
     ciP->httpStatusCode = SccBadRequest;
     orionldErrorResponseCreate(ciP, OrionldBadRequestData, "No payload", NULL, OrionldDetailsString);
@@ -59,15 +59,15 @@ bool orionldPatchAttribute(ConnectionInfo* ciP)
   }
 
   // Is the payload not a JSON object?
-  if  (ciP->requestTree->type != KjObject)
+  if  (orionldState.requestTree->type != KjObject)
   {
     ciP->httpStatusCode = SccBadRequest;
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Payload not a JSON object", kjValueType(ciP->requestTree->type), OrionldDetailsString);
+    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Payload not a JSON object", kjValueType(orionldState.requestTree->type), OrionldDetailsString);
     return false;
   }
 
   // Is the payload an empty object?
-  if  (ciP->requestTree->value.firstChildP == NULL)
+  if  (orionldState.requestTree->value.firstChildP == NULL)
   {
     ciP->httpStatusCode = SccBadRequest;
     orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Payload is an empty JSON object", NULL, OrionldDetailsString);

--- a/src/lib/orionld/serviceRoutines/orionldPatchAttribute.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchAttribute.cpp
@@ -43,10 +43,10 @@ bool orionldPatchAttribute(ConnectionInfo* ciP)
 {
   LM_T(LmtServiceRoutine, ("In orionldPatchAttribute"));
 
-  if (mongoEntityExists(ciP->wildcard[0], orionldState.tenant) == false)
+  if (mongoEntityExists(orionldState.wildcard[0], orionldState.tenant) == false)
   {
     ciP->httpStatusCode = SccNotFound;
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Entity does not exist", ciP->wildcard[0], OrionldDetailsString);
+    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Entity does not exist", orionldState.wildcard[0], OrionldDetailsString);
     return false;
   }
 
@@ -75,14 +75,14 @@ bool orionldPatchAttribute(ConnectionInfo* ciP)
   }
 
   // Make sure the attribute to be patched exists
-  if (mongoAttributeExists(ciP->wildcard[0], ciP->wildcard[1], orionldState.tenant) == false)
+  if (mongoAttributeExists(orionldState.wildcard[0], orionldState.wildcard[1], orionldState.tenant) == false)
   {
     ciP->httpStatusCode = SccNotFound;
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Attribute does not exist", ciP->wildcard[1], OrionldDetailsString);
+    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Attribute does not exist", orionldState.wildcard[1], OrionldDetailsString);
     return false;
   }
 
   ciP->httpStatusCode = SccNotImplemented;
-  orionldErrorResponseCreate(ciP, OrionldBadRequestData, "not implemented - PATCH /ngsi-ld/v1/entities/*/attrs", ciP->wildcard[0], OrionldDetailsString);
+  orionldErrorResponseCreate(ciP, OrionldBadRequestData, "not implemented - PATCH /ngsi-ld/v1/entities/*/attrs", orionldState.wildcard[0], OrionldDetailsString);
   return true;
 }

--- a/src/lib/orionld/serviceRoutines/orionldPatchEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchEntity.cpp
@@ -44,7 +44,7 @@
 //
 bool orionldPatchEntity(ConnectionInfo* ciP)
 {
-  char* entityId = ciP->wildcard[0];
+  char* entityId = orionldState.wildcard[0];
 
   LM_T(LmtServiceRoutine, ("In orionldPatchEntity"));
 

--- a/src/lib/orionld/serviceRoutines/orionldPatchEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchEntity.cpp
@@ -56,7 +56,7 @@ bool orionldPatchEntity(ConnectionInfo* ciP)
   }
 
   // Is the payload empty?
-  if (ciP->requestTree == NULL)
+  if (orionldState.requestTree == NULL)
   {
     ciP->httpStatusCode = SccBadRequest;
     orionldErrorResponseCreate(ciP, OrionldBadRequestData, "No payload", NULL, OrionldDetailsString);
@@ -65,15 +65,15 @@ bool orionldPatchEntity(ConnectionInfo* ciP)
 
 
   // Is the payload not a JSON object?
-  if  (ciP->requestTree->type != KjObject)
+  if  (orionldState.requestTree->type != KjObject)
   {
     ciP->httpStatusCode = SccBadRequest;
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Payload not a JSON object", kjValueType(ciP->requestTree->type), OrionldDetailsString);
+    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Payload not a JSON object", kjValueType(orionldState.requestTree->type), OrionldDetailsString);
     return false;
   }
 
   // Is the payload an empty object?
-  if  (ciP->requestTree->value.firstChildP == NULL)
+  if  (orionldState.requestTree->value.firstChildP == NULL)
   {
     ciP->httpStatusCode = SccBadRequest;
     orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Payload is an empty JSON object", NULL, OrionldDetailsString);
@@ -83,7 +83,7 @@ bool orionldPatchEntity(ConnectionInfo* ciP)
   //
   // Make sure the attributes to be patched exist - FIXME: too damn slow to get an attribyte at a time - make a smarter query!
   //
-  for (KjNode* attrNodeP = ciP->requestTree->value.firstChildP; attrNodeP != NULL; attrNodeP = attrNodeP->next)
+  for (KjNode* attrNodeP = orionldState.requestTree->value.firstChildP; attrNodeP != NULL; attrNodeP = attrNodeP->next)
   {
     char    longAttrName[256];
     char*   attrNameP;
@@ -128,7 +128,7 @@ bool orionldPatchEntity(ConnectionInfo* ciP)
   mongoRequest.updateActionType = ActionTypeAppendStrict;
 
   // Iterate over the object, to get all attributes
-  for (KjNode* kNodeP = ciP->requestTree->value.firstChildP; kNodeP != NULL; kNodeP = kNodeP->next)
+  for (KjNode* kNodeP = orionldState.requestTree->value.firstChildP; kNodeP != NULL; kNodeP = kNodeP->next)
   {
     KjNode*            attrTypeNodeP = NULL;
     ContextAttribute*  caP           = new ContextAttribute();

--- a/src/lib/orionld/serviceRoutines/orionldPatchRegistration.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchRegistration.cpp
@@ -26,6 +26,7 @@
 #include "logMsg/traceLevels.h"                                // Lmt*
 
 #include "rest/ConnectionInfo.h"                               // ConnectionInfo
+#include "orionld/common/orionldState.h"                       // orionldState
 #include "orionld/common/orionldErrorResponse.h"               // orionldErrorResponseCreate
 #include "orionld/serviceRoutines/orionldPatchRegistration.h"  // Own Interface
 
@@ -39,7 +40,7 @@ bool orionldPatchRegistration(ConnectionInfo* ciP)
 {
   LM_T(LmtServiceRoutine, ("In orionldPatchRegistration"));
 
-  orionldErrorResponseCreate(ciP, OrionldBadRequestData, "not implemented - PATCH /ngsi-ld/v1/csourceRegistrations/*", ciP->wildcard[0], OrionldDetailsString);
+  orionldErrorResponseCreate(ciP, OrionldBadRequestData, "not implemented - PATCH /ngsi-ld/v1/csourceRegistrations/*", orionldState.wildcard[0], OrionldDetailsString);
 
   ciP->httpStatusCode = SccNotImplemented;
 

--- a/src/lib/orionld/serviceRoutines/orionldPatchSubscription.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchSubscription.cpp
@@ -26,6 +26,7 @@
 #include "logMsg/traceLevels.h"                                // Lmt*
 
 #include "rest/ConnectionInfo.h"                               // ConnectionInfo
+#include "orionld/common/orionldState.h"                       // orionldState
 #include "orionld/common/orionldErrorResponse.h"               // orionldErrorResponseCreate
 #include "orionld/serviceRoutines/orionldPatchSubscription.h"  // Own Interface
 
@@ -39,7 +40,7 @@ bool orionldPatchSubscription(ConnectionInfo* ciP)
 {
   LM_T(LmtServiceRoutine, ("In orionldPatchSubscription"));
 
-  orionldErrorResponseCreate(ciP, OrionldBadRequestData, "not implemented - PATCH /ngsi-ld/v1/subscriptions/*", ciP->wildcard[0], OrionldDetailsString);
+  orionldErrorResponseCreate(ciP, OrionldBadRequestData, "not implemented - PATCH /ngsi-ld/v1/subscriptions/*", orionldState.wildcard[0], OrionldDetailsString);
 
   ciP->httpStatusCode = SccNotImplemented;
 

--- a/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
@@ -123,9 +123,9 @@ static bool payloadCheck
   KjNode**         modifiedAtPP
 )
 {
-  OBJECT_CHECK(ciP->requestTree, "toplevel");
+  OBJECT_CHECK(orionldState.requestTree, "toplevel");
 
-  KjNode*  kNodeP                 = ciP->requestTree->value.firstChildP;
+  KjNode*  kNodeP                 = orionldState.requestTree->value.firstChildP;
   KjNode*  idNodeP                = NULL;
   KjNode*  typeNodeP              = NULL;
   KjNode*  contextNodeP           = NULL;
@@ -903,7 +903,7 @@ bool orionldPostEntities(ConnectionInfo* ciP)
   }
 
   // Treat the entire payload
-  for (KjNode* kNodeP = ciP->requestTree->value.firstChildP; kNodeP != NULL; kNodeP = kNodeP->next)
+  for (KjNode* kNodeP = orionldState.requestTree->value.firstChildP; kNodeP != NULL; kNodeP = kNodeP->next)
   {
     LM_T(LmtUriExpansion, ("treating entity node '%s'", kNodeP->name));
 

--- a/src/lib/orionld/serviceRoutines/orionldPostEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntity.cpp
@@ -124,10 +124,10 @@ void orionldPartialUpdateResponseCreate(ConnectionInfo* ciP)
 bool orionldPostEntity(ConnectionInfo* ciP)
 {
   // 1. Check that the entity exists
-  if (mongoEntityExists(ciP->wildcard[0], orionldState.tenant) == false)
+  if (mongoEntityExists(orionldState.wildcard[0], orionldState.tenant) == false)
   {
     ciP->httpStatusCode = SccNotFound;
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Entity does not exist", ciP->wildcard[0], OrionldDetailsString);
+    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Entity does not exist", orionldState.wildcard[0], OrionldDetailsString);
     return false;
   }
 
@@ -170,7 +170,7 @@ bool orionldPostEntity(ConnectionInfo* ciP)
     mongoRequest.updateActionType = ActionTypeAppend;
   }
 
-  entityIdP->id = ciP->wildcard[0];
+  entityIdP->id = orionldState.wildcard[0];
 
 
   //

--- a/src/lib/orionld/serviceRoutines/orionldPostEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntity.cpp
@@ -59,13 +59,13 @@ void orionldPartialUpdateResponseCreate(ConnectionInfo* ciP)
   // Rob the incoming Request Tree - performance to be won!
   //
   LM_TMP(("PART-UPDATE: Here"));
-  ciP->responseTree = ciP->requestTree;
+  orionldState.responseTree = orionldState.requestTree;
   LM_TMP(("PART-UPDATE: Here"));
-  ciP->requestTree  = NULL;
+  orionldState.requestTree  = NULL;
   LM_TMP(("PART-UPDATE: Here"));
 
   //
-  // For all attrs in ciP->responseTree, remove those that are found in orionldState.errorAttributeArrayP.
+  // For all attrs in orionldState.responseTree, remove those that are found in orionldState.errorAttributeArrayP.
   // Remember, the format of orionldState.errorAttributeArrayP is:
   //
   //   |attrName|attrName|attrName|...
@@ -73,14 +73,14 @@ void orionldPartialUpdateResponseCreate(ConnectionInfo* ciP)
 
   // <TMP>
   int ix = 1;
-  for (KjNode* attrNodeP = ciP->responseTree->value.firstChildP; attrNodeP != NULL; attrNodeP = attrNodeP->next)
+  for (KjNode* attrNodeP = orionldState.responseTree->value.firstChildP; attrNodeP != NULL; attrNodeP = attrNodeP->next)
   {
     LM_TMP(("PART-UPDATE: Attr %d: '%s'", ix, attrNodeP->name));
     ++ix;
   }
   // </TMP>
 
-  KjNode* attrNodeP = ciP->responseTree->value.firstChildP;
+  KjNode* attrNodeP = orionldState.responseTree->value.firstChildP;
 
   while (attrNodeP != NULL)
   {
@@ -94,7 +94,7 @@ void orionldPartialUpdateResponseCreate(ConnectionInfo* ciP)
       if ((match[-1] == '|') && (match[strlen(attrNodeP->name)] == '|'))
       {
         LM_TMP(("PART-UPDATE: removing child '%s'", attrNodeP->name));
-        kjChildRemove(ciP->responseTree, attrNodeP);
+        kjChildRemove(orionldState.responseTree, attrNodeP);
         attrNodeP = next;
         moved = true;
       }
@@ -105,7 +105,7 @@ void orionldPartialUpdateResponseCreate(ConnectionInfo* ciP)
   }
 
   // <TMP>
-  for (KjNode* attrNodeP = ciP->responseTree->value.firstChildP; attrNodeP != NULL; attrNodeP = attrNodeP->next)
+  for (KjNode* attrNodeP = orionldState.responseTree->value.firstChildP; attrNodeP != NULL; attrNodeP = attrNodeP->next)
   {
     LM_TMP(("PART-UPDATE: Attr %d: '%s'", ix, attrNodeP->name));
     ++ix;
@@ -132,7 +132,7 @@ bool orionldPostEntity(ConnectionInfo* ciP)
   }
 
   // Is the payload empty?
-  if (ciP->requestTree == NULL)
+  if (orionldState.requestTree == NULL)
   {
     ciP->httpStatusCode = SccBadRequest;
     orionldErrorResponseCreate(ciP, OrionldBadRequestData, "No payload", NULL, OrionldDetailsString);
@@ -140,10 +140,10 @@ bool orionldPostEntity(ConnectionInfo* ciP)
   }
 
   // Is the payload not a JSON object?
-  OBJECT_CHECK(ciP->requestTree, kjValueType(ciP->requestTree->type));
+  OBJECT_CHECK(orionldState.requestTree, kjValueType(orionldState.requestTree->type));
 
   // Is the payload an empty object?
-  if (ciP->requestTree->value.firstChildP == NULL)
+  if (orionldState.requestTree->value.firstChildP == NULL)
   {
     ciP->httpStatusCode = SccBadRequest;
     orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Payload is an empty JSON object", NULL, OrionldDetailsString);
@@ -179,7 +179,7 @@ bool orionldPostEntity(ConnectionInfo* ciP)
   //
   KjNode* contextNodeP = NULL;
 
-  for (KjNode* kNodeP = ciP->requestTree->value.firstChildP; kNodeP != NULL; kNodeP = kNodeP->next)
+  for (KjNode* kNodeP = orionldState.requestTree->value.firstChildP; kNodeP != NULL; kNodeP = kNodeP->next)
   {
     if (SCOMPARE9(kNodeP->name, '@', 'c', 'o', 'n', 't', 'e', 'x', 't', 0))
     {
@@ -198,7 +198,7 @@ bool orionldPostEntity(ConnectionInfo* ciP)
   }
 
   // 3. Iterate over the object, to get all attributes
-  for (KjNode* kNodeP = ciP->requestTree->value.firstChildP; kNodeP != NULL; kNodeP = kNodeP->next)
+  for (KjNode* kNodeP = orionldState.requestTree->value.firstChildP; kNodeP != NULL; kNodeP = kNodeP->next)
   {
     KjNode* attrTypeNodeP = NULL;
 

--- a/src/lib/orionld/serviceRoutines/orionldPostSubscriptions.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostSubscriptions.cpp
@@ -47,7 +47,7 @@ extern "C"
 #include "orionld/common/urnCheck.h"                           // urnCheck
 #include "orionld/common/SCOMPARE.h"                           // SCOMPAREx
 #include "orionld/common/CHECK.h"                              // CHECKx(U)
-#include "orionld/common/OrionldConnection.h"                  // orionldState
+#include "orionld/common/orionldState.h"                       // orionldState
 #include "orionld/common/orionldErrorResponse.h"               // orionldErrorResponseCreate
 #include "orionld/context/orionldCoreContext.h"                // ORIONLD_CORE_CONTEXT_URL
 #include "orionld/context/orionldContextTreat.h"               // orionldContextTreat
@@ -273,7 +273,7 @@ static bool ktreeToSubscriptionExpression(ConnectionInfo* ciP, KjNode* kNodeP, S
     // NGSI-LD needs it to be able to be an array.
     // Easiest way to fix this is to render the JSON Array and translate it to a string, and then removing the '[]'
     //
-    kjRender(ciP->kjsonP, coordinatesNodeP, coords, sizeof(coords));
+    kjRender(orionldState.kjsonP, coordinatesNodeP, coords, sizeof(coords));
     coords[strlen(coords) - 1] = 0;
     LM_T(LmtGeoJson, ("Rendered coords array: '%s'", &coords[1]));
     subExpressionP->coords = &coords[1];
@@ -516,7 +516,7 @@ static bool ktreeToSubscription(ConnectionInfo* ciP, ngsiv2::Subscription* subP,
   // 1. First lookup the tree nodes of 'id' and '@context'
   // 2. Then create a context attribute for the context - FIXME: combine code with POST Entities
   //
-  for (kNodeP = ciP->requestTree->value.firstChildP; kNodeP != NULL; kNodeP = kNodeP->next)
+  for (kNodeP = orionldState.requestTree->value.firstChildP; kNodeP != NULL; kNodeP = kNodeP->next)
   {
     if (SCOMPARE9(kNodeP->name, '@', 'c', 'o', 'n', 't', 'e', 'x', 't', 0))
     {
@@ -584,7 +584,7 @@ static bool ktreeToSubscription(ConnectionInfo* ciP, ngsiv2::Subscription* subP,
   //
   // Now loop over the tree
   //
-  for (kNodeP = ciP->requestTree->value.firstChildP; kNodeP != NULL; kNodeP = kNodeP->next)
+  for (kNodeP = orionldState.requestTree->value.firstChildP; kNodeP != NULL; kNodeP = kNodeP->next)
   {
     if (SCOMPARE3(kNodeP->name, 'i', 'd', 0))
     {

--- a/src/lib/rest/ConnectionInfo.cpp
+++ b/src/lib/rest/ConnectionInfo.cpp
@@ -86,18 +86,7 @@ ConnectionInfo::ConnectionInfo():
   inCompoundValue        (false),
   compoundValueP         (NULL),
   compoundValueRoot      (NULL),
-  httpStatusCode         (SccOk),
-#ifdef ORIONLD
-  responsePayload           (NULL),
-  responsePayloadAllocated  (false),
-  urlPath                   (NULL),
-  wildcard                  { NULL, NULL},
-  kjsonP                    (NULL),
-  requestTree               (NULL),
-  responseTree              (NULL),
-  prettyPrint               (false),
-  prettyPrintSpaces         (2)
-#endif
+  httpStatusCode         (SccOk)
 {
 }
 
@@ -126,18 +115,7 @@ ConnectionInfo::ConnectionInfo(MimeType _outMimeType):
   inCompoundValue        (false),
   compoundValueP         (NULL),
   compoundValueRoot      (NULL),
-  httpStatusCode         (SccOk),
-#ifdef ORIONLD
-  responsePayload           (NULL),
-  responsePayloadAllocated  (false),
-  urlPath                   (NULL),
-  wildcard                  { NULL, NULL},
-  kjsonP                    (NULL),
-  requestTree               (NULL),
-  responseTree              (NULL),
-  prettyPrint               (false),
-  prettyPrintSpaces         (2)
-#endif
+  httpStatusCode         (SccOk)
 {
 }
 
@@ -169,18 +147,7 @@ ConnectionInfo::ConnectionInfo(std::string _url, std::string _method, std::strin
   inCompoundValue        (false),
   compoundValueP         (NULL),
   compoundValueRoot      (NULL),
-  httpStatusCode         (SccOk),
-#ifdef ORIONLD
-  responsePayload           (NULL),
-  responsePayloadAllocated  (false),
-  urlPath                   (NULL),
-  wildcard                  { NULL, NULL},
-  kjsonP                    (NULL),
-  requestTree               (NULL),
-  responseTree              (NULL),
-  prettyPrint               (false),
-  prettyPrintSpaces         (2)
-#endif
+  httpStatusCode         (SccOk)
 {
   if      (_method == "POST")    verb = POST;
   else if (_method == "PUT")     verb = PUT;
@@ -211,39 +178,6 @@ ConnectionInfo::~ConnectionInfo()
 
   servicePathV.clear();
   httpHeaders.release();
-
-#ifdef ORIONLD
-
-#if 0
-  // The request tree is now allocated under KAlloc - another free to be done
-  if (requestTree != NULL)
-  {
-    kjFree(requestTree);
-    requestTree = NULL;
-  }
-
-  if (responseTree != NULL)
-  {
-    kjFree(responseTree);
-    responseTree = NULL;
-  }
-#endif
-
-#if 0
-  // This pointer is no longer to be used - the one in orionldState is to be used instead
-  if (kjsonP != NULL)
-  {
-    if (kjsonP->iVec != NULL)
-      free(kjsonP->iVec);
-
-    if (kjsonP->iStrings != NULL)
-      free(kjsonP->iStrings);
-  
-    free(kjsonP);
-    kjsonP = NULL;
-  }
-#endif
-#endif
 }
 
 
@@ -290,11 +224,13 @@ int uriParamOptionsParse(ConnectionInfo* ciP, const char* value)
 
     ciP->uriParamOptions[vec[ix]] = true;
 
+#ifdef ORIONLD
     if (strcmp(vec[ix].c_str(), "noOverwrite") == 0)
     {
       LM_TMP(("AppendAttributes: Setting orionldState.uriParamOptions.noOverwrite to TRUE"));
       orionldState.uriParamOptions.noOverwrite = true;
     }
+#endif
   }
 
   //

--- a/src/lib/rest/ConnectionInfo.cpp
+++ b/src/lib/rest/ConnectionInfo.cpp
@@ -88,7 +88,6 @@ ConnectionInfo::ConnectionInfo():
   compoundValueRoot      (NULL),
   httpStatusCode         (SccOk),
 #ifdef ORIONLD
-  serviceP                  (NULL),
   responsePayload           (NULL),
   responsePayloadAllocated  (false),
   urlPath                   (NULL),
@@ -96,7 +95,6 @@ ConnectionInfo::ConnectionInfo():
   kjsonP                    (NULL),
   requestTree               (NULL),
   responseTree              (NULL),
-  contextToBeFreed          (false),
   prettyPrint               (false),
   prettyPrintSpaces         (2)
 #endif
@@ -130,7 +128,6 @@ ConnectionInfo::ConnectionInfo(MimeType _outMimeType):
   compoundValueRoot      (NULL),
   httpStatusCode         (SccOk),
 #ifdef ORIONLD
-  serviceP                  (NULL),
   responsePayload           (NULL),
   responsePayloadAllocated  (false),
   urlPath                   (NULL),
@@ -138,7 +135,6 @@ ConnectionInfo::ConnectionInfo(MimeType _outMimeType):
   kjsonP                    (NULL),
   requestTree               (NULL),
   responseTree              (NULL),
-  contextToBeFreed          (false),
   prettyPrint               (false),
   prettyPrintSpaces         (2)
 #endif
@@ -175,7 +171,6 @@ ConnectionInfo::ConnectionInfo(std::string _url, std::string _method, std::strin
   compoundValueRoot      (NULL),
   httpStatusCode         (SccOk),
 #ifdef ORIONLD
-  serviceP                  (NULL),
   responsePayload           (NULL),
   responsePayloadAllocated  (false),
   urlPath                   (NULL),
@@ -183,7 +178,6 @@ ConnectionInfo::ConnectionInfo(std::string _url, std::string _method, std::strin
   kjsonP                    (NULL),
   requestTree               (NULL),
   responseTree              (NULL),
-  contextToBeFreed          (false),
   prettyPrint               (false),
   prettyPrintSpaces         (2)
 #endif

--- a/src/lib/rest/ConnectionInfo.h
+++ b/src/lib/rest/ConnectionInfo.h
@@ -48,12 +48,10 @@
 extern "C"
 {
 #include "kjson/kjson.h"
-#include "kjson/kjFree.h"
 }
 
 #include "orionld/context/OrionldContext.h"
 
-struct OrionLdRestService;
 #endif  
 
 
@@ -125,7 +123,6 @@ public:
   struct timespec           reqStartTime;
 
 #ifdef ORIONLD
-  OrionLdRestService*       serviceP;
   char*                     responsePayload;
   bool                      responsePayloadAllocated;
   char*                     urlPath;
@@ -134,7 +131,6 @@ public:
   Kjson*                    kjsonP;
   KjNode*                   requestTree;
   KjNode*                   responseTree;
-  bool                      contextToBeFreed;
   bool                      prettyPrint;
   char                      prettyPrintSpaces;
 #endif  

--- a/src/lib/rest/ConnectionInfo.h
+++ b/src/lib/rest/ConnectionInfo.h
@@ -50,8 +50,6 @@ extern "C"
 #include "kjson/kjson.h"
 }
 
-#include "orionld/context/OrionldContext.h"
-
 #endif  
 
 
@@ -123,16 +121,6 @@ public:
   struct timespec           reqStartTime;
 
 #ifdef ORIONLD
-  char*                     responsePayload;
-  bool                      responsePayloadAllocated;
-  char*                     urlPath;
-  char*                     verbString;
-  char*                     wildcard[2];
-  Kjson*                    kjsonP;
-  KjNode*                   requestTree;
-  KjNode*                   responseTree;
-  bool                      prettyPrint;
-  char                      prettyPrintSpaces;
 #endif  
 };
 

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -720,7 +720,7 @@ static void requestCompleted
   delete(ciP);
 
 #ifdef ORIONLD
-  kaBufferReset(&orionldState.kalloc, false);  // 'false: it reused, but in a different thread ...
+  kaBufferReset(&orionldState.kalloc, false);  // 'false': it's reused, but in a different thread ...
 #endif
 
   *con_cls = NULL;

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -254,12 +254,12 @@ int uriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, const ch
   {
     if (strcmp(val, "yes") == 0)
     {
-      ciP->prettyPrint = true;
+      orionldState.prettyPrint = true;
     }
   }
   else if (key == URI_PARAM_SPACES)
   {
-    ciP->prettyPrintSpaces = atoi(val);
+    orionldState.prettyPrintSpaces = atoi(val);
   }
 #endif
   else if ((key != URI_PARAM_Q)       &&

--- a/src/lib/rest/restReply.cpp
+++ b/src/lib/rest/restReply.cpp
@@ -54,6 +54,9 @@
 #include "rest/OrionError.h"
 #include "rest/restReply.h"
 
+#ifdef ORIONLD
+#include "orionld/common/orionldState.h"                       // orionldState
+#endif
 #include "logMsg/traceLevels.h"
 
 
@@ -92,10 +95,10 @@ void restReply(ConnectionInfo* ciP, const std::string& answer)
     LM_E(("Runtime Error (MHD_create_response_from_buffer FAILED)"));
 
 #ifdef ORIONLD
-    if (ciP->responsePayloadAllocated == true)
+    if (orionldState.responsePayloadAllocated == true)
     {
-      free(ciP->responsePayload);
-      ciP->responsePayload = NULL;
+      free(orionldState.responsePayload);
+      orionldState.responsePayload = NULL;
     }
 #endif    
 
@@ -186,10 +189,10 @@ void restReply(ConnectionInfo* ciP, const std::string& answer)
   MHD_destroy_response(response);
 
 #ifdef ORIONLD
-  if ((ciP->responsePayloadAllocated == true) && (ciP->responsePayload != NULL))
+  if ((orionldState.responsePayloadAllocated == true) && (orionldState.responsePayload != NULL))
   {
-    free(ciP->responsePayload);
-    ciP->responsePayload = NULL;
+    free(orionldState.responsePayload);
+    orionldState.responsePayload = NULL;
   }
 #endif    
 }

--- a/test/functionalTest/testHarness.sh
+++ b/test/functionalTest/testHarness.sh
@@ -23,7 +23,7 @@
 # Author: Ken Zangelin
 #
 date
-export BROKER=${BROKER:-contextBroker}
+export BROKER=${BROKER:-orionld}
 testStartTime=$(date +%s.%2N)
 MAX_TRIES=${CB_MAX_TRIES:-3}
 
@@ -141,6 +141,7 @@ function usage()
   echo "$sfile [-u (usage)]"
   echo "$empty [-v (verbose)]"
   echo "$empty [-s (silent)]"
+  echo "$empty [-ld (only ngsild tests)]"
   echo "$empty [--filter <test filter>]"
   echo "$empty [--match <string for test to match>]"
   echo "$empty [--keep (don't remove output files)]"
@@ -384,6 +385,7 @@ toIx=0
 ixList=""
 noCache=""
 threadpool=ON
+ngsild=OFF
 
 logMsg "parsing options"
 while [ "$#" != 0 ]
@@ -391,6 +393,7 @@ do
   if   [ "$1" == "-u" ];             then usage 0;
   elif [ "$1" == "-v" ];             then verbose=on;
   elif [ "$1" == "-s" ];             then silent=on;
+  elif [ "$1" == "-ld" ];            then ngsild=on;
   elif [ "$1" == "--dryrun" ];       then dryrun=on;
   elif [ "$1" == "--keep" ];         then keep=on;
   elif [ "$1" == "--stopOnError" ];  then stopOnError=on;
@@ -432,6 +435,8 @@ then
   export CB_NO_CACHE=$noCache
 fi
 
+
+
 # -----------------------------------------------------------------------------
 #
 # The function brokerStart looks at the env var CB_THREADPOOL to decide
@@ -442,6 +447,21 @@ if [ "$CB_THREADPOOL" == "" ]
 then
   export CB_THREADPOOL=$threadpool
 fi
+
+
+
+# -----------------------------------------------------------------------------
+#
+# Only ngsild tests?
+#
+# If set, overrides parameter
+#
+if [ "$ngsild" == "on" ]
+then
+  dirOrFile=test/functionalTest/cases/0000_ngsild
+fi
+
+
 
 # ------------------------------------------------------------------------------
 #

--- a/test/unittests/orionld/partialUpdate_test.cpp
+++ b/test/unittests/orionld/partialUpdate_test.cpp
@@ -99,7 +99,7 @@ TEST(orionld, partialUpdateResponse)
   //
   // Create a request tree with attributes A1, A2, and A3
   //
-  ci.requestTree = kjObject(orionldState.kjsonP, NULL);
+  orionldState.requestTree = kjObject(orionldState.kjsonP, NULL);
 
   for (unsigned int ix = 0; ix < sizeof(attrNamesV) / sizeof(attrNamesV[0]); ix++)
   {
@@ -111,7 +111,7 @@ TEST(orionld, partialUpdateResponse)
     kNodeP = kjString(orionldState.kjsonP, "value", attrNamesV[ix]);
     kjChildAdd(attrNodeP, kNodeP);
 
-    kjChildAdd(ci.requestTree, attrNodeP);
+    kjChildAdd(orionldState.requestTree, attrNodeP);
   }
 
   //
@@ -128,22 +128,22 @@ TEST(orionld, partialUpdateResponse)
   LM_TMP(("Calling orionldPartialUpdateResponseCreate"));
   orionldPartialUpdateResponseCreate(&ci);
   LM_TMP(("After orionldPartialUpdateResponseCreate"));
-  EXPECT_EQ(NULL, ci.requestTree);
+  EXPECT_EQ(NULL, orionldState.requestTree);
 
   //
-  // Now, ci.responseTree should contain only A2
+  // Now, orionldState.responseTree should contain only A2
   //
-  if (ci.responseTree->value.firstChildP == NULL)
+  if (orionldState.responseTree->value.firstChildP == NULL)
   {
-    EXPECT_STREQ("ci.responseTree->value.firstChildP == NULL", "It should be != NULL");
+    EXPECT_STREQ("orionldState.responseTree->value.firstChildP == NULL", "It should be != NULL");
   }
 
-  for (kNodeP = ci.responseTree->value.firstChildP; kNodeP != NULL; kNodeP = kNodeP->next)
+  for (kNodeP = orionldState.responseTree->value.firstChildP; kNodeP != NULL; kNodeP = kNodeP->next)
     LM_TMP(("  Node: '%s'", kNodeP->name));
   
-  EXPECT_EQ(NULL, ci.responseTree->value.firstChildP->next);
+  EXPECT_EQ(NULL, orionldState.responseTree->value.firstChildP->next);
 
-  char* attrName = ci.responseTree->value.firstChildP->name;
+  char* attrName = orionldState.responseTree->value.firstChildP->name;
 
   EXPECT_STREQ("A2", attrName);
 


### PR DESCRIPTION
* Took ConnectionInit.h/cpp back to their "init.ial" state.
   All orionld stuff now in orionldState.
* New option for functest suite: `-ld` (to run only ngsild functests)