### PR TITLE
hardening/200.startup-error-due-to-mongo-oid

### DIFF
--- a/src/lib/mongoBackend/mongoSubCache.cpp
+++ b/src/lib/mongoBackend/mongoSubCache.cpp
@@ -40,7 +40,7 @@
 #include "cache/subCache.h"
 
 #ifdef ORIONLD
-#include "orionld/common/OrionldConnection.h"                  // orionldState
+#include "orionld/common/orionldState.h"                        // orionldState
 #endif
 
 #include "mongoBackend/MongoGlobal.h"
@@ -123,7 +123,7 @@ int mongoSubCacheItemInsert(const char* tenant, const BSONObj& sub)
   //        Should check whether the subscription was created with NGSI-LD or not
   //        I can always check idField.toString().c_str() ...
   //
-  if (orionldState.apiVersion == NGSI_LD_V1)
+  if ((orionldState.apiVersion == NGSI_LD_V1) || (firstSubCacheRefresh == true))
     cSubP->subscriptionId        = strdup(idField.toString().c_str());
   else
     cSubP->subscriptionId        = strdup(idField.OID().toString().c_str());
@@ -506,6 +506,7 @@ void mongoSubCacheRefresh(const std::string& database)
   }
   releaseMongoConnection(connection);
 
+  firstSubCacheRefresh = false;
   LM_T(LmtSubCache, ("Added %d subscriptions for database '%s'", subNo, database.c_str()));
 }
 

--- a/src/lib/orionld/common/orionldState.cpp
+++ b/src/lib/orionld/common/orionldState.cpp
@@ -35,7 +35,7 @@ extern "C"
 
 #include "orionld/context/orionldContextFree.h"                // orionldContextFree
 #include "orionld/common/QNode.h"                              // QNode
-#include "orionld/common/OrionldConnection.h"                  // OrionldConnectionState
+#include "orionld/common/orionldState.h"                       // Own interface
 
 
 
@@ -55,13 +55,14 @@ __thread OrionldConnectionState orionldState = { 0 };
 // orionldThreadState.cpp/h
 // orionldGlobalState.cpp/h
 //
-int             requestNo                = 0;             // Never mind protecting with semaphore. Just a debugging help
-char            kallocBuffer[32 * 1024];
-KAlloc          kalloc;
-Kjson           kjson;
-Kjson*          kjsonP;
-uint16_t        portNo                   = 0;
-char*           hostname                 = (char*) "localhost";
+int       requestNo                = 0;             // Never mind protecting with semaphore. Just a debugging help
+char      kallocBuffer[32 * 1024];
+KAlloc    kalloc;
+Kjson     kjson;
+Kjson*    kjsonP;
+uint16_t  portNo                   = 0;
+char*     hostname                 = (char*) "localhost";
+bool      firstSubCacheRefresh     = true;
 
 
 

--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -149,6 +149,7 @@ extern Kjson     kjson;
 extern Kjson*    kjsonP;
 extern char*     hostname;
 extern uint16_t  portNo;
+extern bool      firstSubCacheRefresh;
 
 
 


### PR DESCRIPTION
Existing ngsi-ld subscriptions made initial sub-cache-population crash due to sub::id not mongo::OID.

Put on hold, for now, due to two errors;
* unit test: mongoUpdateContext_withOnchangeSubscriptions.Cond1_updateMatch
* func test: cache_population_at_init.test