### PR TITLE
task/191.stringValue-in-orionldContextValueLookup

### DIFF
--- a/src/lib/orionld/context/orionldAliasLookup.cpp
+++ b/src/lib/orionld/context/orionldAliasLookup.cpp
@@ -52,11 +52,11 @@ char* orionldAliasLookup(OrionldContext* contextP, const char* longName)
   }
 
   LM_T(LmtAlias, ("Calling orionldContextValueLookup for long-name '%s'", longName));
-  bool    useStringValue = false;
   LM_T(LmtContextValueLookup, ("CTX:"));
   LM_T(LmtContextValueLookup, ("CTX: =============================== Calling orionldContextValueLookup for '%s'", longName));
-  KjNode* aliasNodeP     = orionldContextValueLookup(contextP, longName, &useStringValue);
+  KjNode* aliasNodeP     = orionldContextValueLookup(contextP, longName);
   LM_T(LmtContextValueLookup, ("CTX: =================================================================================================="));
+
   if (aliasNodeP != NULL)
   {
     if (aliasNodeP->type == KjObject)
@@ -77,7 +77,7 @@ char* orionldAliasLookup(OrionldContext* contextP, const char* longName)
     }
     else
     {
-      char* alias = (useStringValue == false)? aliasNodeP->name : aliasNodeP->value.s;
+      char* alias = aliasNodeP->name;
 
       LM_T(LmtAlias, ("Found the alias: '%s' => '%s'", longName, alias));
       return alias;

--- a/src/lib/orionld/context/orionldContextValueLookup.cpp
+++ b/src/lib/orionld/context/orionldContextValueLookup.cpp
@@ -42,7 +42,7 @@ extern "C"
 //
 // orionldContextValueLookupInArray -
 //
-static KjNode* orionldContextValueLookupInArray(KjNode* contextVector, const char* value, bool* useStringValueP);
+static KjNode* orionldContextValueLookupInArray(KjNode* contextVector, const char* value);
 
 
 
@@ -50,7 +50,7 @@ static KjNode* orionldContextValueLookupInArray(KjNode* contextVector, const cha
 //
 // orionldContextValueLookupInUrl -
 //
-static KjNode* orionldContextValueLookupInUrl(char* contextUrl, const char* value, bool* useStringValueP)
+static KjNode* orionldContextValueLookupInUrl(char* contextUrl, const char* value)
 {
   LM_T(LmtContextValueLookup, ("CTX: Looking up '%s' in URI STRING context '%s'", value, contextUrl));
 
@@ -62,7 +62,7 @@ static KjNode* orionldContextValueLookupInUrl(char* contextUrl, const char* valu
     return NULL;
   }
 
-  return orionldContextValueLookup(contextP, value, useStringValueP);
+  return orionldContextValueLookup(contextP, value);
 }
 
 
@@ -71,7 +71,7 @@ static KjNode* orionldContextValueLookupInUrl(char* contextUrl, const char* valu
 //
 // orionldContextValueLookupInObject -
 //
-static KjNode* orionldContextValueLookupInObject(KjNode* contextP, const char* value, bool* useStringValueP)
+static KjNode* orionldContextValueLookupInObject(KjNode* contextP, const char* value)
 {
   LM_T(LmtContextValueLookup, ("CTX: Looking up '%s' in OBJECT context '%s'", value, contextP->name));
 
@@ -98,7 +98,6 @@ static KjNode* orionldContextValueLookupInObject(KjNode* contextP, const char* v
         {
           if (SCOMPARE4(idNodeP->name, '@', 'i', 'd', 0))
           {
-            *useStringValueP = false;  // FIXME - useStringValueP not needed!
             if (strcmp(idNodeP->value.s, value) == 0)
               return contextItemP;
           }
@@ -117,11 +116,11 @@ static KjNode* orionldContextValueLookupInObject(KjNode* contextP, const char* v
     KjNode* firstChildP = contextP->value.firstChildP;
 
     if (firstChildP->type == KjArray)
-      return orionldContextValueLookupInArray(firstChildP, value, useStringValueP);
+      return orionldContextValueLookupInArray(firstChildP, value);
     else if (firstChildP->type == KjObject)
-      return orionldContextValueLookupInObject(firstChildP, value, useStringValueP);
+      return orionldContextValueLookupInObject(firstChildP, value);
     else if (firstChildP->type == KjString)
-      return orionldContextValueLookupInUrl(firstChildP->value.s, value, useStringValueP);
+      return orionldContextValueLookupInUrl(firstChildP->value.s, value);
     else
       LM_E(("CTX: invalid type: %s", kjValueType(firstChildP->type)));
   }
@@ -140,7 +139,7 @@ static KjNode* orionldContextValueLookupInObject(KjNode* contextP, const char* v
 //
 // orionldContextValueLookupInArray -
 //
-static KjNode* orionldContextValueLookupInArray(KjNode* contextVector, const char* value, bool* useStringValueP)
+static KjNode* orionldContextValueLookupInArray(KjNode* contextVector, const char* value)
 {
   LM_T(LmtContextValueLookup, ("CTX: Looking up '%s' in ARRAY context '%s'", value, contextVector->name));
 
@@ -149,9 +148,9 @@ static KjNode* orionldContextValueLookupInArray(KjNode* contextVector, const cha
     KjNode* itemP;
 
     if (contextNodeP->type == KjString)
-      itemP = orionldContextValueLookupInUrl(contextNodeP->value.s, value, useStringValueP);
+      itemP = orionldContextValueLookupInUrl(contextNodeP->value.s, value);
     else if (contextNodeP->type == KjObject)
-      itemP = orionldContextValueLookupInObject(contextNodeP, value, useStringValueP);
+      itemP = orionldContextValueLookupInObject(contextNodeP, value);
     else
     {
       LM_E(("Invalid array member - must be String or Object, not '%s'", kjValueType(contextNodeP->type)));
@@ -171,21 +170,19 @@ static KjNode* orionldContextValueLookupInArray(KjNode* contextVector, const cha
 //
 // orionldContextValueLookup -
 //
-KjNode* orionldContextValueLookup(OrionldContext* contextP, const char* value, bool* useStringValueP)
+KjNode* orionldContextValueLookup(OrionldContext* contextP, const char* value)
 {
-  *useStringValueP = false;
-
   if (contextP == NULL)
     return NULL;
 
   LM_T(LmtContextValueLookup, ("CTX: Looking up '%s' in context '%s' (which is of type '%s')", value, contextP->url, kjValueType(contextP->tree->type)));
 
   if (contextP->tree->type == KjString)
-    return orionldContextValueLookupInUrl(contextP->tree->value.s, value, useStringValueP);
+    return orionldContextValueLookupInUrl(contextP->tree->value.s, value);
   else if (contextP->tree->type == KjArray)
-    return orionldContextValueLookupInArray(contextP->tree, value, useStringValueP);
+    return orionldContextValueLookupInArray(contextP->tree, value);
   else if (contextP->tree->type == KjObject)
-    return orionldContextValueLookupInObject(contextP->tree, value, useStringValueP);
+    return orionldContextValueLookupInObject(contextP->tree, value);
 
   LM_E(("Error: contexts must be either a String, an Object ot an Array"));
   return NULL;

--- a/src/lib/orionld/context/orionldContextValueLookup.h
+++ b/src/lib/orionld/context/orionldContextValueLookup.h
@@ -38,7 +38,7 @@ extern "C"
 //
 // orionldContextValueLookup -
 //
-extern KjNode* orionldContextValueLookup(OrionldContext* contextP, const char* value, bool* useStringValueP);
+extern KjNode* orionldContextValueLookup(OrionldContext* contextP, const char* value);
 
 
 

--- a/src/lib/orionld/context/orionldUserContextKeyValuesCheck.cpp
+++ b/src/lib/orionld/context/orionldUserContextKeyValuesCheck.cpp
@@ -79,9 +79,7 @@ static bool orionldUserContextKeyValuesCheck2(KjNode* tree, char* url, char** de
     }
     if (childP->type == KjString)
     {
-      bool useStringValue = false;
-
-      if (orionldContextValueLookup(&orionldCoreContext, childP->value.s, &useStringValue) != NULL)
+      if (orionldContextValueLookup(&orionldCoreContext, childP->value.s) != NULL)
       {
         LM_E(("In context '%s', the context item '%s' uses a value from the Core Context (%s)",
               url, childP->name, childP->value.s));
@@ -104,11 +102,9 @@ static bool orionldUserContextKeyValuesCheck2(KjNode* tree, char* url, char** de
 
         if (SCOMPARE4(itemP->name, '@', 'i', 'd', 0))
         {
-          bool useStringValue = false;
-
           atidP = itemP;
           LM_T(LmtContext, ("Checking value '%s' for iten named '%s'", itemP->value.s, itemP->name));
-          if (orionldContextValueLookup(&orionldCoreContext, itemP->value.s, &useStringValue) != NULL)
+          if (orionldContextValueLookup(&orionldCoreContext, itemP->value.s) != NULL)
           {
             LM_E(("In context '%s', the context item '%s' of '%s' uses a value from the Core Context (%s)",
                   url, itemP->name, childP->name, itemP->value.s));

--- a/src/lib/orionld/kjTree/kjTreeFromQueryContextResponseWithAttrList.cpp
+++ b/src/lib/orionld/kjTree/kjTreeFromQueryContextResponseWithAttrList.cpp
@@ -248,15 +248,12 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
 
       if (nodeP == NULL)
       {
-        bool    useStringValue = false;
-        KjNode* aliasNodeP     = orionldContextValueLookup(contextP, ceP->entityId.type.c_str(), &useStringValue);
+        KjNode* aliasNodeP     = orionldContextValueLookup(contextP, ceP->entityId.type.c_str());
 
         if (aliasNodeP != NULL)
         {
-          char* alias = (useStringValue == false)? aliasNodeP->name: aliasNodeP->value.s;
-
-          LM_T(LmtAlias, ("Found the alias: '%s' => '%s'", ceP->entityId.type.c_str(), alias));
-          nodeP = kjString(orionldState.kjsonP, "type", alias);
+          LM_T(LmtAlias, ("Found the alias: '%s' => '%s'", ceP->entityId.type.c_str(), aliasNodeP->name));
+          nodeP = kjString(orionldState.kjsonP, "type", aliasNodeP->name);
         }
         else
         {
@@ -307,19 +304,16 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
 
       // Is it the default URL ?
       if ((orionldDefaultUrlLen != -1) && (strncmp(attrName, orionldDefaultUrl, orionldDefaultUrlLen) == 0))
-      {
         attrName = &attrName[orionldDefaultUrlLen];
-      }
       else
       {
         //
         // Lookup alias for the Attribute Name
         //
-        bool    useStringValue = false;
-        KjNode* aliasNodeP     = orionldContextValueLookup(contextP, aP->name.c_str(), &useStringValue);
+        KjNode* aliasNodeP = orionldContextValueLookup(contextP, aP->name.c_str());
 
         if (aliasNodeP != NULL)
-          attrName = (useStringValue == false)? aliasNodeP->name : aliasNodeP->value.s;
+          attrName = aliasNodeP->name;
       }
 
       char* match;


### PR DESCRIPTION
Removed unused parameter 'useStringValueP' from orionldContextValueLookup, making  the function *much* easier to understand - it was a bit confusing ...