### PR TITLE
bug/175.trailing-zeroes

### DIFF
--- a/src/lib/rest/StringFilter.cpp
+++ b/src/lib/rest/StringFilter.cpp
@@ -25,6 +25,11 @@
 #include <string>
 #include <vector>
 
+extern "C"
+{
+#include "kbase/kFloatTrim.h"                 // kFloatTrim
+}
+
 #include "mongo/client/dbclient.h"
 
 #include "logMsg/logMsg.h"
@@ -749,50 +754,6 @@ bool StringFilterItem::parse(char* qItem, std::string* errorStringP, StringFilte
 
 /* ****************************************************************************
 *
-* floatTrim - remove trailing zeroes in decimal part
-*/
-static void floatTrim(char* floatString)
-{
-  //
-  // 1. Is there a decimal part?
-  //
-  char* cP          = floatString;
-  bool  decimalPart = false;
-
-  while (*cP != 0)
-  {
-    if (*cP == '.')
-    {
-      decimalPart = true;
-      break;
-    }
-    ++cP;
-  }
-
-  if (decimalPart == false)
-    return;
-
-  //
-  // 2. Remove last char if it's a '0'
-  //
-  int lastCharIx = strlen(floatString) - 1;
-  while (floatString[lastCharIx] == '0')
-  {
-    floatString[lastCharIx] = 0;
-    --lastCharIx;
-  }
-
-  //
-  // 3. Remove last char if it's a '.'
-  //
-  if (floatString[lastCharIx] == '.')
-    floatString[lastCharIx] = 0;
-}
-
-
-
-/* ****************************************************************************
-*
 * StringFilterItem::valueAsString -
 */
 void StringFilterItem::valueAsString(char* buf, int bufLen)
@@ -812,7 +773,7 @@ void StringFilterItem::valueAsString(char* buf, int bufLen)
 
   case SfvtNumber:
     snprintf(buf, bufLen, "%f", numberValue);
-    floatTrim(buf);
+    kFloatTrim(buf);
     break;
 
   case SfvtNull:

--- a/test/functionalTest/cases/0000_ngsild/ngsild-test-suite--RE-should-retrieve-entity-LD-requested.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild-test-suite--RE-should-retrieve-entity-LD-requested.test
@@ -92,7 +92,7 @@ Date: REGEX(.*)
 02. GET entity, accepting application/ld+json, and with same context as the entity creation
 ===========================================================================================
 HTTP/1.1 200 OK
-Content-Length: 650
+Content-Length: 639
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -101,10 +101,10 @@ Date: REGEX(.*)
   "type": "T",
   "P1": {
     "type": "Property",
-    "value": 12.000000,
+    "value": 12,
     "P1_P1": {
       "type": "Property",
-      "value": 0.790000
+      "value": 0.79
     },
     "P1_R1": {
       "type": "Relationship",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_@value_@type.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_@value_@type.test
@@ -398,7 +398,7 @@ Date: REGEX(.*)
 12. GET entity E10
 ==================
 HTTP/1.1 200 OK
-Content-Length: 141
+Content-Length: 134
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -409,7 +409,7 @@ Date: REGEX(.*)
   "P1": {
     "type": "Property",
     "value": {
-      "A": 1.000000,
+      "A": 1,
       "B": "2"
     }
   }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_GET_with_keyValues.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_GET_with_keyValues.test
@@ -104,7 +104,7 @@ Date: REGEX(.*)
 02. GET the entity with options=keyValues
 =========================================
 HTTP/1.1 200 OK
-Content-Length: 221
+Content-Length: 186
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -112,17 +112,17 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:T:2018-11-22T10:00:00",
   "type": "T",
-  "P1": 1.000000,
+  "P1": 1,
   "P2": "Stringeling",
   "P3": true,
   "P4": {
-    "a": 1.000000,
+    "a": 1,
     "b": "2"
   },
   "P5": [
-    1.000000,
-    2.000000,
-    3.000000
+    1,
+    2,
+    3
   ]
 }
 
@@ -131,7 +131,7 @@ Date: REGEX(.*)
 03. GET attributes P1 and P4 with options=keyValues
 ===================================================
 HTTP/1.1 200 OK
-Content-Length: 128
+Content-Length: 114
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -139,9 +139,9 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:T:2018-11-22T10:00:00",
   "type": "T",
-  "P1": 1.000000,
+  "P1": 1,
   "P4": {
-    "a": 1.000000,
+    "a": 1,
     "b": "2"
   }
 }
@@ -151,7 +151,7 @@ Date: REGEX(.*)
 04. GET all entities with options=keyValues
 ===========================================
 HTTP/1.1 200 OK
-Content-Length: 257
+Content-Length: 222
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -160,17 +160,17 @@ Date: REGEX(.*)
   {
     "id": "urn:ngsi-ld:T:2018-11-22T10:00:00",
     "type": "T",
-    "P1": 1.000000,
+    "P1": 1,
     "P2": "Stringeling",
     "P3": true,
     "P4": {
-      "a": 1.000000,
+      "a": 1,
       "b": "2"
     },
     "P5": [
-      1.000000,
-      2.000000,
-      3.000000
+      1,
+      2,
+      3
     ]
   }
 ]

--- a/test/functionalTest/cases/0000_ngsild/ngsild_GET_with_sysAttrs.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_GET_with_sysAttrs.test
@@ -88,7 +88,7 @@ Date: REGEX(.*)
 02. GET the entity with options=sysAttrs, see 'createdAt' and 'modifiedAt' as text strings
 ==========================================================================================
 HTTP/1.1 200 OK
-Content-Length: 286
+Content-Length: 279
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -100,7 +100,7 @@ Date: REGEX(.*)
   "modifiedAt": "REGEX(.*)",
   "P1": {
     "type": "Property",
-    "value": 1.000000,
+    "value": 1,
     "createdAt": "REGEX(.*)",
     "modifiedAt": "REGEX(.*)"
   }
@@ -111,7 +111,7 @@ Date: REGEX(.*)
 03. GET the entity with options=sysAttrs AND attrs=P1, see 'createdAt' and 'modifiedAt' as text strings
 =======================================================================================================
 HTTP/1.1 200 OK
-Content-Length: 286
+Content-Length: 279
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -123,7 +123,7 @@ Date: REGEX(.*)
   "modifiedAt": "REGEX(.*)",
   "P1": {
     "type": "Property",
-    "value": 1.000000,
+    "value": 1,
     "createdAt": "REGEX(.*)",
     "modifiedAt": "REGEX(.*)"
   }
@@ -134,7 +134,7 @@ Date: REGEX(.*)
 04. GET the entity with options=sysAttrs,keyValues AND attrs=P1, see 'createdAt' and 'modifiedAt' as text strings but only for the entity, not for P1
 =====================================================================================================================================================
 HTTP/1.1 200 OK
-Content-Length: 160
+Content-Length: 153
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -144,7 +144,7 @@ Date: REGEX(.*)
   "type": "T",
   "createdAt": "REGEX(.*)",
   "modifiedAt": "REGEX(.*)",
-  "P1": 1.000000
+  "P1": 1
 }
 
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_add_and_modify_attr.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_add_and_modify_attr.test
@@ -107,7 +107,7 @@ Date: REGEX(.*)
 02. GET the entity - see P1
 ===========================
 HTTP/1.1 200 OK
-Content-Length: 124
+Content-Length: 117
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -117,7 +117,7 @@ Date: REGEX(.*)
   "type": "T",
   "P1": {
     "type": "Property",
-    "value": 1.000000
+    "value": 1
   }
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_add_attr-noOverwrite.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_add_attr-noOverwrite.test
@@ -119,7 +119,7 @@ Date: REGEX(.*)
 03. GET the entity, make sure P2 == 12
 ======================================
 HTTP/1.1 200 OK
-Content-Length: 187
+Content-Length: 173
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -129,11 +129,11 @@ Date: REGEX(.*)
   "type": "T",
   "P1": {
     "type": "Property",
-    "value": 11.000000
+    "value": 11
   },
   "P2": {
     "type": "Property",
-    "value": 12.000000
+    "value": 12
   }
 }
 
@@ -150,7 +150,7 @@ Date: REGEX(.*)
 05. GET the entity, make sure P2 == 42
 ======================================
 HTTP/1.1 200 OK
-Content-Length: 187
+Content-Length: 173
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -160,11 +160,11 @@ Date: REGEX(.*)
   "type": "T",
   "P1": {
     "type": "Property",
-    "value": 11.000000
+    "value": 11
   },
   "P2": {
     "type": "Property",
-    "value": 42.000000
+    "value": 42
   }
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_add_attr.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_add_attr.test
@@ -107,7 +107,7 @@ Date: REGEX(.*)
 02. GET the entity - see P1
 ===========================
 HTTP/1.1 200 OK
-Content-Length: 124
+Content-Length: 117
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -117,7 +117,7 @@ Date: REGEX(.*)
   "type": "T",
   "P1": {
     "type": "Property",
-    "value": 1.000000
+    "value": 1
   }
 }
 
@@ -134,7 +134,7 @@ Date: REGEX(.*)
 04. GET the entity, see P1, P2 and P3
 =====================================
 HTTP/1.1 200 OK
-Content-Length: 240
+Content-Length: 233
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -144,7 +144,7 @@ Date: REGEX(.*)
   "type": "T",
   "P1": {
     "type": "Property",
-    "value": 1.000000
+    "value": 1
   },
   "P2": {
     "type": "Property",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_big_integer.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_big_integer.test
@@ -84,7 +84,7 @@ Date: REGEX(.*)
 03. Get the entity from broker, check that the BIG Integer value is correct
 ===========================================================================
 HTTP/1.1 200 OK
-Content-Length: 116
+Content-Length: 109
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -94,7 +94,7 @@ Date: REGEX(.*)
   "type": "T",
   "P1": {
     "type": "Property",
-    "value": 1543924800.000000
+    "value": 1543924800
   }
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_content_type_and_context.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_content_type_and_context.test
@@ -265,7 +265,7 @@ Date: REGEX(.*)
 10. GET Entity from step 05 - see correct URI Expansion (matching @context in payload)
 ======================================================================================
 HTTP/1.1 200 OK
-Content-Length: 214
+Content-Length: 207
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -273,7 +273,7 @@ Date: REGEX(.*)
     "@context": "https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld",
     "http://example.org/P100": {
         "type": "Property",
-        "value": 100.0
+        "value": 100
     },
     "id": "http://a.b.c/entity/E5",
     "type": "A"

--- a/test/functionalTest/cases/0000_ngsild/ngsild_context_in_header_or_payload_when_entity_has_a_context.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_context_in_header_or_payload_when_entity_has_a_context.test
@@ -100,7 +100,7 @@ Date: REGEX(.*)
 02. GET all entities using application/json - see context in Link HTTP Header
 =============================================================================
 HTTP/1.1 200 OK
-Content-Length: 287
+Content-Length: 280
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -111,7 +111,7 @@ Date: REGEX(.*)
     "type": "T",
     "P1": {
       "type": "Property",
-      "value": 12.000000,
+      "value": 12,
       "P1_R1": {
         "type": "Relationship",
         "object": "urn:ngsi-ld:T2:6789"
@@ -126,7 +126,7 @@ Date: REGEX(.*)
 03. GET all entities using application/ld+json - see context in payload
 =======================================================================
 HTTP/1.1 200 OK
-Content-Length: 400
+Content-Length: 393
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -136,7 +136,7 @@ Date: REGEX(.*)
     "type": "T",
     "P1": {
       "type": "Property",
-      "value": 12.000000,
+      "value": 12,
       "P1_R1": {
         "type": "Relationship",
         "object": "urn:ngsi-ld:T2:6789"
@@ -152,7 +152,7 @@ Date: REGEX(.*)
 04. GET the entity using application/json - see context in Link HTTP Header
 ===========================================================================
 HTTP/1.1 200 OK
-Content-Length: 257
+Content-Length: 250
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -162,7 +162,7 @@ Date: REGEX(.*)
   "type": "T",
   "P1": {
     "type": "Property",
-    "value": 12.000000,
+    "value": 12,
     "P1_R1": {
       "type": "Relationship",
       "object": "urn:ngsi-ld:T2:6789"
@@ -176,7 +176,7 @@ Date: REGEX(.*)
 05. GET the entity using application/ld+json - see context in payload
 =====================================================================
 HTTP/1.1 200 OK
-Content-Length: 368
+Content-Length: 361
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -185,7 +185,7 @@ Date: REGEX(.*)
   "type": "T",
   "P1": {
     "type": "Property",
-    "value": 12.000000,
+    "value": 12,
     "P1_R1": {
       "type": "Relationship",
       "object": "urn:ngsi-ld:T2:6789"

--- a/test/functionalTest/cases/0000_ngsild/ngsild_context_in_header_or_payload_when_entity_has_no_context.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_context_in_header_or_payload_when_entity_has_no_context.test
@@ -99,7 +99,7 @@ Date: REGEX(.*)
 02. GET all entities using application/json - see context in Link HTTP Header
 =============================================================================
 HTTP/1.1 200 OK
-Content-Length: 287
+Content-Length: 280
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -110,7 +110,7 @@ Date: REGEX(.*)
     "type": "T",
     "P1": {
       "type": "Property",
-      "value": 12.000000,
+      "value": 12,
       "P1_R1": {
         "type": "Relationship",
         "object": "urn:ngsi-ld:T2:6789"
@@ -125,7 +125,7 @@ Date: REGEX(.*)
 03. GET all entities using application/ld+json - see context in payload
 =======================================================================
 HTTP/1.1 200 OK
-Content-Length: 400
+Content-Length: 393
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -135,7 +135,7 @@ Date: REGEX(.*)
     "type": "T",
     "P1": {
       "type": "Property",
-      "value": 12.000000,
+      "value": 12,
       "P1_R1": {
         "type": "Relationship",
         "object": "urn:ngsi-ld:T2:6789"
@@ -151,7 +151,7 @@ Date: REGEX(.*)
 04. GET the entity using application/json - see context in Link HTTP Header
 ===========================================================================
 HTTP/1.1 200 OK
-Content-Length: 257
+Content-Length: 250
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -161,7 +161,7 @@ Date: REGEX(.*)
   "type": "T",
   "P1": {
     "type": "Property",
-    "value": 12.000000,
+    "value": 12,
     "P1_R1": {
       "type": "Relationship",
       "object": "urn:ngsi-ld:T2:6789"
@@ -175,7 +175,7 @@ Date: REGEX(.*)
 05. GET the entity using application/ld+json - see context in payload
 =====================================================================
 HTTP/1.1 200 OK
-Content-Length: 368
+Content-Length: 361
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -184,7 +184,7 @@ Date: REGEX(.*)
   "type": "T",
   "P1": {
     "type": "Property",
-    "value": 12.000000,
+    "value": 12,
     "P1_R1": {
       "type": "Relationship",
       "object": "urn:ngsi-ld:T2:6789"

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_eq.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_eq.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A equal to 2018-11-23T08:00:00.00Z - see E3
 ======================================================================================
 HTTP/1.1 200 OK
-Content-Length: 240
+Content-Length: 233
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -159,7 +159,7 @@ Date: REGEX(.*)
     "type": "T",
     "A": {
       "type": "TemporalProperty",
-      "value": 1542960000.000000
+      "value": 1542960000
     },
     "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_greater_than.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_greater_than.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A > 2018-11-21T08:00:00.00Z - see E3
 ===============================================================================
 HTTP/1.1 200 OK
-Content-Length: 240
+Content-Length: 233
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -159,7 +159,7 @@ Date: REGEX(.*)
     "type": "T",
     "A": {
       "type": "TemporalProperty",
-      "value": 1542960000.000000
+      "value": 1542960000
     },
     "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_greater_than_or_equal.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_greater_than_or_equal.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A >= 2018-11-21T08:00:00.00Z - see E1 and E3
 =======================================================================================
 HTTP/1.1 200 OK
-Content-Length: 477
+Content-Length: 463
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -159,7 +159,7 @@ Date: REGEX(.*)
     "type": "T",
     "A": {
       "type": "TemporalProperty",
-      "value": 1542787200.000000
+      "value": 1542787200
     },
     "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
@@ -168,7 +168,7 @@ Date: REGEX(.*)
     "type": "T",
     "A": {
       "type": "TemporalProperty",
-      "value": 1542960000.000000
+      "value": 1542960000
     },
     "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_less_than.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_less_than.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A < 2018-11-22T08:00:00.00Z - see E1
 ===============================================================================
 HTTP/1.1 200 OK
-Content-Length: 240
+Content-Length: 233
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -159,7 +159,7 @@ Date: REGEX(.*)
     "type": "T",
     "A": {
       "type": "TemporalProperty",
-      "value": 1542787200.000000
+      "value": 1542787200
     },
     "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_less_than_or_equal.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_less_than_or_equal.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A <= 2018-11-25T08:00:00.00Z - see E1 and E3
 =======================================================================================
 HTTP/1.1 200 OK
-Content-Length: 477
+Content-Length: 463
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -159,7 +159,7 @@ Date: REGEX(.*)
     "type": "T",
     "A": {
       "type": "TemporalProperty",
-      "value": 1542787200.000000
+      "value": 1542787200
     },
     "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
@@ -168,7 +168,7 @@ Date: REGEX(.*)
     "type": "T",
     "A": {
       "type": "TemporalProperty",
-      "value": 1542960000.000000
+      "value": 1542960000
     },
     "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_not_eq.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_DateTime_attr_not_eq.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A not equal to 2018-11-23T08:00:00.00Z - see E1
 ==========================================================================================
 HTTP/1.1 200 OK
-Content-Length: 240
+Content-Length: 233
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -159,7 +159,7 @@ Date: REGEX(.*)
     "type": "T",
     "A": {
       "type": "TemporalProperty",
-      "value": 1542787200.000000
+      "value": 1542787200
     },
     "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_doesnt_exist.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_doesnt_exist.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that does not have an attribute A - see E2 and E4
 ======================================================================
 HTTP/1.1 200 OK
-Content-Length: 447
+Content-Length: 433
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -159,7 +159,7 @@ Date: REGEX(.*)
     "type": "T2",
     "A2": {
       "type": "Property",
-      "value": 2.000000
+      "value": 2
     },
     "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
@@ -168,7 +168,7 @@ Date: REGEX(.*)
     "type": "T2",
     "A2": {
       "type": "Property",
-      "value": 4.000000
+      "value": 4
     },
     "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_eq.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_eq.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A equal to 3 - see E3
 ================================================================
 HTTP/1.1 200 OK
-Content-Length: 223
+Content-Length: 216
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -159,7 +159,7 @@ Date: REGEX(.*)
     "type": "T",
     "A": {
       "type": "Property",
-      "value": 3.000000
+      "value": 3
     },
     "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_exists.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_exists.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A - see E1 and E3
 ============================================================
 HTTP/1.1 200 OK
-Content-Length: 443
+Content-Length: 429
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -159,7 +159,7 @@ Date: REGEX(.*)
     "type": "T",
     "A": {
       "type": "Property",
-      "value": 1.000000
+      "value": 1
     },
     "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
@@ -168,7 +168,7 @@ Date: REGEX(.*)
     "type": "T",
     "A": {
       "type": "Property",
-      "value": 3.000000
+      "value": 3
     },
     "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_greater_than.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_greater_than.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A > 2 - see E3
 =========================================================
 HTTP/1.1 200 OK
-Content-Length: 223
+Content-Length: 216
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -159,7 +159,7 @@ Date: REGEX(.*)
     "type": "T",
     "A": {
       "type": "Property",
-      "value": 3.000000
+      "value": 3
     },
     "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_greater_than_or_equal.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_greater_than_or_equal.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A >= 3 - see E3
 ==========================================================
 HTTP/1.1 200 OK
-Content-Length: 223
+Content-Length: 216
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -159,7 +159,7 @@ Date: REGEX(.*)
     "type": "T",
     "A": {
       "type": "Property",
-      "value": 3.000000
+      "value": 3
     },
     "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_less_than.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_less_than.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A < 2 - see E1
 =========================================================
 HTTP/1.1 200 OK
-Content-Length: 223
+Content-Length: 216
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -159,7 +159,7 @@ Date: REGEX(.*)
     "type": "T",
     "A": {
       "type": "Property",
-      "value": 1.000000
+      "value": 1
     },
     "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_less_than_or_equal.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_less_than_or_equal.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A <= 3 - see E1 and E3
 =================================================================
 HTTP/1.1 200 OK
-Content-Length: 443
+Content-Length: 429
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -159,7 +159,7 @@ Date: REGEX(.*)
     "type": "T",
     "A": {
       "type": "Property",
-      "value": 1.000000
+      "value": 1
     },
     "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
@@ -168,7 +168,7 @@ Date: REGEX(.*)
     "type": "T",
     "A": {
       "type": "Property",
-      "value": 3.000000
+      "value": 3
     },
     "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_list.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_list.test
@@ -175,7 +175,7 @@ Date: REGEX(.*)
 06. GET all entities that has an attribute A == 1 or 3 - see E1 and E3
 ======================================================================
 HTTP/1.1 200 OK
-Content-Length: 443
+Content-Length: 429
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -185,7 +185,7 @@ Date: REGEX(.*)
     "type": "T",
     "A": {
       "type": "Property",
-      "value": 1.000000
+      "value": 1
     },
     "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
@@ -194,7 +194,7 @@ Date: REGEX(.*)
     "type": "T",
     "A": {
       "type": "Property",
-      "value": 3.000000
+      "value": 3
     },
     "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_not_eq.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_not_eq.test
@@ -149,7 +149,7 @@ Date: REGEX(.*)
 05. GET all entities that has an attribute A2 not equal to 4 - see E2
 =====================================================================
 HTTP/1.1 200 OK
-Content-Length: 225
+Content-Length: 218
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -159,7 +159,7 @@ Date: REGEX(.*)
     "type": "T2",
     "A2": {
       "type": "Property",
-      "value": 2.000000
+      "value": 2
     },
     "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_range.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_q_int_attr_range.test
@@ -175,7 +175,7 @@ Date: REGEX(.*)
 06. GET all entities that has an attribute A == 1 to 3 - see E1 and E3
 ======================================================================
 HTTP/1.1 200 OK
-Content-Length: 443
+Content-Length: 429
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -185,7 +185,7 @@ Date: REGEX(.*)
     "type": "T",
     "A": {
       "type": "Property",
-      "value": 1.000000
+      "value": 1
     },
     "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   },
@@ -194,7 +194,7 @@ Date: REGEX(.*)
     "type": "T",
     "A": {
       "type": "Property",
-      "value": 3.000000
+      "value": 3
     },
     "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
   }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_attrs_and_without_any_context.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_attrs_and_without_any_context.test
@@ -91,7 +91,7 @@ Date: REGEX(.*)
 02. GET the entity with P1 in URI param 'attrs' - see entity with P1 only (not R1)
 ==================================================================================
 HTTP/1.1 200 OK
-Content-Length: 367
+Content-Length: 356
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -102,10 +102,10 @@ Date: REGEX(.*)
     "type": "T",
     "P1": {
       "type": "Property",
-      "value": 12.000000,
+      "value": 12,
       "P1_P1": {
         "type": "Property",
-        "value": 0.790000
+        "value": 0.79
       },
       "P1_R1": {
         "type": "Relationship",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_ld_single_uri.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_ld_single_uri.test
@@ -82,7 +82,7 @@ Date: REGEX(.*)
 02. GET entity
 ==============
 HTTP/1.1 200 OK
-Content-Length: 437
+Content-Length: 423
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -94,8 +94,8 @@ Date: REGEX(.*)
     "value": {
       "type": "Point",
       "coordinates": [
-        -8.000000,
-        40.000000
+        -8,
+        40
       ]
     }
   },

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_ld_single_uri_and_datetime_property_inline.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_ld_single_uri_and_datetime_property_inline.test
@@ -170,7 +170,7 @@ bye
 03. GET entity
 ==============
 HTTP/1.1 200 OK
-Content-Length: 568
+Content-Length: 554
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -189,8 +189,8 @@ Date: REGEX(.*)
     "value": {
       "type": "Point",
       "coordinates": [
-        -8.000000,
-        40.000000
+        -8,
+        40
       ]
     }
   },

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_geoproperty.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_geoproperty.test
@@ -127,7 +127,7 @@ bye
 03. GET entity
 ==============
 HTTP/1.1 200 OK
-Content-Length: 212
+Content-Length: 198
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -140,8 +140,8 @@ Date: REGEX(.*)
     "value": {
       "type": "Point",
       "coordinates": [
-        -8.000000,
-        40.000000
+        -8,
+        40
       ]
     }
   }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_property_observedAt.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_property_observedAt.test
@@ -116,7 +116,7 @@ bye
 03. GET entity
 ==============
 HTTP/1.1 200 OK
-Content-Length: 156
+Content-Length: 149
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -126,7 +126,7 @@ Date: REGEX(.*)
   "type": "T",
   "P1": {
     "type": "Property",
-    "value": 12.000000,
+    "value": 12,
     "observedAt": "2018-12-04T12:00:00Z"
   }
 }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_property_property.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_property_property.test
@@ -125,7 +125,7 @@ bye
 03. GET entity
 ==============
 HTTP/1.1 200 OK
-Content-Length: 228
+Content-Length: 217
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -135,10 +135,10 @@ Date: REGEX(.*)
   "type": "T",
   "P1": {
     "type": "Property",
-    "value": 12.000000,
+    "value": 12,
     "P1_P1": {
       "type": "Property",
-      "value": 0.890000
+      "value": 0.89
     },
     "observedAt": "2018-12-04T12:00:00Z"
   }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_property_relationship.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_property_relationship.test
@@ -125,7 +125,7 @@ bye
 03. GET entity
 ==============
 HTTP/1.1 200 OK
-Content-Length: 246
+Content-Length: 239
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -135,7 +135,7 @@ Date: REGEX(.*)
   "type": "T",
   "P1": {
     "type": "Property",
-    "value": 12.000000,
+    "value": 12,
     "P1_R1": {
       "type": "Relationship",
       "object": "urn:ngsi-ld:T2:6789"

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_property_unitCode.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_property_unitCode.test
@@ -116,7 +116,7 @@ bye
 03. GET entity
 ==============
 HTTP/1.1 200 OK
-Content-Length: 135
+Content-Length: 131
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -126,7 +126,7 @@ Date: REGEX(.*)
   "type": "T",
   "P1": {
     "type": "Property",
-    "value": 12.450000,
+    "value": 12.45,
     "unitCode": "m"
   }
 }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_get_with_attrs.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_get_with_attrs.test
@@ -86,7 +86,7 @@ Date: REGEX(.*)
 02. GET entity with the first three attributes only, using URI param 'attrs'
 ============================================================================
 HTTP/1.1 200 OK
-Content-Length: 235
+Content-Length: 214
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -96,15 +96,15 @@ Date: REGEX(.*)
   "type": "T",
   "P1": {
     "type": "Property",
-    "value": 1.000000
+    "value": 1
   },
   "P2": {
     "type": "Property",
-    "value": 2.000000
+    "value": 2
   },
   "P3": {
     "type": "Property",
-    "value": 3.000000
+    "value": 3
   }
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_retrieval_with_attribute_in_filter.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_retrieval_with_attribute_in_filter.test
@@ -134,7 +134,7 @@ Date: REGEX(.*)
 02. Retrieve entities with an attribute named P100
 ==================================================
 HTTP/1.1 200 OK
-Content-Length: 255
+Content-Length: 244
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -152,7 +152,7 @@ Date: REGEX(.*)
             },
             "observedAt": "2018-12-04T12:00:00Z",
             "type": "Property",
-            "value": 12.0
+            "value": 12
         },
         "id": "urn:ngsi-ld:T_Query:EntityForQuery2345",
         "type": "T_Query"
@@ -163,7 +163,7 @@ Date: REGEX(.*)
 03. Retrieve entities with condition over object
 ================================================
 HTTP/1.1 200 OK
-Content-Length: 562
+Content-Length: 536
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -172,7 +172,7 @@ Date: REGEX(.*)
     {
         "P1": {
             "type": "Property",
-            "value": 45.0
+            "value": 45
         },
         "P100": {
             "P1_P1": {
@@ -185,7 +185,7 @@ Date: REGEX(.*)
             },
             "observedAt": "2018-12-04T12:00:00Z",
             "type": "Property",
-            "value": 12.0
+            "value": 12
         },
         "R100": {
             "R1_P1": {
@@ -229,7 +229,7 @@ Date: REGEX(.*)
 05. Retrieve entities with query by condition over values
 =========================================================
 HTTP/1.1 200 OK
-Content-Length: 562
+Content-Length: 536
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -238,7 +238,7 @@ Date: REGEX(.*)
     {
         "P1": {
             "type": "Property",
-            "value": 45.0
+            "value": 45
         },
         "P100": {
             "P1_P1": {
@@ -251,7 +251,7 @@ Date: REGEX(.*)
             },
             "observedAt": "2018-12-04T12:00:00Z",
             "type": "Property",
-            "value": 12.0
+            "value": 12
         },
         "R100": {
             "R1_P1": {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_first_notification.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_first_notification.test
@@ -165,7 +165,7 @@ Date: REGEX(.*)
 ========================================================================
 POST http://REGEX(.*)/notify
 Fiware-Servicepath: /
-Content-Length: 369
+Content-Length: 362
 User-Agent: orion/REGEX(.*)
 Ngsiv2-Attrsformat: normalized
 Host: REGEX(.*)
@@ -178,7 +178,7 @@ Content-Type: application/ld+json
         {
             "P1": {
                 "type": "Property",
-                "value": 1.0
+                "value": 1
             },
             "P2": {
                 "type": "Property",
@@ -208,7 +208,7 @@ Date: REGEX(.*)
 ========================================================================
 POST http://REGEX(.*)/notify
 Fiware-Servicepath: /
-Content-Length: 370
+Content-Length: 363
 User-Agent: orion/REGEX(.*)
 Ngsiv2-Attrsformat: normalized
 Host: REGEX(.*)
@@ -221,7 +221,7 @@ Content-Type: application/ld+json
         {
             "P1": {
                 "type": "Property",
-                "value": 11.0
+                "value": 11
             },
             "P2": {
                 "type": "Property",
@@ -251,7 +251,7 @@ Date: REGEX(.*)
 ============================================
 POST http://REGEX(.*)/notify
 Fiware-Servicepath: /
-Content-Length: 412
+Content-Length: 398
 User-Agent: orion/REGEX(.*)
 Ngsiv2-Attrsformat: normalized
 Host: REGEX(.*)
@@ -264,7 +264,7 @@ Content-Type: application/ld+json
         {
             "P1": {
                 "type": "Property",
-                "value": 11.0
+                "value": 11
             },
             "P2": {
                 "type": "Property",
@@ -272,7 +272,7 @@ Content-Type: application/ld+json
             },
             "P3": {
                 "type": "Property",
-                "value": 3.0
+                "value": 3
             },
             "id": "urn:ngsi-ld:E01",
             "type": "T"

--- a/test/functionalTest/cases/0000_ngsild/ngsild_geoqueries-point.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_geoqueries-point.test
@@ -180,7 +180,7 @@ Date: REGEX(.*)
 05. Geoquery with Max Distance 100000 - all three matching
 ==========================================================
 HTTP/1.1 200 OK
-Content-Length: 438
+Content-Length: 434
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -260,7 +260,7 @@ Date: REGEX(.*)
 07. Geoquery with Max Distance 10 at GeoPoint Leganes - only Leganes matching
 =============================================================================
 HTTP/1.1 200 OK
-Content-Length: 146
+Content-Length: 142
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)

--- a/test/functionalTest/cases/0000_ngsild/ngsild_geoqueries-polygon.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_geoqueries-polygon.test
@@ -155,7 +155,7 @@ Date: REGEX(.*)
 03. Query all entities with a point inside the rectangle: -1,2 - see E1
 =======================================================================
 HTTP/1.1 200 OK
-Content-Length: 223
+Content-Length: 153
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -169,24 +169,24 @@ Date: REGEX(.*)
                 "coordinates": [
                     [
                         [
-                            0.0,
-                            0.0
+                            0,
+                            0
                         ],
                         [
-                            0.0,
-                            4.0
+                            0,
+                            4
                         ],
                         [
-                            -2.0,
-                            4.0
+                            -2,
+                            4
                         ],
                         [
-                            -2.0,
-                            0.0
+                            -2,
+                            0
                         ],
                         [
-                            0.0,
-                            0.0
+                            0,
+                            0
                         ]
                     ]
                 ],
@@ -212,7 +212,7 @@ Date: REGEX(.*)
 05. Query all entities using a rectangle covering E2 and WITHIN:  - see E2
 ==========================================================================
 HTTP/1.1 200 OK
-Content-Length: 136
+Content-Length: 122
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -224,8 +224,8 @@ Date: REGEX(.*)
             "type": "GeoProperty",
             "value": {
                 "coordinates": [
-                    -1.0,
-                    3.0
+                    -1,
+                    3
                 ],
                 "type": "Point"
             }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_inline_context.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_inline_context.test
@@ -136,7 +136,7 @@ Date: REGEX(.*)
 02. Get the entity without context - see long names
 ===================================================
 HTTP/1.1 200 OK
-Content-Length: 306
+Content-Length: 278
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -144,19 +144,19 @@ Date: REGEX(.*)
 {
     "http://example.org/P1": {
         "type": "Property",
-        "value": 1.0
+        "value": 1
     },
     "http://example.org/P2": {
         "type": "Property",
-        "value": 2.0
+        "value": 2
     },
     "http://example.org/P3": {
         "type": "Property",
-        "value": 3.0
+        "value": 3
     },
     "http://example.org/P4": {
         "type": "Property",
-        "value": 4.0
+        "value": 4
     },
     "id": "http://a.b.c/entity/E1",
     "type": "http://example.org/T2"
@@ -166,7 +166,7 @@ Date: REGEX(.*)
 03. Get the entity with context https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld - see its shortnames
 ============================================================================================================================
 HTTP/1.1 200 OK
-Content-Length: 230
+Content-Length: 202
 Content-Type: application/json
 Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -174,19 +174,19 @@ Date: REGEX(.*)
 {
     "P1": {
         "type": "Property",
-        "value": 1.0
+        "value": 1
     },
     "P2": {
         "type": "Property",
-        "value": 2.0
+        "value": 2
     },
     "P3": {
         "type": "Property",
-        "value": 3.0
+        "value": 3
     },
     "http://example.org/P4": {
         "type": "Property",
-        "value": 4.0
+        "value": 4
     },
     "id": "http://a.b.c/entity/E1",
     "type": "T2"

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0019.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0019.test
@@ -199,7 +199,7 @@ bye
 03. GET the entity and see the rounding error
 =============================================
 HTTP/1.1 200 OK
-Content-Length: 517
+Content-Length: 498
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -216,7 +216,7 @@ Date: REGEX(.*)
         },
         "observedAt": "2018-12-04T12:00:00Z",
         "type": "Property",
-        "value": 12.0
+        "value": 12
     },
     "R100": {
         "R1_P1": {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0028.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0028.test
@@ -102,7 +102,7 @@ Date: REGEX(.*)
 03. Get the entity to see the new value of P1
 =============================================
 HTTP/1.1 200 OK
-Content-Length: 315
+Content-Length: 311
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -115,7 +115,7 @@ Date: REGEX(.*)
     "value": "Hola",
     "P1_P1": {
       "type": "Property",
-      "value": 0.790000
+      "value": 0.79
     },
     "P1_R1": {
       "type": "Relationship",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0032.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0032.test
@@ -92,7 +92,7 @@ Date: REGEX(.*)
 02. GET /ngsi-ld/v1/entities to see the 'observedAt' of the attribute P1 as an ISO 8601 string
 ==============================================================================================
 HTTP/1.1 200 OK
-Content-Length: 401
+Content-Length: 390
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -110,7 +110,7 @@ Date: REGEX(.*)
             },
             "observedAt": "2018-12-04T12:00:00Z",
             "type": "Property",
-            "value": 12.0
+            "value": 12
         },
         "R1": {
             "R1_P1": {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_metadata_with_compound_value.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_metadata_with_compound_value.test
@@ -127,7 +127,7 @@ bye
 03. GET the entity
 ==================
 HTTP/1.1 200 OK
-Content-Length: 145
+Content-Length: 124
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -137,12 +137,12 @@ Date: REGEX(.*)
         "M": {
             "type": "Property",
             "value": {
-                "a": 1.0,
-                "b": 2.0
+                "a": 1,
+                "b": 2
             }
         },
         "type": "Property",
-        "value": 12.0
+        "value": 12
     },
     "id": "http://a.b.c/entity/E",
     "type": "TTT"

--- a/test/functionalTest/cases/0000_ngsild/ngsild_modify_attr.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_modify_attr.test
@@ -103,7 +103,7 @@ Date: REGEX(.*)
 02. GET the entity - see P1
 ===========================
 HTTP/1.1 200 OK
-Content-Length: 124
+Content-Length: 117
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -113,7 +113,7 @@ Date: REGEX(.*)
   "type": "T",
   "P1": {
     "type": "Property",
-    "value": 1.000000
+    "value": 1
   }
 }
 
@@ -130,7 +130,7 @@ Date: REGEX(.*)
 04. GET the entity, see new P1
 ==============================
 HTTP/1.1 200 OK
-Content-Length: 124
+Content-Length: 117
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -140,7 +140,7 @@ Date: REGEX(.*)
   "type": "T",
   "P1": {
     "type": "Property",
-    "value": 2.000000
+    "value": 2
   }
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_notification_with_context_in_link_header_or_in_payload.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_notification_with_context_in_link_header_or_in_payload.test
@@ -158,7 +158,7 @@ Date: REGEX(.*)
 ==========================================================================================================
 POST http://REGEX(.*)/notify
 Fiware-Servicepath: /
-Content-Length: 284
+Content-Length: 277
 User-Agent: orion/REGEX(.*)
 Ngsiv2-Attrsformat: normalized
 Host: REGEX(.*)
@@ -171,7 +171,7 @@ Content-Type: application/json; charset=utf-8
         {
             "P1": {
                 "type": "Property",
-                "value": 1.0
+                "value": 1
             },
             "P2": {
                 "type": "Property",
@@ -202,7 +202,7 @@ Date: REGEX(.*)
 =========================================================================
 POST http://REGEX(.*)/notify
 Fiware-Servicepath: /
-Content-Length: 369
+Content-Length: 362
 User-Agent: orion/REGEX(.*)
 Ngsiv2-Attrsformat: normalized
 Host: REGEX(.*)
@@ -215,7 +215,7 @@ Content-Type: application/ld+json
         {
             "P1": {
                 "type": "Property",
-                "value": 1.0
+                "value": 1
             },
             "P2": {
                 "type": "Property",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_notification_with_keyValues.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_notification_with_keyValues.test
@@ -165,7 +165,7 @@ Date: REGEX(.*)
 ========================================================================
 POST http://REGEX(.*)/notify
 Fiware-Servicepath: /
-Content-Length: 313
+Content-Length: 306
 User-Agent: orion/REGEX(.*)
 Ngsiv2-Attrsformat: keyValues
 Host: REGEX(.*)
@@ -176,7 +176,7 @@ Content-Type: application/ld+json
     "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld", 
     "data": [
         {
-            "P1": 1.0,
+            "P1": 1,
             "P2": "ok",
             "id": "urn:ngsi-ld:E01",
             "type": "T"
@@ -202,7 +202,7 @@ Date: REGEX(.*)
 ========================================================================
 POST http://REGEX(.*)/notify
 Fiware-Servicepath: /
-Content-Length: 314
+Content-Length: 307
 User-Agent: orion/REGEX(.*)
 Ngsiv2-Attrsformat: keyValues
 Host: REGEX(.*)
@@ -213,7 +213,7 @@ Content-Type: application/ld+json
     "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld", 
     "data": [
         {
-            "P1": 11.0,
+            "P1": 11,
             "P2": "ok",
             "id": "urn:ngsi-ld:E01",
             "type": "T"
@@ -239,7 +239,7 @@ Date: REGEX(.*)
 ============================================
 POST http://REGEX(.*)/notify
 Fiware-Servicepath: /
-Content-Length: 328
+Content-Length: 314
 User-Agent: orion/REGEX(.*)
 Ngsiv2-Attrsformat: keyValues
 Host: REGEX(.*)
@@ -250,9 +250,9 @@ Content-Type: application/ld+json
     "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld", 
     "data": [
         {
-            "P1": 11.0,
+            "P1": 11,
             "P2": "ok",
-            "P3": 3.0,
+            "P3": 3,
             "id": "urn:ngsi-ld:E01",
             "type": "T"
         }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_observedAt.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_observedAt.test
@@ -80,7 +80,7 @@ Date: REGEX(.*)
 02. Get the entity from broker, see speed::observedAt as a string
 =================================================================
 HTTP/1.1 200 OK
-Content-Length: 182
+Content-Length: 175
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -91,7 +91,7 @@ Date: REGEX(.*)
     "type": "Vehicle",
     "speed": {
       "type": "Property",
-      "value": 22.000000,
+      "value": 22,
       "observedAt": "2012-09-09T12:00:00Z"
     }
   }
@@ -102,7 +102,7 @@ Date: REGEX(.*)
 03. Get the entity with attrList, see speed::observedAt as a string
 ===================================================================
 HTTP/1.1 200 OK
-Content-Length: 160
+Content-Length: 153
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -112,7 +112,7 @@ Date: REGEX(.*)
   "type": "Vehicle",
   "speed": {
     "type": "Property",
-    "value": 22.000000,
+    "value": 22,
     "observedAt": "2012-09-09T12:00:00Z"
   }
 }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_property_with_compound_value.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_property_with_compound_value.test
@@ -115,7 +115,7 @@ bye
 03. GET the entity
 ==================
 HTTP/1.1 200 OK
-Content-Length: 103
+Content-Length: 89
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -124,8 +124,8 @@ Date: REGEX(.*)
     "A": {
         "type": "Property",
         "value": {
-            "a": 1.0,
-            "b": 2.0
+            "a": 1,
+            "b": 2
         }
     },
     "id": "http://a.b.c/entity/E",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_query-by-condition-over-object.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_query-by-condition-over-object.test
@@ -107,7 +107,7 @@ Date: REGEX(.*)
 02. Query with q=R100=="urn:ngsi-ld:T2:6789"
 ============================================
 HTTP/1.1 200 OK
-Content-Length: 519
+Content-Length: 500
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -125,7 +125,7 @@ Date: REGEX(.*)
             },
             "observedAt": "2018-12-04T12:00:00Z",
             "type": "Property",
-            "value": 12.0
+            "value": 12
         },
         "R100": {
             "R1_P1": {
@@ -158,7 +158,7 @@ Date: REGEX(.*)
 03. Same query, but with id=urn:ngsi-ld:T_Query:EntityForQuery2345 also
 =======================================================================
 HTTP/1.1 200 OK
-Content-Length: 519
+Content-Length: 500
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -176,7 +176,7 @@ Date: REGEX(.*)
             },
             "observedAt": "2018-12-04T12:00:00Z",
             "type": "Property",
-            "value": 12.0
+            "value": 12
         },
         "R100": {
             "R1_P1": {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_query_condition_over_compound_value.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_query_condition_over_compound_value.test
@@ -145,7 +145,7 @@ bye
 03. Query the property P100 over its property 'P1' using q=P100.P1==2, see the entity as P100.P1==2 (the property P!, not the compound value item P1)
 =====================================================================================================================================================
 HTTP/1.1 200 OK
-Content-Length: 282
+Content-Length: 261
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -157,12 +157,12 @@ Date: REGEX(.*)
     "P100": {
       "type": "Property",
       "value": {
-        "P1": 1.000000,
-        "P2": 2.000000
+        "P1": 1,
+        "P2": 2
       },
       "P1": {
         "type": "Property",
-        "value": 2.000000
+        "value": 2
       }
     }
   }
@@ -173,7 +173,7 @@ Date: REGEX(.*)
 04. Query the compound value P100[P1]==1, see the entity as P1 inside compound value == 1
 =========================================================================================
 HTTP/1.1 200 OK
-Content-Length: 282
+Content-Length: 261
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -185,12 +185,12 @@ Date: REGEX(.*)
     "P100": {
       "type": "Property",
       "value": {
-        "P1": 1.000000,
-        "P2": 2.000000
+        "P1": 1,
+        "P2": 2
       },
       "P1": {
         "type": "Property",
-        "value": 2.000000
+        "value": 2
       }
     }
   }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_query_condition_over_deep_compound_value.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_query_condition_over_deep_compound_value.test
@@ -88,7 +88,7 @@ Date: REGEX(.*)
 02. Query the property P over its compound value L1.L2.L3.L4, in the fifth level for correct value 12, see the entity
 =====================================================================================================================
 HTTP/1.1 200 OK
-Content-Length: 316
+Content-Length: 309
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -104,7 +104,7 @@ Date: REGEX(.*)
           "L2": {
             "L3": {
               "L4": {
-                "val": 12.000000
+                "val": 12
               }
             }
           }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_query_condition_over_object.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_query_condition_over_object.test
@@ -82,7 +82,7 @@ Date: REGEX(.*)
 02. Query Relationship over its object (really: value)
 ======================================================
 HTTP/1.1 200 OK
-Content-Length: 421
+Content-Length: 414
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -93,7 +93,7 @@ Date: REGEX(.*)
     "type": "T_Query",
     "P1": {
       "type": "Property",
-      "value": 12.000000
+      "value": 12
     },
     "R100": {
       "type": "Relationship",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_query_condition_over_observedAt.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_query_condition_over_observedAt.test
@@ -235,7 +235,7 @@ Date: REGEX(.*)
 04. Query the property P100 over 'observedAt' after 2018-12-04 - see entity urn:ngsi-ld:T_Query:EntityForQuery2345
 ==================================================================================================================
 HTTP/1.1 200 OK
-Content-Length: 826
+Content-Length: 807
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -246,10 +246,10 @@ Date: REGEX(.*)
     "type": "T_Query",
     "P100": {
       "type": "Property",
-      "value": 12.000000,
+      "value": 12,
       "P1_P1": {
         "type": "Property",
-        "value": 0.790000
+        "value": 0.79
       },
       "P1_R1": {
         "type": "Relationship",
@@ -287,7 +287,7 @@ Date: REGEX(.*)
 05. Query the property P100 over 'observedAt' of EXACT 2018-12-04T12:00:00.00Z - see entity urn:ngsi-ld:T_Query:EntityForQuery2345
 ==================================================================================================================================
 HTTP/1.1 200 OK
-Content-Length: 826
+Content-Length: 807
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -298,10 +298,10 @@ Date: REGEX(.*)
     "type": "T_Query",
     "P100": {
       "type": "Property",
-      "value": 12.000000,
+      "value": 12,
       "P1_P1": {
         "type": "Property",
-        "value": 0.790000
+        "value": 0.79
       },
       "P1_R1": {
         "type": "Relationship",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_query_condition_over_property_of_property.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_query_condition_over_property_of_property.test
@@ -136,7 +136,7 @@ MongoDB server version: REGEX(.*)
 				},
 				"P1_P1" : {
 					"type" : "Property",
-					"value" : 0.79REGEX(.*)
+					"value" : 0.79
 				}
 			},
 			"mdNames" : [
@@ -199,7 +199,7 @@ bye
 03. Query the property P100 over its property 'P1_P1'
 =====================================================
 HTTP/1.1 200 OK
-Content-Length: 826
+Content-Length: 807
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -210,10 +210,10 @@ Date: REGEX(.*)
     "type": "T_Query",
     "P100": {
       "type": "Property",
-      "value": 12.000000,
+      "value": 12,
       "P1_P1": {
         "type": "Property",
-        "value": 0.790000
+        "value": 0.79
       },
       "P1_R1": {
         "type": "Relationship",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_query_entities_geo_test_js.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_query_entities_geo_test_js.test
@@ -129,7 +129,7 @@ Date: REGEX(.*)
 05. geoQuery near. Max Distance. The three results
 ==================================================
 HTTP/1.1 200 OK
-Content-Length: 438
+Content-Length: 434
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -182,4 +182,4 @@ Date: REGEX(.*)
 
 --TEARDOWN--
 brokerStop CB
-#dbDrop CB
+dbDrop CB

--- a/test/functionalTest/cases/0000_ngsild/ngsild_should_send_only_one_notification.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_should_send_only_one_notification.test
@@ -21,7 +21,7 @@
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
 --NAME--
-Subscription Creation and a simple notification
+Subscription Creation and update and ONE notification
 
 --SHELL-INIT--
 export BROKER=orionld
@@ -32,13 +32,15 @@ accumulatorStart --pretty-print 127.0.0.1 ${LISTENER_PORT}
 --SHELL--
 
 #
-# 01. An entity urn:ngsi-ld:Vehicle:V1234 is created
-# 02. A Subscription is created, matching the entity urn:ngsi-ld:Vehicle:V1234
-# 03. Dump accumulator to see one notification
+# 01. An entity urn:ngsi-ld:Vehicle:V1234 is created, with speed == 34
+# 02. A Subscription is created, with q == speed>80, NOT matching the entity urn:ngsi-ld:Vehicle:V1234
+# 03. Dump accumulator to see no notification
+# 04. Update speed to 81 (to provoke a notification)
+# 05. Dump accumulator to see ONE notification
 #
 
-echo "01. An entity urn:ngsi-ld:Vehicle:V1234 is created"
-echo "=================================================="
+echo "01. An entity urn:ngsi-ld:Vehicle:V1234 is created, with speed == 34"
+echo "===================================================================="
 payload='{
   "id": "urn:ngsi-ld:Vehicle:V1234",
   "type": "Vehicle",
@@ -56,8 +58,8 @@ echo
 echo
 
 
-echo "02. A Subscription is created, matching the entity urn:ngsi-ld:Vehicle:V1234"
-echo "============================================================================"
+echo "02. A Subscription is created, with q == speed>80, NOT matching the entity urn:ngsi-ld:Vehicle:V1234"
+echo "===================================================================================================="
 payload='{
   "id": "urn:ngsi-ld:Subscription:mySubscription:XXX",
   "type": "Subscription",
@@ -66,6 +68,7 @@ payload='{
       "type": "Vehicle"
     }
   ],
+  "q": "speed>80",
   "notification": {
     "endpoint": {
       "uri": "http://127.0.0.1:'${LISTENER_PORT}'/notify",
@@ -78,16 +81,35 @@ echo
 echo
 
 
-echo "03. Dump accumulator to see one notification"
+echo "03. Dump accumulator to see no notification"
+echo "==========================================="
+sleep .1
+accumulatorDump
+echo
+echo
+
+
+echo "04. Update speed to 81 (to provoke a notification)"
+echo "=================================================="
+payload='{
+  "speed": { "value": 81, "type": "Property" }
+}'
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:Vehicle:V1234/attrs?options=keyValues --payload "$payload"
+echo
+echo
+
+
+echo "05. Dump accumulator to see ONE notification"
 echo "============================================"
+sleep .1
 accumulatorDump
 echo
 echo
 
 
 --REGEXPECT--
-01. An entity urn:ngsi-ld:Vehicle:V1234 is created
-==================================================
+01. An entity urn:ngsi-ld:Vehicle:V1234 is created, with speed == 34
+====================================================================
 HTTP/1.1 201 Created
 Content-Length: 0
 Location: /ngsi-ld/v1/entities/urn:ngsi-ld:Vehicle:V1234
@@ -95,8 +117,8 @@ Date: REGEX(.*)
 
 
 
-02. A Subscription is created, matching the entity urn:ngsi-ld:Vehicle:V1234
-============================================================================
+02. A Subscription is created, with q == speed>80, NOT matching the entity urn:ngsi-ld:Vehicle:V1234
+====================================================================================================
 HTTP/1.1 201 Created
 Content-Length: 0
 Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:mySubscription:XXX
@@ -104,7 +126,19 @@ Date: REGEX(.*)
 
 
 
-03. Dump accumulator to see one notification
+03. Dump accumulator to see no notification
+===========================================
+
+
+04. Update speed to 81 (to provoke a notification)
+==================================================
+HTTP/1.1 204 No Content
+Content-Length: 0
+Date: REGEX(.*)
+
+
+
+05. Dump accumulator to see ONE notification
 ============================================
 POST http://REGEX(.*)/notify
 Fiware-Servicepath: /
@@ -126,7 +160,7 @@ Content-Type: application/json; charset=utf-8
             "id": "urn:ngsi-ld:Vehicle:V1234", 
             "speed": {
                 "type": "Property", 
-                "value": 34
+                "value": 81
             }, 
             "type": "Vehicle"
         }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription-with-geo-polygon.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription-with-geo-polygon.test
@@ -87,7 +87,7 @@ Date: REGEX(.*)
 02. GET the subscription to see the geo-data intact
 ===================================================
 HTTP/1.1 200 OK
-Content-Length: 438
+Content-Length: 406
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_with_one_attribute_with_filter_query.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_with_one_attribute_with_filter_query.test
@@ -172,7 +172,7 @@ Date: REGEX(.*)
 =====================================================
 POST http://REGEX(.*)/notify
 Fiware-Servicepath: /
-Content-Length: 333
+Content-Length: 326
 User-Agent: orion/REGEX(.*)
 Ngsiv2-Attrsformat: normalized
 Host: REGEX(.*)
@@ -190,7 +190,7 @@ Content-Type: application/json; charset=utf-8
             "id": "urn:ngsi-ld:Vehicle:V1234", 
             "speed": {
                 "type": "Property", 
-                "value": 81.0
+                "value": 81
             }, 
             "type": "Vehicle"
         }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_tests_01.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_tests_01.test
@@ -138,7 +138,7 @@ bye
 03. Get the entity from broker
 ==============================
 HTTP/1.1 200 OK
-Content-Length: 329
+Content-Length: 318
 Content-Type: application/json
 Link: <https://forge.etsi.org/gitlab/NGSI-LD/NGSI-LD/raw/master/defaultContext/defaultContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -148,10 +148,10 @@ Date: REGEX(.*)
   "type": "T",
   "P1": {
     "type": "Property",
-    "value": 12.000000,
+    "value": 12,
     "P1_P1": {
       "type": "Property",
-      "value": 0.790000
+      "value": 0.79
     },
     "P1_R1": {
       "type": "Relationship",


### PR DESCRIPTION
Changes in k-libs fixing the problem with trailing zeroes in decimals made a bug number of functests to need modifications.
Also, moved `floatTrim()` from StringFilter.cpp to new module: kbase/kFloatTrim.[ch]
