### PR TITLE
bug/ngsild-issue-0096

### DIFF
--- a/src/lib/orionld/common/orionldErrorResponse.cpp
+++ b/src/lib/orionld/common/orionldErrorResponse.cpp
@@ -114,4 +114,11 @@ void orionldErrorResponseCreate
   kjChildAdd(orionldState.responseTree, typeP);
   kjChildAdd(orionldState.responseTree, titleP);
   kjChildAdd(orionldState.responseTree, detailsP);
+
+  if ((orionldState.acceptJsonld) && (orionldState.contextP != NULL))
+  {
+    KjNode* contextP = kjString(orionldState.kjsonP, "@context", orionldState.contextP->url);
+
+    kjChildAdd(orionldState.responseTree, contextP);
+  }
 }

--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -97,6 +97,9 @@ typedef struct OrionldConnectionState
   char*                   verbString;
   bool                    prettyPrint;
   char                    prettyPrintSpaces;
+  bool                    acceptJson;
+  bool                    acceptJsonld;
+  bool                    ngsildContent;
 } OrionldConnectionState;
 
 

--- a/src/lib/orionld/context/orionldContextInlineCheck.cpp
+++ b/src/lib/orionld/context/orionldContextInlineCheck.cpp
@@ -49,7 +49,7 @@ bool orionldContextInlineCheck(ConnectionInfo* ciP, KjNode* contextObjectP)
     if ((nodeP->type != KjString) && (nodeP->type != KjObject))
     {
       LM_E(("The context is invalid - value of '%s' is not a String nor an Object", nodeP->name));
-      orionldState.contextP = NULL;  // Leak?      
+      orionldState.contextP = NULL;  // Leak?
       orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid key-value in @context", nodeP->name, OrionldDetailsString);
       return false;
     }

--- a/src/lib/orionld/context/orionldContextInlineCheck.cpp
+++ b/src/lib/orionld/context/orionldContextInlineCheck.cpp
@@ -49,6 +49,7 @@ bool orionldContextInlineCheck(ConnectionInfo* ciP, KjNode* contextObjectP)
     if ((nodeP->type != KjString) && (nodeP->type != KjObject))
     {
       LM_E(("The context is invalid - value of '%s' is not a String nor an Object", nodeP->name));
+      orionldState.contextP = NULL;  // Leak?      
       orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid key-value in @context", nodeP->name, OrionldDetailsString);
       return false;
     }

--- a/src/lib/orionld/context/orionldContextTreat.cpp
+++ b/src/lib/orionld/context/orionldContextTreat.cpp
@@ -57,6 +57,7 @@ static OrionldContext* contextItemNodeTreat(ConnectionInfo* ciP, char* url)
   if (contextP == NULL)
   {
     LM_E(("Invalid context '%s': %s", url, details));
+    orionldState.contextP = NULL;  // Leak?
     orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid context", details, OrionldDetailsString);
     return NULL;
   }
@@ -189,6 +190,7 @@ bool orionldContextTreat
         {
           LM_E(("contextItemNodeTreat failed"));
           // Error payload set by contextItemNodeTreat
+          orionldState.contextP = NULL;  // Leak?
           return false;
         }
       }
@@ -197,6 +199,7 @@ bool orionldContextTreat
         if (orionldContextTreat(ciP, contextArrayItemP, entityId, caPP) == false)
         {
           LM_E(("Error treating context object inside array"));
+          orionldState.contextP = NULL;  // Leak?
           orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Error treating context object inside array", NULL, OrionldDetailsString);
           return false;
         }
@@ -204,6 +207,7 @@ bool orionldContextTreat
       else
       {
         LM_E(("Context Array Item is not a String nor an Object, but of type '%s'", kjValueType(contextArrayItemP->type)));
+        orionldState.contextP = NULL;  // Leak?
         orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Context Array Item of unsupported type", NULL, OrionldDetailsString);
         return false;
       }
@@ -215,6 +219,7 @@ bool orionldContextTreat
     {
       // orionldContextInlineCheck sets the error response
       LM_E(("Invalid inline context"));
+      orionldState.contextP = NULL;  // Leak?
       return false;
     }
 
@@ -231,6 +236,7 @@ bool orionldContextTreat
   else
   {
     LM_E(("invalid JSON type of @context member"));
+    orionldState.contextP = NULL;  // Leak?
     orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid context", "invalid JSON type of @context member", OrionldDetailsString);
     return false;
   }

--- a/src/lib/orionld/kjTree/kjTreeFromQueryContextResponse.cpp
+++ b/src/lib/orionld/kjTree/kjTreeFromQueryContextResponse.cpp
@@ -535,7 +535,7 @@ KjNode* kjTreeFromQueryContextResponse(ConnectionInfo* ciP, bool oneHit, bool ke
     // Set MIME Type to JSONLD if JSONLD is in the Accept header of the incoming request
     // FIXME: Probably not necessary, as it is done in orionldMhdConnectionTreat.cpp::acceptHeaderCheck()
     //
-    if (ciP->httpHeaders.acceptJsonld == true)
+    if (orionldState.acceptJsonld == true)
     {
       ciP->outMimeType = JSONLD;
     }
@@ -548,7 +548,7 @@ KjNode* kjTreeFromQueryContextResponse(ConnectionInfo* ciP, bool oneHit, bool ke
     //
     if (atContextAttributeP == NULL)
     {
-      if (ciP->httpHeaders.acceptJsonld == true)
+      if (orionldState.acceptJsonld == true)
       {
         nodeP = kjString(orionldState.kjsonP, "@context", orionldDefaultContext.url);
         kjChildAdd(top, nodeP);
@@ -556,7 +556,7 @@ KjNode* kjTreeFromQueryContextResponse(ConnectionInfo* ciP, bool oneHit, bool ke
     }
     else
     {
-      if (ciP->httpHeaders.acceptJsonld == true)
+      if (orionldState.acceptJsonld == true)
       {
         if (atContextAttributeP->valueType == orion::ValueTypeString)
         {

--- a/src/lib/orionld/kjTree/kjTreeFromQueryContextResponseWithAttrList.cpp
+++ b/src/lib/orionld/kjTree/kjTreeFromQueryContextResponseWithAttrList.cpp
@@ -557,7 +557,7 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
     // Set MIME Type to JSONLD if JSONLD is in the Accept header of the incoming request
     // FIXME: probably no longer necessary - done in orionldMhdConnectionTreat.cpp::acceptHeaderCheck()
     //
-    if (ciP->httpHeaders.acceptJsonld == true)
+    if (orionldState.acceptJsonld == true)
     {
       ciP->outMimeType = JSONLD;
     }
@@ -568,7 +568,7 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
     //
     if (atContextAttributeP == NULL)
     {
-      if (ciP->httpHeaders.acceptJsonld == true)
+      if (orionldState.acceptJsonld == true)
       {
         nodeP = kjString(orionldState.kjsonP, "@context", orionldDefaultContext.url);
         kjChildAdd(top, nodeP);
@@ -578,7 +578,7 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
     else
     {
       // NOTE: HTTP Link header is added ONLY in orionldMhdConnectionTreat
-      if (ciP->httpHeaders.acceptJsonld == true)
+      if (orionldState.acceptJsonld == true)
       {
         if (atContextAttributeP->valueType == orion::ValueTypeString)
         {

--- a/src/lib/orionld/kjTree/kjTreeFromSubscription.cpp
+++ b/src/lib/orionld/kjTree/kjTreeFromSubscription.cpp
@@ -367,7 +367,7 @@ KjNode* kjTreeFromSubscription(ConnectionInfo* ciP, ngsiv2::Subscription* subscr
   }
 
   // @context - in payload if Mime Type is application/ld+json, else in Link header
-  if (ciP->httpHeaders.acceptJsonld)
+  if (orionldState.acceptJsonld)
   {
     if (subscriptionP->ldContext != "")
       nodeP = kjString(orionldState.kjsonP, "@context", subscriptionP->ldContext.c_str());

--- a/src/lib/orionld/kjTree/kjTreeToSubscription.cpp
+++ b/src/lib/orionld/kjTree/kjTreeToSubscription.cpp
@@ -135,7 +135,7 @@ bool kjTreeToSubscription(ConnectionInfo* ciP, ngsiv2::Subscription* subP, char*
     subP->id += randomId;
   }
 
-  if (ciP->httpHeaders.ngsildContent)  // Context in payload
+  if (orionldState.ngsildContent)  // Context in payload
   {
     if (contextNodeP == NULL)
     {

--- a/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
@@ -406,7 +406,7 @@ int orionldMhdConnectionTreat(ConnectionInfo* ciP)
         orionldState.contextP = NULL;  // FIXME: Memleak?
         orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to clone context tree - out of memory?", NULL, OrionldDetailsString);
         ciP->httpStatusCode = SccReceiverInternalError;
-        
+
         goto respond;
       }
 

--- a/src/lib/rest/HttpHeaders.cpp
+++ b/src/lib/rest/HttpHeaders.cpp
@@ -36,7 +36,7 @@
 *
 * HttpHeaders::HttpHeaders - 
 */
-HttpHeaders::HttpHeaders(): gotHeaders(false), servicePathReceived(false), contentLength(0), linkUrl(NULL), acceptJson(false), acceptJsonld(false), ngsildContent(false)
+HttpHeaders::HttpHeaders(): gotHeaders(false), servicePathReceived(false), contentLength(0), linkUrl(NULL)
 {
 }
 

--- a/src/lib/rest/HttpHeaders.h
+++ b/src/lib/rest/HttpHeaders.h
@@ -144,9 +144,6 @@ typedef struct HttpHeaders
 
 #ifdef ORIONLD
   char*         linkUrl;        // FIXME: To be removed, perhaps moved to OrionldConnection
-  bool          acceptJson;     // FIXME: To be moved to OrionldConnection
-  bool          acceptJsonld;   // FIXME: To be moved to OrionldConnection
-  bool          ngsildContent;  // FIXME: To be moved to OrionldConnection
 #endif
 } HttpHeaders;
 

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -561,7 +561,7 @@ int httpHeaderGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, const cha
 
 #ifdef ORIONLD
     if (strcmp(value, "application/ld+json") == 0)
-      headerP->ngsildContent = true;
+      orionldState.ngsildContent = true;
 #endif
   }
   else if (strcasecmp(key.c_str(), HTTP_CONTENT_LENGTH) == 0)    headerP->contentLength  = atoi(value);


### PR DESCRIPTION
Fix for issue  #96 

More fields from ConnectionInfo to orionldState (acceptJson, acceptJsonld, and ngsildContent), to facilitate the inclusion of @context inside error payloads (if a correct context has been created).

With this change, the context can be included inside the payload by orionldErrorResponseCreate(), if applicable.