### PR TITLE
bug/171.ngsild-test-suite--RE-should-retrieve-entity-LD-requested

### DIFF
--- a/src/lib/orionld/context/orionldContextTreat.cpp
+++ b/src/lib/orionld/context/orionldContextTreat.cpp
@@ -125,6 +125,7 @@ bool orionldContextTreat
   {
     char* details;
 
+    LM_TMP(("KZ: Setting orionldState.contextP to the output from orionldContextCreateFromUrl"));
     if ((orionldState.contextP = orionldContextCreateFromUrl(ciP, contextNodeP->value.s, OrionldUserContext, &details)) == NULL)
     {
       LM_E(("Failed to create context from URL: %s", details));
@@ -164,6 +165,7 @@ bool orionldContextTreat
 
     snprintf(linkPath, linkPathLen, "http://%s:%d/ngsi-ld/ex/v1/contexts/%s", orionldHostName, restPortGet(), entityId);
 
+    LM_TMP(("KZ: Setting orionldState.contextP to the output from orionldContextCreateFromTree"));
     orionldState.contextP = orionldContextCreateFromTree(contextNodeP, linkPath, OrionldUserContext, &details);
 
     if (linkPath != linkPathV)
@@ -230,6 +232,7 @@ bool orionldContextTreat
     orionldState.inlineContext.temporary = true;
     orionldState.inlineContext.next      = NULL;
     orionldState.contextP                = &orionldState.inlineContext;
+    LM_TMP(("KZ: Set orionldState.contextP to &orionldState.inlineContext"));
 
     return true;
   }

--- a/src/lib/orionld/kjTree/kjTreeFromQueryContextResponse.cpp
+++ b/src/lib/orionld/kjTree/kjTreeFromQueryContextResponse.cpp
@@ -548,18 +548,22 @@ KjNode* kjTreeFromQueryContextResponse(ConnectionInfo* ciP, bool oneHit, bool ke
     //
     if (atContextAttributeP == NULL)
     {
+      LM_TMP(("KZ: no context inside attribute list - Content.Type is appliction/json and the context came via HTTP Header, if at all"));
       if (orionldState.acceptJsonld == true)
       {
-        nodeP = kjString(orionldState.kjsonP, "@context", orionldDefaultContext.url);
+        LM_TMP(("KZ: adding default context to payload"));
+        nodeP = kjString(orionldState.kjsonP, "@context", orionldState.contextP->url);
         kjChildAdd(top, nodeP);
       }
     }
     else
     {
+      LM_TMP(("KZ: context found inside attribute list. orion value type: %d", atContextAttributeP->valueType));
       if (orionldState.acceptJsonld == true)
       {
         if (atContextAttributeP->valueType == orion::ValueTypeString)
         {
+          LM_TMP(("KZ: string context '%s' to payload", atContextAttributeP->stringValue.c_str()));
           nodeP = kjString(orionldState.kjsonP, "@context", atContextAttributeP->stringValue.c_str());
           kjChildAdd(top, nodeP);
         }
@@ -567,6 +571,7 @@ KjNode* kjTreeFromQueryContextResponse(ConnectionInfo* ciP, bool oneHit, bool ke
         {
           if (atContextAttributeP->compoundValueP->valueType == orion::ValueTypeVector)
           {
+            LM_TMP(("KZ: vector context to payload"));
             nodeP = kjArray(orionldState.kjsonP, "@context");
             kjChildAdd(top, nodeP);
 
@@ -579,6 +584,7 @@ KjNode* kjTreeFromQueryContextResponse(ConnectionInfo* ciP, bool oneHit, bool ke
           }
           else
           {
+            LM_TMP(("KZ: inline context to payload - must be implemented!!!"));
             orionldErrorResponseCreate(ciP, OrionldInternalError, "invalid context", "inline contexts not supported - wait it's coming ...", OrionldDetailsString);
             return orionldState.responseTree;
           }

--- a/src/lib/orionld/kjTree/kjTreeFromQueryContextResponse.cpp
+++ b/src/lib/orionld/kjTree/kjTreeFromQueryContextResponse.cpp
@@ -548,9 +548,13 @@ KjNode* kjTreeFromQueryContextResponse(ConnectionInfo* ciP, bool oneHit, bool ke
     //
     if (atContextAttributeP == NULL)
     {
-      LM_TMP(("KZ: no context inside attribute list - Content.Type is appliction/json and the context came via HTTP Header, if at all"));
+      LM_TMP(("KZ: no context inside attribute list - Content-Type is appliction/json and the context came via HTTP Header, if at all"));
+
       if (orionldState.acceptJsonld == true)
       {
+        if (orionldState.contextP == NULL)
+          orionldState.contextP = &orionldDefaultContext;
+
         LM_TMP(("KZ: adding default context to payload"));
         nodeP = kjString(orionldState.kjsonP, "@context", orionldState.contextP->url);
         kjChildAdd(top, nodeP);

--- a/src/lib/orionld/kjTree/kjTreeFromQueryContextResponseWithAttrList.cpp
+++ b/src/lib/orionld/kjTree/kjTreeFromQueryContextResponseWithAttrList.cpp
@@ -571,6 +571,9 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
       LM_TMP(("KZ: no context inside attribute list - Content.Type is appliction/json and the context came via HTTP Header, if at all"));
       if (orionldState.acceptJsonld == true)
       {
+        if (orionldState.contextP == NULL)
+          orionldState.contextP = &orionldDefaultContext;
+
         LM_TMP(("KZ: adding default context to payload"));
         nodeP = kjString(orionldState.kjsonP, "@context", orionldState.contextP->url);
         kjChildAdd(top, nodeP);

--- a/src/lib/orionld/kjTree/kjTreeFromQueryContextResponseWithAttrList.cpp
+++ b/src/lib/orionld/kjTree/kjTreeFromQueryContextResponseWithAttrList.cpp
@@ -568,9 +568,11 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
     //
     if (atContextAttributeP == NULL)
     {
+      LM_TMP(("KZ: no context inside attribute list - Content.Type is appliction/json and the context came via HTTP Header, if at all"));
       if (orionldState.acceptJsonld == true)
       {
-        nodeP = kjString(orionldState.kjsonP, "@context", orionldDefaultContext.url);
+        LM_TMP(("KZ: adding default context to payload"));
+        nodeP = kjString(orionldState.kjsonP, "@context", orionldState.contextP->url);
         kjChildAdd(top, nodeP);
       }
       // NOTE: HTTP Link header is added ONLY in orionldMhdConnectionTreat
@@ -578,10 +580,12 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
     else
     {
       // NOTE: HTTP Link header is added ONLY in orionldMhdConnectionTreat
+      LM_TMP(("KZ: context found inside attribute list. orion value type: %d", atContextAttributeP->valueType));
       if (orionldState.acceptJsonld == true)
       {
         if (atContextAttributeP->valueType == orion::ValueTypeString)
         {
+          LM_TMP(("KZ: string context '%s' to payload", atContextAttributeP->stringValue.c_str()));
           nodeP = kjString(orionldState.kjsonP, "@context", atContextAttributeP->stringValue.c_str());
           kjChildAdd(top, nodeP);
         }
@@ -589,6 +593,7 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
         {
           if (atContextAttributeP->compoundValueP->valueType == orion::ValueTypeVector)
           {
+            LM_TMP(("KZ: vector context to payload"));
             nodeP = kjArray(orionldState.kjsonP, "@context");
             kjChildAdd(top, nodeP);
 
@@ -601,6 +606,7 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
           }
           else
           {
+            LM_TMP(("KZ: inline context to payload - must be implemented!!!"));
             orionldErrorResponseCreate(ciP, OrionldInternalError, "invalid context", "inline contexts not supported - wait it's coming ...", OrionldDetailsString);
             return orionldState.responseTree;
           }

--- a/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
@@ -369,12 +369,14 @@ int orionldMhdConnectionTreat(ConnectionInfo* ciP)
         goto respond;
       }
 
+      LM_TMP(("KZ: Context in Link header: %s", ciP->httpHeaders.linkUrl));
       if ((orionldState.contextP = orionldContextCreateFromUrl(ciP, ciP->httpHeaders.linkUrl, OrionldUserContext, &details)) == NULL)
       {
         orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Failure to create context from URL", details, OrionldDetailsString);
         ciP->httpStatusCode = SccBadRequest;
         goto respond;
       }
+      LM_TMP(("KZ: orionldState.contextP points to '%s'", orionldState.contextP->url));
     }
     else
       orionldState.contextP = NULL;

--- a/test/functionalTest/cases/0000_ngsild/ngsild-test-suite--RE-should-retrieve-entity-LD-requested.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild-test-suite--RE-should-retrieve-entity-LD-requested.test
@@ -1,0 +1,134 @@
+# Copyright 2019 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+NGSILD Test Suite - Retrieve Entity - should retrieve the entity. JSON-LD MIME Type requested
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+brokerStart CB 242-243 --prettyPrint
+
+--SHELL--
+
+#
+# 01. Create entity as in NGSILD Test Suite - Retrieve Entity - should retrieve the entity. JSON-LD MIME Type requested
+# 02. GET entity, accepting application/ld+json
+#
+
+echo "01. Create entity as in NGSILD Test Suite - Retrieve Entity - should retrieve the entity. JSON-LD MIME Type requested"
+echo "====================================================================================================================="
+payload='{
+    "id": "urn:ngsi-ld:T:00:00:00",
+    "type": "T",
+    "P1": {
+      "type": "Property",
+      "value": 12,
+      "observedAt": "2018-12-04T12:00:00Z",
+      "P1_R1": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:T2:6789"
+      },
+      "P1_P1": {
+        "type": "Property",
+        "value": 0.79
+      }
+    },
+    "R1": {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:T2:6789",
+      "R1_R1": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:T3:A2345"
+      },
+      "R1_P1": {
+        "type": "Property",
+        "value": false
+      }
+    },
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld"
+}'
+orionCurl --url /ngsi-ld/v1/entities -X POST --payload "$payload" -H "Content-Type: application/ld+json"
+echo
+echo
+
+
+echo "02. GET entity, accepting application/ld+json, and with same context as the entity creation"
+echo "==========================================================================================="
+orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:T:00:00:00?prettyPrint=yes&spaces=2' --noPayloadCheck  -H "Accept: application/ld+json" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity as in NGSILD Test Suite - Retrieve Entity - should retrieve the entity. JSON-LD MIME Type requested
+=====================================================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:T:00:00:00
+Date: REGEX(.*)
+
+
+
+02. GET entity, accepting application/ld+json, and with same context as the entity creation
+===========================================================================================
+HTTP/1.1 200 OK
+Content-Length: 650
+Content-Type: application/ld+json
+Date: REGEX(.*)
+
+{
+  "id": "urn:ngsi-ld:T:00:00:00",
+  "type": "T",
+  "P1": {
+    "type": "Property",
+    "value": 12.000000,
+    "P1_P1": {
+      "type": "Property",
+      "value": 0.790000
+    },
+    "P1_R1": {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:T2:6789"
+    },
+    "observedAt": "2018-12-04T12:00:00Z"
+  },
+  "R1": {
+    "type": "Relationship",
+    "object": "urn:ngsi-ld:T2:6789",
+    "R1_P1": {
+      "type": "Property",
+      "value": false
+    },
+    "R1_R1": {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:T3:A2345"
+    }
+  },
+  "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld"
+}
+
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get.test
@@ -182,7 +182,7 @@ Date: REGEX(.*)
 05. GET all entities of type T, see E1 and E3
 =============================================
 HTTP/1.1 200 OK
-Content-Length: 481
+Content-Length: 437
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -194,7 +194,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E1"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -203,7 +203,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E3"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 
@@ -212,7 +212,7 @@ Date: REGEX(.*)
 06. GET all entities of type T2, see E2 and E4
 ==============================================
 HTTP/1.1 200 OK
-Content-Length: 483
+Content-Length: 439
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -224,7 +224,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E2"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E4",
@@ -233,7 +233,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E4"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 
@@ -242,7 +242,7 @@ Date: REGEX(.*)
 07. GET all entities with id E1, see entity E1 only
 ===================================================
 HTTP/1.1 200 OK
-Content-Length: 242
+Content-Length: 220
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -254,7 +254,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E1"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 
@@ -263,7 +263,7 @@ Date: REGEX(.*)
 08. GET all entities with id E.*, see all four entities
 =======================================================
 HTTP/1.1 200 OK
-Content-Length: 961
+Content-Length: 873
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -275,7 +275,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E1"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E2",
@@ -284,7 +284,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E2"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -293,7 +293,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E3"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E4",
@@ -302,7 +302,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E4"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_eq.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_eq.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A equal to 2018-11-23T08:00:00.00Z - see E3
 ======================================================================================
 HTTP/1.1 200 OK
-Content-Length: 262
+Content-Length: 240
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "TemporalProperty",
       "value": 1542960000.000000
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_greater_than.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_greater_than.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A > 2018-11-21T08:00:00.00Z - see E3
 ===============================================================================
 HTTP/1.1 200 OK
-Content-Length: 262
+Content-Length: 240
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "TemporalProperty",
       "value": 1542960000.000000
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_greater_than_or_equal.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_greater_than_or_equal.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A >= 2018-11-21T08:00:00.00Z - see E1 and E3
 =======================================================================================
 HTTP/1.1 200 OK
-Content-Length: 521
+Content-Length: 477
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "TemporalProperty",
       "value": 1542787200.000000
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -170,7 +170,7 @@ Date: REGEX(.*)
       "type": "TemporalProperty",
       "value": 1542960000.000000
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_less_than.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_less_than.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A < 2018-11-22T08:00:00.00Z - see E1
 ===============================================================================
 HTTP/1.1 200 OK
-Content-Length: 262
+Content-Length: 240
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "TemporalProperty",
       "value": 1542787200.000000
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_less_than_or_equal.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_less_than_or_equal.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A <= 2018-11-25T08:00:00.00Z - see E1 and E3
 =======================================================================================
 HTTP/1.1 200 OK
-Content-Length: 521
+Content-Length: 477
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "TemporalProperty",
       "value": 1542787200.000000
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -170,7 +170,7 @@ Date: REGEX(.*)
       "type": "TemporalProperty",
       "value": 1542960000.000000
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_not_eq.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_not_eq.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A not equal to 2018-11-23T08:00:00.00Z - see E1
 ==========================================================================================
 HTTP/1.1 200 OK
-Content-Length: 262
+Content-Length: 240
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "TemporalProperty",
       "value": 1542787200.000000
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_bool_attr_doesnt_exist.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_bool_attr_doesnt_exist.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that does not have an attribute A - see E2 and E4
 ======================================================================
 HTTP/1.1 200 OK
-Content-Length: 484
+Content-Length: 440
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": true
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E4",
@@ -170,7 +170,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": false
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_bool_attr_eq.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_bool_attr_eq.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A equal to false - see E3
 ====================================================================
 HTTP/1.1 200 OK
-Content-Length: 242
+Content-Length: 220
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": false
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_bool_attr_exists.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_bool_attr_exists.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A - see E1 and E3
 ============================================================
 HTTP/1.1 200 OK
-Content-Length: 480
+Content-Length: 436
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": true
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -170,7 +170,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": false
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_bool_attr_not_eq.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_bool_attr_not_eq.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A2 not equal to false - see E2
 =========================================================================
 HTTP/1.1 200 OK
-Content-Length: 243
+Content-Length: 221
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": true
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_doesnt_exist.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_doesnt_exist.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that does not have an attribute A - see E2 and E4
 ======================================================================
 HTTP/1.1 200 OK
-Content-Length: 491
+Content-Length: 447
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": 2.000000
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E4",
@@ -170,7 +170,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": 4.000000
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_eq.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_eq.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A equal to 3 - see E3
 ================================================================
 HTTP/1.1 200 OK
-Content-Length: 245
+Content-Length: 223
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": 3.000000
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_exists.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_exists.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A - see E1 and E3
 ============================================================
 HTTP/1.1 200 OK
-Content-Length: 487
+Content-Length: 443
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": 1.000000
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -170,7 +170,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": 3.000000
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_greater_than.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_greater_than.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A > 2 - see E3
 =========================================================
 HTTP/1.1 200 OK
-Content-Length: 245
+Content-Length: 223
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": 3.000000
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_greater_than_or_equal.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_greater_than_or_equal.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A >= 3 - see E3
 ==========================================================
 HTTP/1.1 200 OK
-Content-Length: 245
+Content-Length: 223
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": 3.000000
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_less_than.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_less_than.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A < 2 - see E1
 =========================================================
 HTTP/1.1 200 OK
-Content-Length: 245
+Content-Length: 223
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": 1.000000
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_less_than_or_equal.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_less_than_or_equal.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A <= 3 - see E1 and E3
 =================================================================
 HTTP/1.1 200 OK
-Content-Length: 487
+Content-Length: 443
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": 1.000000
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -170,7 +170,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": 3.000000
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_list.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_list.test
@@ -175,7 +175,7 @@ Date: REGEX(.*)
 06. GET all entities that has an attribute A == 1 or 3 - see E1 and E3
 ======================================================================
 HTTP/1.1 200 OK
-Content-Length: 487
+Content-Length: 443
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -187,7 +187,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": 1.000000
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -196,7 +196,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": 3.000000
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_not_eq.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_not_eq.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A2 not equal to 4 - see E2
 =====================================================================
 HTTP/1.1 200 OK
-Content-Length: 247
+Content-Length: 225
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": 2.000000
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_range.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_range.test
@@ -175,7 +175,7 @@ Date: REGEX(.*)
 06. GET all entities that has an attribute A == 1 to 3 - see E1 and E3
 ======================================================================
 HTTP/1.1 200 OK
-Content-Length: 487
+Content-Length: 443
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -187,7 +187,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": 1.000000
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -196,7 +196,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": 3.000000
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_doesnt_exist.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_doesnt_exist.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that does not have an attribute A - see E2 and E4
 ======================================================================
 HTTP/1.1 200 OK
-Content-Length: 481
+Content-Length: 437
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "2"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E4",
@@ -170,7 +170,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "4"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_eq.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_eq.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A equal to "3" - see E3
 ==================================================================
 HTTP/1.1 200 OK
-Content-Length: 240
+Content-Length: 218
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "3"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_exists.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_exists.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A - see E1 and E3
 ============================================================
 HTTP/1.1 200 OK
-Content-Length: 477
+Content-Length: 433
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "1"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -170,7 +170,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "3"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_greater_than.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_greater_than.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A > "1" - see E3
 ===========================================================
 HTTP/1.1 200 OK
-Content-Length: 240
+Content-Length: 218
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "3"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_greater_than_or_equal.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_greater_than_or_equal.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A >= "1" - see E1 and E3
 ===================================================================
 HTTP/1.1 200 OK
-Content-Length: 477
+Content-Length: 433
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "1"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -170,7 +170,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "3"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_less_than.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_less_than.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A < "3" - see E1
 ===========================================================
 HTTP/1.1 200 OK
-Content-Length: 240
+Content-Length: 218
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "1"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_less_than_or_equal.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_less_than_or_equal.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A <= "3" - see E1 and E3
 ===================================================================
 HTTP/1.1 200 OK
-Content-Length: 477
+Content-Length: 433
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "1"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -170,7 +170,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "3"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_list.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_list.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A in list '1','2','5' - see E1
 =========================================================================
 HTTP/1.1 200 OK
-Content-Length: 240
+Content-Length: 218
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "1"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_not_eq.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_not_eq.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A not equal to "3" - see E1
 ======================================================================
 HTTP/1.1 200 OK
-Content-Length: 240
+Content-Length: 218
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "1"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_pattern.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_pattern.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A matching 'one' - see E1
 ====================================================================
 HTTP/1.1 200 OK
-Content-Length: 244
+Content-Length: 222
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "1one1"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_range.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_string_attr_range.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A in list '1' to '5' - see E1 and E3
 ===============================================================================
 HTTP/1.1 200 OK
-Content-Length: 477
+Content-Length: 433
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -161,7 +161,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "1"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -170,7 +170,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "3"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_attrs_uri_param_attr_list.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_attrs_uri_param_attr_list.test
@@ -204,7 +204,7 @@ Date: REGEX(.*)
 05. GET all entities with attr A1, see E1 only
 ==============================================
 HTTP/1.1 200 OK
-Content-Length: 245
+Content-Length: 223
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -216,7 +216,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E1/A1"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 
@@ -225,7 +225,7 @@ Date: REGEX(.*)
 06. GET all entities with attr A1 and A5, see E1 and E4
 =======================================================
 HTTP/1.1 200 OK
-Content-Length: 487
+Content-Length: 443
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -237,7 +237,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E1/A1"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E4",
@@ -246,7 +246,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E4/A5"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 
@@ -255,7 +255,7 @@ Date: REGEX(.*)
 07. GET all entities with attr A2 and A6, see E1 and E2
 =======================================================
 HTTP/1.1 200 OK
-Content-Length: 487
+Content-Length: 443
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -267,7 +267,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E1/A2"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E2",
@@ -276,7 +276,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E2/A2"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 
@@ -285,7 +285,7 @@ Date: REGEX(.*)
 08. GET all entities with attr A2, A3 and A4, see all four entities
 ===================================================================
 HTTP/1.1 200 OK
-Content-Length: 1107
+Content-Length: 1019
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -297,7 +297,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E1/A2"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E2",
@@ -310,7 +310,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E2/A3"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -323,7 +323,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E3/A4"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E4",
@@ -332,7 +332,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E4/A4"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 
@@ -341,7 +341,7 @@ Date: REGEX(.*)
 09. GET all entities with attr A2, A3, see E1, E2 and E3
 ========================================================
 HTTP/1.1 200 OK
-Content-Length: 797
+Content-Length: 731
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -353,7 +353,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E1/A2"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E2",
@@ -366,7 +366,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E2/A3"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -375,7 +375,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E3/A3"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_attrs_uri_param_entity_without_any_matching_attrs.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_attrs_uri_param_entity_without_any_matching_attrs.test
@@ -83,14 +83,14 @@ Date: REGEX(.*)
 02. GET /ngsi-ld/v1/entities/http://a.b.c/entity/E1 with URI param 'attrs' set to 'A3' - see E1 but without any attributes
 ==========================================================================================================================
 HTTP/1.1 200 OK
-Content-Length: 163
+Content-Length: 141
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
 {
   "id": "http://a.b.c/entity/E1",
   "type": "T",
-  "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+  "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
 }
 
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_attrs_uri_param_just_one_attr.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_attrs_uri_param_just_one_attr.test
@@ -181,7 +181,7 @@ Date: REGEX(.*)
 05. GET all entities with attr A1, see E1 only
 ==============================================
 HTTP/1.1 200 OK
-Content-Length: 245
+Content-Length: 223
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -193,7 +193,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E1/A1"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 
@@ -202,7 +202,7 @@ Date: REGEX(.*)
 06. GET all entities with attr A2, see E1 and E2
 ================================================
 HTTP/1.1 200 OK
-Content-Length: 487
+Content-Length: 443
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -214,7 +214,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E1/A2"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E2",
@@ -223,7 +223,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E2/A2"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_uri_param_id_list.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_uri_param_id_list.test
@@ -164,7 +164,7 @@ Date: REGEX(.*)
 05. GET entities with id E2 or E4 - see E2 and E4
 =================================================
 HTTP/1.1 200 OK
-Content-Length: 483
+Content-Length: 439
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -176,7 +176,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E2"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E4",
@@ -185,7 +185,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E4"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 
@@ -194,7 +194,7 @@ Date: REGEX(.*)
 06. GET entities with id E1 or E5 - see E1
 ==========================================
 HTTP/1.1 200 OK
-Content-Length: 242
+Content-Length: 220
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -206,7 +206,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E1"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_uri_param_type_list.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_uri_param_type_list.test
@@ -172,7 +172,7 @@ Date: REGEX(.*)
 05. GET entities with type T - see E1
 =====================================
 HTTP/1.1 200 OK
-Content-Length: 242
+Content-Length: 220
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -184,7 +184,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E1"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 
@@ -193,7 +193,7 @@ Date: REGEX(.*)
 06. GET entities with type T2 or T3 or T4 - see E2, E3 and E4
 =============================================================
 HTTP/1.1 200 OK
-Content-Length: 723
+Content-Length: 657
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -205,7 +205,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E2"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E3",
@@ -214,7 +214,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E3"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
   {
     "id": "http://a.b.c/entity/E4",
@@ -223,7 +223,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E4"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 
@@ -232,7 +232,7 @@ Date: REGEX(.*)
 07. GET entities with type T2 or T1 - see E2
 ============================================
 HTTP/1.1 200 OK
-Content-Length: 243
+Content-Length: 221
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -244,7 +244,7 @@ Date: REGEX(.*)
       "type": "Property",
       "value": "E2"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_ld_single_uri.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_ld_single_uri.test
@@ -107,9 +107,8 @@ Date: REGEX(.*)
     "type": "Relationship",
     "object": "urn:ngsi-ld:T2:6789"
   },
-  "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
+  "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld"
 }
-
 
 
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_ld_single_uri.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_ld_single_uri.test
@@ -111,6 +111,7 @@ Date: REGEX(.*)
 }
 
 
+
 --TEARDOWN--
 brokerStop CB
 dbDrop CB

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_ld_single_uri.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_ld_single_uri.test
@@ -82,7 +82,7 @@ Date: REGEX(.*)
 02. GET entity
 ==============
 HTTP/1.1 200 OK
-Content-Length: 455
+Content-Length: 437
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -107,7 +107,7 @@ Date: REGEX(.*)
     "type": "Relationship",
     "object": "urn:ngsi-ld:T2:6789"
   },
-  "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+  "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
 }
 
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_ld_single_uri_and_datetime_property_inline.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_ld_single_uri_and_datetime_property_inline.test
@@ -202,7 +202,7 @@ Date: REGEX(.*)
     "type": "Relationship",
     "object": "urn:ngsi-ld:T2:6789"
   },
-  "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
+  "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld"
 }
 
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_ld_single_uri_and_datetime_property_inline.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_ld_single_uri_and_datetime_property_inline.test
@@ -170,7 +170,7 @@ bye
 03. GET entity
 ==============
 HTTP/1.1 200 OK
-Content-Length: 586
+Content-Length: 568
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -202,7 +202,7 @@ Date: REGEX(.*)
     "type": "Relationship",
     "object": "urn:ngsi-ld:T2:6789"
   },
-  "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+  "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
 }
 
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_deletion.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_deletion.test
@@ -129,14 +129,14 @@ bye
 03. GET the entity
 ==================
 HTTP/1.1 200 OK
-Content-Length: 163
+Content-Length: 145
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
 {
   "id": "urn:ngsi-ld:T:12:13:14",
   "type": "T",
-  "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+  "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
 }
 
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_deletion.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_deletion.test
@@ -136,7 +136,7 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:T:12:13:14",
   "type": "T",
-  "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
+  "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld"
 }
 
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_double_creation.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_double_creation.test
@@ -96,12 +96,12 @@ Date: REGEX(.*)
 02. GET /ngsi-ld/v1/entities/E1
 ===============================
 HTTP/1.1 200 OK
-Content-Length: 193
+Content-Length: 171
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
 {
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld",
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld",
     "id": "http://a.b.c/entity/E1",
     "name": {
         "type": "Property",
@@ -128,12 +128,12 @@ Date: REGEX(.*)
 04. GET /ngsi-ld/v1/entities/E1, making sure step 02 didn't modify anything
 ===========================================================================
 HTTP/1.1 200 OK
-Content-Length: 193
+Content-Length: 171
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
 {
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld",
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld",
     "id": "http://a.b.c/entity/E1",
     "name": {
         "type": "Property",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_get.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_get.test
@@ -121,7 +121,7 @@ Date: REGEX(.*)
 03. GET E1, see default context, pretty-print with 4 spaces
 ===========================================================
 HTTP/1.1 200 OK
-Content-Length: 244
+Content-Length: 222
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -132,7 +132,7 @@ Date: REGEX(.*)
         "type": "Property",
         "value": "John 6"
     },
-    "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
 }
 
 
@@ -140,7 +140,7 @@ Date: REGEX(.*)
 04. GET E2, see test context, pretty-print with default number of spaces (2)
 ============================================================================
 HTTP/1.1 200 OK
-Content-Length: 226
+Content-Length: 204
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -151,7 +151,7 @@ Date: REGEX(.*)
     "type": "Property",
     "value": "John 6"
   },
-  "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+  "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
 }
 
 
@@ -159,11 +159,11 @@ Date: REGEX(.*)
 05. GET E2, but without prettyPrint
 ===================================
 HTTP/1.1 200 OK
-Content-Length: 193
+Content-Length: 171
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
-{"id":"http://a.b.c/entity/E2","type":"A","name":{"type":"Property","value":"John 6"},"@context":"https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"}
+{"id":"http://a.b.c/entity/E2","type":"A","name":{"type":"Property","value":"John 6"},"@context":"https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"}
 
 
 06. Attempt to GET non-existing E3, see 404 not Found

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_get_with_correct_alias_replacement.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_get_with_correct_alias_replacement.test
@@ -110,7 +110,7 @@ bye
 03. GET E1, see short name for 'name', not its long name
 ========================================================
 HTTP/1.1 200 OK
-Content-Length: 226
+Content-Length: 204
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -121,7 +121,7 @@ Date: REGEX(.*)
     "type": "Property",
     "value": "John 1"
   },
-  "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld"
+  "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
 }
 
 


### PR DESCRIPTION
Fixed a bug about returning the wrong context, and
added a functest to cover the NGSILD Test Suite case

retrieve_entity_with_ldcontext_test.js:
  Retrieve Entity. JSON-LD. @context
    should retrieve the entity. JSON-LD MIME Type requested
