### PR TITLE
Fixed a bug in initialization of orionldState

### DIFF
--- a/src/lib/orionld/common/orionldState.cpp
+++ b/src/lib/orionld/common/orionldState.cpp
@@ -105,6 +105,8 @@ void orionldStateInit(void)
   orionldState.payloadContextNode          = NULL;
   orionldState.payloadIdNode               = NULL;
   orionldState.payloadTypeNode             = NULL;
+  orionldState.acceptJson                  = false;
+  orionldState.acceptJsonld                = false;
 }
 
 


### PR DESCRIPTION
Fixed a bug in initialization of `orionldState`.
`acceptJson` and `acceptJsonld` weren't set to false in `orionldStateInit`.
This should fix issue  #160, that is real after all, I was just not lucky enough to reproduce it ...