### PR TITLE
task/202.orionldErrorResponseCreate-without-ciP

### DIFF
--- a/src/lib/orionld/common/CHECK.h
+++ b/src/lib/orionld/common/CHECK.h
@@ -38,7 +38,7 @@ do                                                                              
   if (pointer != NULL)                                                                                                                \
   {                                                                                                                                   \
     LM_E(("Duplicated attribute: '%s'", fieldName));                                                                                  \
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Duplicated field", fieldName, OrionldDetailsString);                      \
+    orionldErrorResponseCreate(OrionldBadRequestData, "Duplicated field", fieldName, OrionldDetailsString);                           \
     ciP->httpStatusCode = SccBadRequest;                                                                                              \
     return false;                                                                                                                     \
   }                                                                                                                                   \
@@ -56,7 +56,7 @@ do                                                                              
 {                                                                                                                                     \
   if (alreadyPresent == true)                                                                                                         \
   {                                                                                                                                   \
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Duplicated field", fieldName, OrionldDetailsString);                      \
+    orionldErrorResponseCreate(OrionldBadRequestData, "Duplicated field", fieldName, OrionldDetailsString);                           \
     ciP->httpStatusCode = SccBadRequest;                                                                                              \
     return false;                                                                                                                     \
   }                                                                                                                                   \
@@ -75,7 +75,7 @@ do                                                                              
 {                                                                                                                                 \
   if (nodeP->type != KjObject)                                                                                                    \
   {                                                                                                                               \
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Not a JSON Object", what, OrionldDetailsString);                      \
+    orionldErrorResponseCreate(OrionldBadRequestData, "Not a JSON Object", what, OrionldDetailsString);                           \
     ciP->httpStatusCode = SccBadRequest;                                                                                          \
     return false;                                                                                                                 \
   }                                                                                                                               \
@@ -87,15 +87,15 @@ do                                                                              
 //
 // ARRAY_CHECK -
 //
-#define ARRAY_CHECK(kNodeP, fieldName)                                                                                                       \
-do                                                                                                                                           \
-{                                                                                                                                            \
-  if (kNodeP->type != KjArray)                                                                                                               \
-  {                                                                                                                                          \
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "not a JSON Array", fieldName, OrionldDetailsString);                             \
-    ciP->httpStatusCode = SccBadRequest;                                                                                                     \
-    return false;                                                                                                                            \
-  }                                                                                                                                          \
+#define ARRAY_CHECK(kNodeP, fieldName)                                                                                            \
+do                                                                                                                                \
+{                                                                                                                                 \
+  if (kNodeP->type != KjArray)                                                                                                    \
+  {                                                                                                                               \
+    orionldErrorResponseCreate(OrionldBadRequestData, "not a JSON Array", fieldName, OrionldDetailsString);                       \
+    ciP->httpStatusCode = SccBadRequest;                                                                                          \
+    return false;                                                                                                                 \
+  }                                                                                                                               \
 } while (0)
 
 
@@ -104,15 +104,15 @@ do                                                                              
 //
 // EMPTY_ARRAY_CHECK -
 //
-#define EMPTY_ARRAY_CHECK(kNodeP, what)                                                                                  \
-do                                                                                                                       \
-{                                                                                                                        \
-  if (kNodeP->value.firstChildP == NULL)                                                                                 \
-  {                                                                                                                      \
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Empty Array", what, OrionldDetailsString);                   \
-    ciP->httpStatusCode = SccBadRequest;                                                                                 \
-    return false;                                                                                                        \
-  }                                                                                                                      \
+#define EMPTY_ARRAY_CHECK(kNodeP, what)                                                                                           \
+do                                                                                                                                \
+{                                                                                                                                 \
+  if (kNodeP->value.firstChildP == NULL)                                                                                          \
+  {                                                                                                                               \
+    orionldErrorResponseCreate(OrionldBadRequestData, "Empty Array", what, OrionldDetailsString);                                 \
+    ciP->httpStatusCode = SccBadRequest;                                                                                          \
+    return false;                                                                                                                 \
+  }                                                                                                                               \
 } while (0)
 
 
@@ -126,7 +126,7 @@ do                                                                              
 {                                                                                                                                 \
   if (nodeP->type != KjObject)                                                                                                    \
   {                                                                                                                               \
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Attribute must be a JSON object", nodeP->name, OrionldDetailsString); \
+    orionldErrorResponseCreate(OrionldBadRequestData, "Attribute must be a JSON object", nodeP->name, OrionldDetailsString);      \
     ciP->httpStatusCode = SccBadRequest;                                                                                          \
     return false;                                                                                                                 \
   }                                                                                                                               \
@@ -138,15 +138,15 @@ do                                                                              
 //
 // STRING_CHECK -
 //
-#define STRING_CHECK(kNodeP, fieldName)                                                                                                      \
-do                                                                                                                                           \
-{                                                                                                                                            \
-  if (kNodeP->type != KjString)                                                                                                              \
-  {                                                                                                                                          \
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Not a JSON String", fieldName, OrionldDetailsString);                            \
-    ciP->httpStatusCode = SccBadRequest;                                                                                                     \
-    return false;                                                                                                                            \
-  }                                                                                                                                          \
+#define STRING_CHECK(kNodeP, fieldName)                                                                                           \
+do                                                                                                                                \
+{                                                                                                                                 \
+  if (kNodeP->type != KjString)                                                                                                   \
+  {                                                                                                                               \
+    orionldErrorResponseCreate(OrionldBadRequestData, "Not a JSON String", fieldName, OrionldDetailsString);                      \
+    ciP->httpStatusCode = SccBadRequest;                                                                                          \
+    return false;                                                                                                                 \
+  }                                                                                                                               \
 } while (0)
 
 
@@ -155,15 +155,15 @@ do                                                                              
 //
 // INTEGER_CHECK -
 //
-#define INTEGER_CHECK(nodeP, fieldName)                                                                                                      \
-do                                                                                                                                           \
-{                                                                                                                                            \
-  if (nodeP->type != KjInt)                                                                                                                  \
-  {                                                                                                                                          \
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Not a JSON Integer", fieldName, OrionldDetailsString);                           \
-    ciP->httpStatusCode = SccBadRequest;                                                                                                     \
-    return false;                                                                                                                            \
-  }                                                                                                                                          \
+#define INTEGER_CHECK(nodeP, fieldName)                                                                                           \
+do                                                                                                                                \
+{                                                                                                                                 \
+  if (nodeP->type != KjInt)                                                                                                       \
+  {                                                                                                                               \
+    orionldErrorResponseCreate(OrionldBadRequestData, "Not a JSON Integer", fieldName, OrionldDetailsString);                     \
+    ciP->httpStatusCode = SccBadRequest;                                                                                          \
+    return false;                                                                                                                 \
+  }                                                                                                                               \
 } while (0)
 
 
@@ -172,15 +172,15 @@ do                                                                              
 //
 // BOOL_CHECK -
 //
-#define BOOL_CHECK(kNodeP, fieldName)                                                                                                 \
-do                                                                                                                                    \
-{                                                                                                                                     \
-  if (kNodeP->type != KjBoolean)                                                                                                      \
-  {                                                                                                                                   \
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Not a JSON Boolean", fieldName, OrionldDetailsString);                    \
-    ciP->httpStatusCode = SccBadRequest;                                                                                              \
-    return false;                                                                                                                     \
-  }                                                                                                                                   \
+#define BOOL_CHECK(kNodeP, fieldName)                                                                                             \
+do                                                                                                                                \
+{                                                                                                                                 \
+  if (kNodeP->type != KjBoolean)                                                                                                  \
+  {                                                                                                                               \
+    orionldErrorResponseCreate(OrionldBadRequestData, "Not a JSON Boolean", fieldName, OrionldDetailsString);                     \
+    ciP->httpStatusCode = SccBadRequest;                                                                                          \
+    return false;                                                                                                                 \
+  }                                                                                                                               \
 } while (0)
 
 
@@ -189,15 +189,15 @@ do                                                                              
 //
 // DATETIME_CHECK -
 //
-#define DATETIME_CHECK(stringValue, fieldName)                                                                                        \
-do                                                                                                                                    \
-{                                                                                                                                     \
-  if (parse8601Time(stringValue) == -1)                                                                                               \
-  {                                                                                                                                   \
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid DateTime value", fieldName, OrionldDetailsString);                \
-    ciP->httpStatusCode = SccBadRequest;                                                                                              \
-    return false;                                                                                                                     \
-  }                                                                                                                                   \
+#define DATETIME_CHECK(stringValue, fieldName)                                                                                    \
+do                                                                                                                                \
+{                                                                                                                                 \
+  if (parse8601Time(stringValue) == -1)                                                                                           \
+  {                                                                                                                               \
+    orionldErrorResponseCreate(OrionldBadRequestData, "Invalid DateTime value", fieldName, OrionldDetailsString);                 \
+    ciP->httpStatusCode = SccBadRequest;                                                                                          \
+    return false;                                                                                                                 \
+  }                                                                                                                               \
 } while (0)
 
 
@@ -206,16 +206,16 @@ do                                                                              
 //
 // ARRAY_OR_STRING_CHECK -
 //
-#define ARRAY_OR_STRING_CHECK(nodeP, what)                                                                             \
-do                                                                                                                     \
-{                                                                                                                      \
-  if ((nodeP->type != KjArray) && (nodeP->type != KjString))                                                           \
-  {                                                                                                                    \
-    LM_T(LmtPayloadCheck, ("the node is a '%s'", kjValueType(nodeP->type)));                                           \
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Not a JSON Array nor String", what, OrionldDetailsString); \
-    ciP->httpStatusCode = SccBadRequest;                                                                               \
-    return false;                                                                                                      \
-  }                                                                                                                    \
+#define ARRAY_OR_STRING_CHECK(nodeP, what)                                                                                        \
+do                                                                                                                                \
+{                                                                                                                                 \
+  if ((nodeP->type != KjArray) && (nodeP->type != KjString))                                                                      \
+  {                                                                                                                               \
+    LM_T(LmtPayloadCheck, ("the node is a '%s'", kjValueType(nodeP->type)));                                                      \
+    orionldErrorResponseCreate(OrionldBadRequestData, "Not a JSON Array nor String", what, OrionldDetailsString);                 \
+    ciP->httpStatusCode = SccBadRequest;                                                                                          \
+    return false;                                                                                                                 \
+  }                                                                                                                               \
 } while (0)
 
 
@@ -224,16 +224,16 @@ do                                                                              
 //
 // ARRAY_OR_STRING_OR_OBJECT_CHECK -
 //
-#define ARRAY_OR_STRING_OR_OBJECT_CHECK(nodeP, what)                                                                                \
-do                                                                                                                                  \
-{                                                                                                                                   \
-  if ((nodeP->type != KjArray) && (nodeP->type != KjString) && (nodeP->type != KjObject))                                           \
-  {                                                                                                                                 \
-    LM_T(LmtPayloadCheck, ("the node is a '%s'", kjValueType(nodeP->type)));                                                        \
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Not a JSON Array nor Object nor a String", what, OrionldDetailsString); \
-    ciP->httpStatusCode = SccBadRequest;                                                                                            \
-    return false;                                                                                                                   \
-  }                                                                                                                                 \
+#define ARRAY_OR_STRING_OR_OBJECT_CHECK(nodeP, what)                                                                              \
+do                                                                                                                                \
+{                                                                                                                                 \
+  if ((nodeP->type != KjArray) && (nodeP->type != KjString) && (nodeP->type != KjObject))                                         \
+  {                                                                                                                               \
+    LM_T(LmtPayloadCheck, ("the node is a '%s'", kjValueType(nodeP->type)));                                                      \
+    orionldErrorResponseCreate(OrionldBadRequestData, "Not a JSON Array nor Object nor a String", what, OrionldDetailsString);    \
+    ciP->httpStatusCode = SccBadRequest;                                                                                          \
+    return false;                                                                                                                 \
+  }                                                                                                                               \
 } while (0)
 
 #endif  // SRC_LIB_ORIONLD_COMMON_CHECK_H_

--- a/src/lib/orionld/common/orionldAttributeTreat.cpp
+++ b/src/lib/orionld/common/orionldAttributeTreat.cpp
@@ -47,13 +47,13 @@ extern "C"
 //
 // ATTRIBUTE_ERROR -
 //
-#define ATTRIBUTE_ERROR(errorString, details)                                                            \
-do                                                                                                       \
-{                                                                                                        \
-  LM_E((errorString));                                                                                   \
-  orionldErrorResponseCreate(ciP, OrionldBadRequestData, errorString, details, OrionldDetailsAttribute); \
-  ciP->httpStatusCode = SccBadRequest;                                                                   \
-  return false;                                                                                          \
+#define ATTRIBUTE_ERROR(errorString, details)                                                        \
+do                                                                                                   \
+{                                                                                                    \
+  LM_E((errorString));                                                                               \
+  orionldErrorResponseCreate(OrionldBadRequestData, errorString, details, OrionldDetailsAttribute);  \
+  ciP->httpStatusCode = SccBadRequest;                                                               \
+  return false;                                                                                      \
 } while (0)
 
 
@@ -123,7 +123,7 @@ static bool compoundValueNodeValueSet(ConnectionInfo* ciP, orion::CompoundValueN
   else
   {
     LM_E(("Invalid json type (KjNone!) for value field of compound '%s'", cNodeP->name.c_str()));
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Internal error", "Invalid type from kjson", OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Internal error", "Invalid type from kjson", OrionldDetailsString);
     return false;
   }
 
@@ -193,7 +193,7 @@ static bool specialCompoundCheck(ConnectionInfo* ciP, KjNode* compoundValueP)
   {
     if (otherNodeP != NULL)
     {
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "unwanted extra items in @value/@type compound", otherNodeP->name, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "unwanted extra items in @value/@type compound", otherNodeP->name, OrionldDetailsString);
       ciP->httpStatusCode = SccBadRequest;
       return false;
     }
@@ -211,7 +211,7 @@ static bool specialCompoundCheck(ConnectionInfo* ciP, KjNode* compoundValueP)
   {
     if (otherNodeP != NULL)
     {
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "unwanted extra items in @value/@type compound", otherNodeP->name, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "unwanted extra items in @value/@type compound", otherNodeP->name, OrionldDetailsString);
       ciP->httpStatusCode = SccBadRequest;
       return false;
     }
@@ -220,7 +220,7 @@ static bool specialCompoundCheck(ConnectionInfo* ciP, KjNode* compoundValueP)
   {
     if (valueNodeP == NULL)
     {
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "missing @value in @value/@type compound", "@value is mandatory", OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "missing @value in @value/@type compound", "@value is mandatory", OrionldDetailsString);
       ciP->httpStatusCode = SccBadRequest;
       return false;
     }
@@ -248,7 +248,7 @@ static bool attributeValueSet(ConnectionInfo* ciP, ContextAttribute* caP, KjNode
   case KjNull:       caP->valueType = orion::ValueTypeNull;    break;
   case KjNone:
     LM_E(("Invalid type from kjson"));
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Internal error", "Invalid type from kjson", OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Internal error", "Invalid type from kjson", OrionldDetailsString);
     ciP->httpStatusCode = SccReceiverInternalError;
     return false;
   }
@@ -281,7 +281,7 @@ static bool metadataValueSet(ConnectionInfo* ciP, Metadata* mdP, KjNode* valueNo
   case KjNull:       mdP->valueType = orion::ValueTypeNull;    break;
   case KjNone:
     LM_E(("Invalid json type (KjNone!) for value field of metadata '%s'", valueNodeP->name));
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Internal error", "Invalid type from kjson", OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Internal error", "Invalid type from kjson", OrionldDetailsString);
     ciP->httpStatusCode = SccReceiverInternalError;
     return false;
   }
@@ -321,7 +321,7 @@ static bool metadataAdd(ConnectionInfo* ciP, ContextAttribute* caP, KjNode* node
         else
         {
           LM_E(("Invalid type for metadata '%s': '%s'", kNodeP->name, kNodeP->value.s));
-          orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid type for attribute", kNodeP->value.s, OrionldDetailsString);
+          orionldErrorResponseCreate(OrionldBadRequestData, "Invalid type for attribute", kNodeP->value.s, OrionldDetailsString);
           return false;
         }
 
@@ -342,20 +342,20 @@ static bool metadataAdd(ConnectionInfo* ciP, ContextAttribute* caP, KjNode* node
     if (typeNodeP == NULL)
     {
       LM_E(("No type for metadata '%s'", nodeP->name));
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "The type field is missing for a metadata", nodeP->name, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "The type field is missing for a metadata", nodeP->name, OrionldDetailsString);
       return false;
     }
 
     if ((isProperty == true) && (valueNodeP == NULL))
     {
       LM_E(("No value for Property metadata '%s'", nodeP->name));
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "The value field is missing for a Property metadata", nodeP->name, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "The value field is missing for a Property metadata", nodeP->name, OrionldDetailsString);
       return false;
     }
     else if ((isRelationship == true) && (objectNodeP == NULL))
     {
       LM_E(("No 'object' for Relationship metadata '%s'", nodeP->name));
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "The value field is missing for a Relationship metadata", nodeP->name, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "The value field is missing for a Relationship metadata", nodeP->name, OrionldDetailsString);
       return false;
     }
   }
@@ -370,7 +370,7 @@ static bool metadataAdd(ConnectionInfo* ciP, ContextAttribute* caP, KjNode* node
   if (mdP == NULL)
   {
     LM_E(("out of memory creating property/relationship '%s' for attribute '%s'", nodeP->name, caName));
-    orionldErrorResponseCreate(ciP, OrionldInternalError, "cannot create property/relationship for attribute", "out of memory", OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldInternalError, "cannot create property/relationship for attribute", "out of memory", OrionldDetailsString);
     return false;
   }
 
@@ -394,7 +394,7 @@ static bool metadataAdd(ConnectionInfo* ciP, ContextAttribute* caP, KjNode* node
     if (objectNodeP->type != KjString)
     {
       LM_E(("invalid json type for relationship-object '%s' of attribute '%s'", nodeP->name, caName));
-      orionldErrorResponseCreate(ciP, OrionldInternalError, "invalid json type for relationship-object", nodeP->name, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldInternalError, "invalid json type for relationship-object", nodeP->name, OrionldDetailsString);
       delete mdP;
       return false;
     }
@@ -475,7 +475,7 @@ bool orionldAttributeTreat(ConnectionInfo* ciP, KjNode* kNodeP, ContextAttribute
 
         if (orionldState.locationAttributeP != NULL)
         {
-          orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Multiple attributes cannot be defined using the GeoProperty type", nodeP->name, OrionldDetailsString);
+          orionldErrorResponseCreate(OrionldBadRequestData, "Multiple attributes cannot be defined using the GeoProperty type", nodeP->name, OrionldDetailsString);
           return false;
         }
 
@@ -489,7 +489,7 @@ bool orionldAttributeTreat(ConnectionInfo* ciP, KjNode* kNodeP, ContextAttribute
       else
       {
         LM_E(("Invalid type for attribute '%s': '%s'", nodeP->name, nodeP->value.s));
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid type for attribute", nodeP->value.s, OrionldDetailsString);
+        orionldErrorResponseCreate(OrionldBadRequestData, "Invalid type for attribute", nodeP->value.s, OrionldDetailsString);
         return false;
       }
 
@@ -506,7 +506,7 @@ bool orionldAttributeTreat(ConnectionInfo* ciP, KjNode* kNodeP, ContextAttribute
       if (metadataAdd(ciP, caP, nodeP, caName) == false)
       {
         LM_E(("Error adding metadata '%s' to attribute", nodeP->name));
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Error adding metadata to attribute", nodeP->name, OrionldDetailsString);
+        orionldErrorResponseCreate(OrionldBadRequestData, "Error adding metadata to attribute", nodeP->name, OrionldDetailsString);
         return false;
       }
     }
@@ -541,7 +541,7 @@ bool orionldAttributeTreat(ConnectionInfo* ciP, KjNode* kNodeP, ContextAttribute
       if (metadataAdd(ciP, caP, nodeP, caName) == false)
       {
         LM_E(("Error adding metadata '%s' to attribute", nodeP->name));
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Error adding metadata to attribute", nodeP->name, OrionldDetailsString);
+        orionldErrorResponseCreate(OrionldBadRequestData, "Error adding metadata to attribute", nodeP->name, OrionldDetailsString);
         return false;
       }
     }
@@ -551,7 +551,7 @@ bool orionldAttributeTreat(ConnectionInfo* ciP, KjNode* kNodeP, ContextAttribute
       if (metadataAdd(ciP, caP, nodeP, caName) == false)
       {
         LM_E(("Error adding metadata '%s' to attribute", nodeP->name));
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Error adding metadata to attribute", nodeP->name, OrionldDetailsString);
+        orionldErrorResponseCreate(OrionldBadRequestData, "Error adding metadata to attribute", nodeP->name, OrionldDetailsString);
         return false;
       }
     }
@@ -561,7 +561,7 @@ bool orionldAttributeTreat(ConnectionInfo* ciP, KjNode* kNodeP, ContextAttribute
       if (metadataAdd(ciP, caP, nodeP, caName) == false)
       {
         LM_E(("Error adding metadata '%s' to attribute", nodeP->name));
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Error adding metadata to attribute", nodeP->name, OrionldDetailsString);
+        orionldErrorResponseCreate(OrionldBadRequestData, "Error adding metadata to attribute", nodeP->name, OrionldDetailsString);
         return false;
       }
     }
@@ -570,14 +570,14 @@ bool orionldAttributeTreat(ConnectionInfo* ciP, KjNode* kNodeP, ContextAttribute
       if (caP->metadataVector.lookupByName(nodeP->name) != NULL)
       {
         LM_E(("Duplicated attribute property '%s' for attribute '%s'", nodeP->name, caP->name.c_str()));
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Duplicated attribute property", nodeP->name, OrionldDetailsString);
+        orionldErrorResponseCreate(OrionldBadRequestData, "Duplicated attribute property", nodeP->name, OrionldDetailsString);
         return false;
       }
 
       if (metadataAdd(ciP, caP, nodeP, caName) == false)
       {
         LM_E(("Error adding metadata '%s' to attribute", nodeP->name));
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Error adding metadata to an attribute", nodeP->name, OrionldDetailsString);
+        orionldErrorResponseCreate(OrionldBadRequestData, "Error adding metadata to an attribute", nodeP->name, OrionldDetailsString);
         return false;
       }
     }
@@ -597,7 +597,7 @@ bool orionldAttributeTreat(ConnectionInfo* ciP, KjNode* kNodeP, ContextAttribute
   if (typeP == NULL)  // Attr Type is mandatory!
   {
     LM_E(("type missing for attribute '%s'", kNodeP->name));
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Attribute found, but the type field is missing", kNodeP->name, OrionldDetailsAttribute);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Attribute found, but the type field is missing", kNodeP->name, OrionldDetailsAttribute);
     return false;
   }
 
@@ -611,17 +611,17 @@ bool orionldAttributeTreat(ConnectionInfo* ciP, KjNode* kNodeP, ContextAttribute
       if (isGeoProperty == true)
       {
         LM_E(("value missing for GeoProperty '%s'", kNodeP->name));
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Attribute with type GeoProperty found, but the associated value field is missing", kNodeP->name, OrionldDetailsAttribute);
+        orionldErrorResponseCreate(OrionldBadRequestData, "Attribute with type GeoProperty found, but the associated value field is missing", kNodeP->name, OrionldDetailsAttribute);
       }
       else if (isTemporalProperty == true)
       {
         LM_E(("value missing for TemporalProperty '%s'", kNodeP->name));
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Attribute with type TemporalProperty found, but the associated value field is missing", kNodeP->name, OrionldDetailsAttribute);
+        orionldErrorResponseCreate(OrionldBadRequestData, "Attribute with type TemporalProperty found, but the associated value field is missing", kNodeP->name, OrionldDetailsAttribute);
       }
       else
       {
         LM_E(("value missing for Property '%s'", kNodeP->name));
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Attribute with type Property found, but the associated value field is missing", kNodeP->name, OrionldDetailsAttribute);
+        orionldErrorResponseCreate(OrionldBadRequestData, "Attribute with type Property found, but the associated value field is missing", kNodeP->name, OrionldDetailsAttribute);
       }
 
       return false;
@@ -630,7 +630,7 @@ bool orionldAttributeTreat(ConnectionInfo* ciP, KjNode* kNodeP, ContextAttribute
     if (valueP->type == KjNull)
     {
       LM_E(("NULL value for Property '%s'", kNodeP->name));
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Attributes with type Property cannot be given the value NULL", kNodeP->name, OrionldDetailsAttribute);
+      orionldErrorResponseCreate(OrionldBadRequestData, "Attributes with type Property cannot be given the value NULL", kNodeP->name, OrionldDetailsAttribute);
       return NULL;
     }
 
@@ -644,14 +644,14 @@ bool orionldAttributeTreat(ConnectionInfo* ciP, KjNode* kNodeP, ContextAttribute
       if (valueP->type != KjObject)
       {
         LM_E(("geo-property attribute value must be a JSON Object: %s", kNodeP->name));
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, "The value of an attribute of type GeoProperty must be a JSON Object", kNodeP->name, OrionldDetailsString);
+        orionldErrorResponseCreate(OrionldBadRequestData, "The value of an attribute of type GeoProperty must be a JSON Object", kNodeP->name, OrionldDetailsString);
         return false;
       }
 
       if (geoJsonCheck(ciP, valueP, &details) == false)
       {
         LM_E(("geoJsonCheck error for %s: %s", caName, details));
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, "The value of an attribute of type GeoProperty must be valid GeoJson", details, OrionldDetailsString);
+        orionldErrorResponseCreate(OrionldBadRequestData, "The value of an attribute of type GeoProperty must be valid GeoJson", details, OrionldDetailsString);
         return false;
       }
       caP->valueType       = orion::ValueTypeObject;

--- a/src/lib/orionld/common/orionldErrorResponse.cpp
+++ b/src/lib/orionld/common/orionldErrorResponse.cpp
@@ -31,7 +31,6 @@ extern "C"
 #include "logMsg/logMsg.h"                                     // LM_*
 #include "logMsg/traceLevels.h"                                // Lmt*
 
-#include "rest/ConnectionInfo.h"                               // ConnectionInfo
 #include "orionld/context/orionldCoreContext.h"                // orionldDefaultUrl
 #include "orionld/context/orionldContextItemLookup.h"          // orionldContextItemLookup
 #include "orionld/common/orionldState.h"                       // orionldState
@@ -65,7 +64,6 @@ static const char* errorTypeStringV[] =
 //
 void orionldErrorResponseCreate
 (
-  ConnectionInfo*           ciP,
   OrionldResponseErrorType  errorType,
   const char*               title,
   const char*               details,

--- a/src/lib/orionld/common/orionldErrorResponse.h
+++ b/src/lib/orionld/common/orionldErrorResponse.h
@@ -25,7 +25,6 @@
 *
 * Author: Ken Zangelin
 */
-#include "rest/ConnectionInfo.h"                               // ConnectionInfo
 
 
 
@@ -65,7 +64,6 @@ typedef enum OrionldDetailsType
 //
 extern void orionldErrorResponseCreate
 (
-  ConnectionInfo*           ciP,
   OrionldResponseErrorType  errorType,
   const char*               title,
   const char*               details,

--- a/src/lib/orionld/context/orionldContextInlineCheck.cpp
+++ b/src/lib/orionld/context/orionldContextInlineCheck.cpp
@@ -50,7 +50,7 @@ bool orionldContextInlineCheck(ConnectionInfo* ciP, KjNode* contextObjectP)
     {
       LM_E(("The context is invalid - value of '%s' is not a String nor an Object", nodeP->name));
       orionldState.contextP = NULL;  // Leak?
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid key-value in @context", nodeP->name, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "Invalid key-value in @context", nodeP->name, OrionldDetailsString);
       ciP->httpStatusCode = SccBadRequest;
       return false;
     }

--- a/src/lib/orionld/context/orionldContextTreat.cpp
+++ b/src/lib/orionld/context/orionldContextTreat.cpp
@@ -57,7 +57,7 @@ static OrionldContext* contextItemNodeTreat(ConnectionInfo* ciP, char* url)
   {
     LM_E(("Invalid context '%s': %s", url, details));
     orionldState.contextP = NULL;  // Leak?
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid context", details, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Invalid context", details, OrionldDetailsString);
     ciP->httpStatusCode = SccBadRequest;
     return NULL;
   }
@@ -126,7 +126,7 @@ bool orionldContextTreat
     if ((orionldState.contextP = orionldContextCreateFromUrl(ciP, contextNodeP->value.s, OrionldUserContext, &details)) == NULL)
     {
       LM_E(("Failed to create context from URL: %s", details));
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Failure to create context from URL", details, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "Failure to create context from URL", details, OrionldDetailsString);
       ciP->httpStatusCode = SccBadRequest;
       return false;
     }
@@ -142,7 +142,7 @@ bool orionldContextTreat
     if (orionldState.contextP == NULL)
     {
       LM_E(("Failed to create context from Tree : %s", details));
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Failure to create context from tree", details, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "Failure to create context from tree", details, OrionldDetailsString);
       ciP->httpStatusCode = SccBadRequest;
       return false;
     }
@@ -171,7 +171,7 @@ bool orionldContextTreat
         {
           LM_E(("Error treating context object inside array"));
           orionldState.contextP = NULL;  // Leak?
-          orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Error treating context object inside array", NULL, OrionldDetailsString);
+          orionldErrorResponseCreate(OrionldBadRequestData, "Error treating context object inside array", NULL, OrionldDetailsString);
           ciP->httpStatusCode = SccBadRequest;
           return false;
         }
@@ -180,7 +180,7 @@ bool orionldContextTreat
       {
         LM_E(("Context Array Item is not a String nor an Object, but of type '%s'", kjValueType(contextArrayItemP->type)));
         orionldState.contextP = NULL;  // Leak?
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Context Array Item is of an unsupported type", NULL, OrionldDetailsString);
+        orionldErrorResponseCreate(OrionldBadRequestData, "Context Array Item is of an unsupported type", NULL, OrionldDetailsString);
         ciP->httpStatusCode = SccBadRequest;
         return false;
       }
@@ -210,7 +210,7 @@ bool orionldContextTreat
   {
     LM_E(("invalid JSON type of @context member"));
     orionldState.contextP = NULL;  // Leak?
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid context", "invalid JSON type of @context member", OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Invalid context", "invalid JSON type of @context member", OrionldDetailsString);
     ciP->httpStatusCode = SccBadRequest;
     return false;
   }
@@ -231,7 +231,7 @@ bool orionldContextTreat
 
   if (orionldUserContextKeyValuesCheck(orionldState.contextP->tree, orionldState.contextP->url, &details) == false)
   {
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid context", details, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Invalid context", details, OrionldDetailsString);
     ciP->httpStatusCode = SccBadRequest;
     return false;
   }

--- a/src/lib/orionld/kjTree/kjTreeFromQueryContextResponse.cpp
+++ b/src/lib/orionld/kjTree/kjTreeFromQueryContextResponse.cpp
@@ -72,7 +72,7 @@ bool orionldSysAttrs(ConnectionInfo* ciP, double creDate, double modDate, KjNode
   if (numberToDate((time_t) creDate, date, sizeof(date), &details) == false)
   {
     LM_E(("Error creating a stringified date for 'createdAt'"));
-    orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to create a stringified createdAt date", details, OrionldDetailsEntity);
+    orionldErrorResponseCreate(OrionldInternalError, "Unable to create a stringified createdAt date", details, OrionldDetailsEntity);
     return false;
   }
 
@@ -83,7 +83,7 @@ bool orionldSysAttrs(ConnectionInfo* ciP, double creDate, double modDate, KjNode
   if (numberToDate((time_t) modDate, date, sizeof(date), &details) == false)
   {
     LM_E(("Error creating a stringified date for 'modifiedAt'"));
-    orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to create a stringified modifiedAt date", details, OrionldDetailsEntity);
+    orionldErrorResponseCreate(OrionldInternalError, "Unable to create a stringified modifiedAt date", details, OrionldDetailsEntity);
     return false;
   }
 
@@ -140,7 +140,7 @@ KjNode* kjTreeFromQueryContextResponse(ConnectionInfo* ciP, bool oneHit, bool ke
     LM_E(("Error %d from mongoBackend", responseP->errorCode.code));
     OrionldResponseErrorType errorType = httpStatusCodeToOrionldErrorType(responseP->errorCode.code);
 
-    orionldErrorResponseCreate(ciP, errorType, responseP->errorCode.reasonPhrase.c_str(), responseP->errorCode.details.c_str(), OrionldDetailsString);
+    orionldErrorResponseCreate(errorType, responseP->errorCode.reasonPhrase.c_str(), responseP->errorCode.details.c_str(), OrionldDetailsString);
 
     if (responseP->errorCode.code == SccContextElementNotFound)
       ciP->httpStatusCode = responseP->errorCode.code;
@@ -163,7 +163,7 @@ KjNode* kjTreeFromQueryContextResponse(ConnectionInfo* ciP, bool oneHit, bool ke
   }
   else if ((hits > 1) && (oneHit == true))  // More than one hit - not possible!
   {
-    orionldErrorResponseCreate(ciP, OrionldInternalError, "More than one hit", orionldState.wildcard[0], OrionldDetailsEntity);
+    orionldErrorResponseCreate(OrionldInternalError, "More than one hit", orionldState.wildcard[0], OrionldDetailsEntity);
     return NULL;
   }
 
@@ -212,7 +212,7 @@ KjNode* kjTreeFromQueryContextResponse(ConnectionInfo* ciP, bool oneHit, bool ke
       if (nodeP == NULL)
       {
         LM_E(("out of memory"));
-        orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to create tree node", "out of memory", OrionldDetailsEntity);
+        orionldErrorResponseCreate(OrionldInternalError, "Unable to create tree node", "out of memory", OrionldDetailsEntity);
         return NULL;
       }
 
@@ -265,21 +265,21 @@ KjNode* kjTreeFromQueryContextResponse(ConnectionInfo* ciP, bool oneHit, bool ke
             if (kjTreeFromCompoundValue(aP->compoundValueP, aTop, &details) == NULL)
             {
               LM_E(("kjTreeFromCompoundValue: %s", details));
-              orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to create tree node from a compound value", details, OrionldDetailsEntity);
+              orionldErrorResponseCreate(OrionldInternalError, "Unable to create tree node from a compound value", details, OrionldDetailsEntity);
               return NULL;
             }
           }
           break;
 
         case orion::ValueTypeNotGiven:
-          orionldErrorResponseCreate(ciP, OrionldInternalError, "Invalid internal JSON type for Context Atribute", NULL, OrionldDetailsEntity);
+          orionldErrorResponseCreate(OrionldInternalError, "Invalid internal JSON type for Context Atribute", NULL, OrionldDetailsEntity);
           break;
         }
 
         if (aTop == NULL)
         {
           LM_E(("kjTreeFromCompoundValue: %s", details));
-          orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to create tree node for a compound value", "out of memory", OrionldDetailsEntity);
+          orionldErrorResponseCreate(OrionldInternalError, "Unable to create tree node for a compound value", "out of memory", OrionldDetailsEntity);
           return NULL;
         }
 
@@ -292,7 +292,7 @@ KjNode* kjTreeFromQueryContextResponse(ConnectionInfo* ciP, bool oneHit, bool ke
         if (aTop == NULL)
         {
           LM_E(("Error creating a KjNode Object"));
-          orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to create tree node", "out of memory", OrionldDetailsEntity);
+          orionldErrorResponseCreate(OrionldInternalError, "Unable to create tree node", "out of memory", OrionldDetailsEntity);
           return NULL;
         }
 
@@ -303,7 +303,7 @@ KjNode* kjTreeFromQueryContextResponse(ConnectionInfo* ciP, bool oneHit, bool ke
           if (nodeP == NULL)
           {
             LM_E(("Error creating a KjNode String"));
-            orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to create tree node", "out of memory", OrionldDetailsEntity);
+            orionldErrorResponseCreate(OrionldInternalError, "Unable to create tree node", "out of memory", OrionldDetailsEntity);
             return NULL;
           }
 
@@ -324,7 +324,7 @@ KjNode* kjTreeFromQueryContextResponse(ConnectionInfo* ciP, bool oneHit, bool ke
             if (numberToDate((time_t) aP->numberValue, date, sizeof(date), &details) == false)
             {
               LM_E(("Error creating a stringified date"));
-              orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to create a stringified observedAt date", details, OrionldDetailsEntity);
+              orionldErrorResponseCreate(OrionldInternalError, "Unable to create a stringified observedAt date", details, OrionldDetailsEntity);
               return NULL;
             }
 
@@ -345,14 +345,14 @@ KjNode* kjTreeFromQueryContextResponse(ConnectionInfo* ciP, bool oneHit, bool ke
           if (nodeP == NULL)
           {
             LM_E(("kjTreeFromCompoundValue: %s", details));
-            orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to create tree node for compound value", "out of memory", OrionldDetailsEntity);
+            orionldErrorResponseCreate(OrionldInternalError, "Unable to create tree node for compound value", "out of memory", OrionldDetailsEntity);
             return NULL;
           }
 
           if (kjTreeFromCompoundValue(aP->compoundValueP, nodeP, &details) == NULL)
           {
             LM_E(("kjTreeFromCompoundValue: %s", details));
-            orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to create tree node from compound value", details, OrionldDetailsEntity);
+            orionldErrorResponseCreate(OrionldInternalError, "Unable to create tree node from compound value", details, OrionldDetailsEntity);
             return NULL;
           }
           break;
@@ -403,7 +403,7 @@ KjNode* kjTreeFromQueryContextResponse(ConnectionInfo* ciP, bool oneHit, bool ke
                 if (numberToDate((time_t) mdP->numberValue, date, sizeof(date), &details) == false)
                 {
                   LM_E(("Error creating a stringified date"));
-                  orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to create a stringified observedAt date", details, OrionldDetailsEntity);
+                  orionldErrorResponseCreate(OrionldInternalError, "Unable to create a stringified observedAt date", details, OrionldDetailsEntity);
                   return NULL;
                 }
 
@@ -439,7 +439,7 @@ KjNode* kjTreeFromQueryContextResponse(ConnectionInfo* ciP, bool oneHit, bool ke
                 if (numberToDate((time_t) mdP->numberValue, date, sizeof(date), &details) == false)
                 {
                   LM_E(("Error creating a stringified date"));
-                  orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to create a stringified date", details, OrionldDetailsEntity);
+                  orionldErrorResponseCreate(OrionldInternalError, "Unable to create a stringified date", details, OrionldDetailsEntity);
                   return NULL;
                 }
 

--- a/src/lib/orionld/kjTree/kjTreeFromQueryContextResponseWithAttrList.cpp
+++ b/src/lib/orionld/kjTree/kjTreeFromQueryContextResponseWithAttrList.cpp
@@ -102,7 +102,7 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
     LM_E(("Error %d from mongoBackend", responseP->errorCode.code));
     OrionldResponseErrorType errorType = httpStatusCodeToOrionldErrorType(responseP->errorCode.code);
 
-    orionldErrorResponseCreate(ciP, errorType, responseP->errorCode.reasonPhrase.c_str(), responseP->errorCode.details.c_str(), OrionldDetailsString);
+    orionldErrorResponseCreate(errorType, responseP->errorCode.reasonPhrase.c_str(), responseP->errorCode.details.c_str(), OrionldDetailsString);
 
     if (responseP->errorCode.code == SccContextElementNotFound)
       ciP->httpStatusCode = responseP->errorCode.code;
@@ -123,7 +123,7 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
   }
   else if ((hits > 1) && (oneHit == true))  // More than one hit - not possible!
   {
-    orionldErrorResponseCreate(ciP, OrionldInternalError, "More than one hit", orionldState.wildcard[0], OrionldDetailsEntity);
+    orionldErrorResponseCreate(OrionldInternalError, "More than one hit", orionldState.wildcard[0], OrionldDetailsEntity);
     return NULL;
   }
 
@@ -177,7 +177,7 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
           if (nodeP == NULL)
           {
             LM_E(("out of memory"));
-            orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to create tree node", "out of memory", OrionldDetailsEntity);
+            orionldErrorResponseCreate(OrionldInternalError, "Unable to create tree node", "out of memory", OrionldDetailsEntity);
             return NULL;
           }
         }
@@ -201,7 +201,7 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
         if (nodeP == NULL)
         {
           LM_E(("out of memory"));
-          orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to create tree node", "out of memory", OrionldDetailsEntity);
+          orionldErrorResponseCreate(OrionldInternalError, "Unable to create tree node", "out of memory", OrionldDetailsEntity);
           return NULL;
         }
       }
@@ -276,21 +276,21 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
             if (kjTreeFromCompoundValue(aP->compoundValueP, aTop, &details) == NULL)
             {
               LM_E(("kjTreeFromCompoundValue: %s", details));
-              orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to create tree node from compound value", details, OrionldDetailsEntity);
+              orionldErrorResponseCreate(OrionldInternalError, "Unable to create tree node from compound value", details, OrionldDetailsEntity);
               return NULL;
             }
           }
           break;
 
         case orion::ValueTypeNotGiven:
-          orionldErrorResponseCreate(ciP, OrionldInternalError, "invalid internal JSON type for Context Atribute", NULL, OrionldDetailsEntity);
+          orionldErrorResponseCreate(OrionldInternalError, "invalid internal JSON type for Context Atribute", NULL, OrionldDetailsEntity);
           break;
         }
 
         if (aTop == NULL)
         {
           LM_E(("kjTreeFromCompoundValue: %s", details));
-          orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to create tree node for compound value", "out of memory", OrionldDetailsEntity);
+          orionldErrorResponseCreate(OrionldInternalError, "Unable to create tree node for compound value", "out of memory", OrionldDetailsEntity);
           return NULL;
         }
 
@@ -302,7 +302,7 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
         if (aTop == NULL)
         {
           LM_E(("Error creating a KjNode Object"));
-          orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to create tree node", "out of memory", OrionldDetailsEntity);
+          orionldErrorResponseCreate(OrionldInternalError, "Unable to create tree node", "out of memory", OrionldDetailsEntity);
           return NULL;
         }
 
@@ -313,7 +313,7 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
           if (nodeP == NULL)
           {
             LM_E(("Error creating a KjNode String"));
-            orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to create tree node", "out of memory", OrionldDetailsEntity);
+            orionldErrorResponseCreate(OrionldInternalError, "Unable to create tree node", "out of memory", OrionldDetailsEntity);
             return NULL;
           }
 
@@ -334,7 +334,7 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
             if (numberToDate((time_t) aP->numberValue, date, sizeof(date), &details) == false)
             {
               LM_E(("Error creating a stringified date"));
-              orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to create a stringified observedAt date", details, OrionldDetailsEntity);
+              orionldErrorResponseCreate(OrionldInternalError, "Unable to create a stringified observedAt date", details, OrionldDetailsEntity);
               return NULL;
             }
 
@@ -355,14 +355,14 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
           if (nodeP == NULL)
           {
             LM_E(("kjTreeFromCompoundValue: %s", details));
-            orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to create tree node for compound value", "out of memory", OrionldDetailsEntity);
+            orionldErrorResponseCreate(OrionldInternalError, "Unable to create tree node for compound value", "out of memory", OrionldDetailsEntity);
             return NULL;
           }
 
           if (kjTreeFromCompoundValue(aP->compoundValueP, nodeP, &details) == NULL)
           {
             LM_E(("kjTreeFromCompoundValue: %s", details));
-            orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to create tree node from compound value", details, OrionldDetailsEntity);
+            orionldErrorResponseCreate(OrionldInternalError, "Unable to create tree node from compound value", details, OrionldDetailsEntity);
             return NULL;
           }
           break;
@@ -413,7 +413,7 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
                 if (numberToDate((time_t) mdP->numberValue, date, sizeof(date), &details) == false)
                 {
                   LM_E(("Error creating a stringified date"));
-                  orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to create a stringified date", details, OrionldDetailsEntity);
+                  orionldErrorResponseCreate(OrionldInternalError, "Unable to create a stringified date", details, OrionldDetailsEntity);
                   return NULL;
                 }
 
@@ -448,7 +448,7 @@ KjNode* kjTreeFromQueryContextResponseWithAttrList(ConnectionInfo* ciP, bool one
                 if (numberToDate((time_t) mdP->numberValue, date, sizeof(date), &details) == false)
                 {
                   LM_E(("Error creating a stringified date"));
-                  orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to create a stringified date", details, OrionldDetailsEntity);
+                  orionldErrorResponseCreate(OrionldInternalError, "Unable to create a stringified date", details, OrionldDetailsEntity);
                   return NULL;
                 }
 

--- a/src/lib/orionld/kjTree/kjTreeFromSubscription.cpp
+++ b/src/lib/orionld/kjTree/kjTreeFromSubscription.cpp
@@ -274,7 +274,7 @@ KjNode* kjTreeFromSubscription(ConnectionInfo* ciP, ngsiv2::Subscription* subscr
     if (numberToDate((time_t) subscriptionP->timeInterval, date, sizeof(date), &details) == false)
     {
       LM_E(("Error creating a stringified date for 'timeInterval'"));
-      orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to create a stringified date", details, OrionldDetailsEntity);
+      orionldErrorResponseCreate(OrionldInternalError, "Unable to create a stringified date", details, OrionldDetailsEntity);
       return NULL;
     }
     nodeP = kjString(orionldState.kjsonP, "timeInterval", date);
@@ -320,7 +320,7 @@ KjNode* kjTreeFromSubscription(ConnectionInfo* ciP, ngsiv2::Subscription* subscr
       if (coordValueP == NULL)
       {
         LM_E(("error parsing coordinates: '%s'", coordinateString));
-        orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to parse coordinates string", coordinateString, OrionldDetailsEntity);
+        orionldErrorResponseCreate(OrionldInternalError, "Unable to parse coordinates string", coordinateString, OrionldDetailsEntity);
         return NULL;
       }
 
@@ -434,7 +434,7 @@ KjNode* kjTreeFromSubscription(ConnectionInfo* ciP, ngsiv2::Subscription* subscr
     if (numberToDate((time_t) subscriptionP->expires, date, sizeof(date), &details) == false)
     {
       LM_E(("Error creating a stringified date for 'expires'"));
-      orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to create a stringified expires date", details, OrionldDetailsEntity);
+      orionldErrorResponseCreate(OrionldInternalError, "Unable to create a stringified expires date", details, OrionldDetailsEntity);
       return NULL;
     }
     nodeP = kjString(orionldState.kjsonP, "expires", date);

--- a/src/lib/orionld/kjTree/kjTreeToEndpoint.cpp
+++ b/src/lib/orionld/kjTree/kjTreeToEndpoint.cpp
@@ -65,7 +65,7 @@ bool kjTreeToEndpoint(ConnectionInfo* ciP, KjNode* kNodeP, ngsiv2::HttpInfo* htt
 
       if (!urlCheck(uriP, &details) && !urnCheck(uriP, &details))
       {
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid Endpoint::uri", "Endpoint is neither a URL nor a URN", OrionldDetailsString);
+        orionldErrorResponseCreate(OrionldBadRequestData, "Invalid Endpoint::uri", "Endpoint is neither a URL nor a URN", OrionldDetailsString);
         return false;
       }
 
@@ -79,7 +79,7 @@ bool kjTreeToEndpoint(ConnectionInfo* ciP, KjNode* kNodeP, ngsiv2::HttpInfo* htt
 
       if (!SCOMPARE12(mimeType, 'a', 'p', 'p', 'l', 'i', 'c', 'a', 't', 'i', 'o', 'n', '/'))
       {
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid Endpoint::accept value", mimeType, OrionldDetailsString);
+        orionldErrorResponseCreate(OrionldBadRequestData, "Invalid Endpoint::accept value", mimeType, OrionldDetailsString);
         return false;
       }
 
@@ -91,20 +91,20 @@ bool kjTreeToEndpoint(ConnectionInfo* ciP, KjNode* kNodeP, ngsiv2::HttpInfo* htt
         httpInfoP->mimeType = JSONLD;
       else
       {
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid Endpoint::accept value", itemP->value.s, OrionldDetailsString);
+        orionldErrorResponseCreate(OrionldBadRequestData, "Invalid Endpoint::accept value", itemP->value.s, OrionldDetailsString);
         return false;
       }
     }
     else
     {
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Unrecognized field in Endpoint", itemP->name, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "Unrecognized field in Endpoint", itemP->name, OrionldDetailsString);
       return false;
     }
   }
 
   if (uriP == NULL)
   {
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Mandatory field missing", "Endpoint::uri", OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Mandatory field missing", "Endpoint::uri", OrionldDetailsString);
     return false;
   }
 

--- a/src/lib/orionld/kjTree/kjTreeToEntIdVector.cpp
+++ b/src/lib/orionld/kjTree/kjTreeToEntIdVector.cpp
@@ -62,7 +62,7 @@ bool kjTreeToEntIdVector(ConnectionInfo* ciP, KjNode* kNodeP, std::vector<ngsiv2
   {
     if (entityP->type != KjObject)
     {
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "EntityInfo array member not a JSON Object", NULL, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "EntityInfo array member not a JSON Object", NULL, OrionldDetailsString);
       return false;
     }
 
@@ -90,20 +90,20 @@ bool kjTreeToEntIdVector(ConnectionInfo* ciP, KjNode* kNodeP, std::vector<ngsiv2
       }
       else
       {
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Unknown EntityInfo field", itemP->name, OrionldDetailsString);
+        orionldErrorResponseCreate(OrionldBadRequestData, "Unknown EntityInfo field", itemP->name, OrionldDetailsString);
         return false;
       }
     }
 
     if ((idP == NULL) && (idPatternP == NULL) && (typeP == NULL))
     {
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Empty EntityInfo object", NULL, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "Empty EntityInfo object", NULL, OrionldDetailsString);
       return false;
     }
 
     if ((idP != NULL) && (idPatternP != NULL))
     {
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Both 'id' and 'idPattern' given in EntityInfo object", NULL, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "Both 'id' and 'idPattern' given in EntityInfo object", NULL, OrionldDetailsString);
       return false;
     }
 
@@ -114,7 +114,7 @@ bool kjTreeToEntIdVector(ConnectionInfo* ciP, KjNode* kNodeP, std::vector<ngsiv2
 
       if ((urlCheck(idP, &details) == false) && (urnCheck(idP, &details) == false))
       {
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid Entity ID", details, OrionldDetailsString);
+        orionldErrorResponseCreate(OrionldBadRequestData, "Invalid Entity ID", details, OrionldDetailsString);
         ciP->httpStatusCode = SccBadRequest;
         return false;
       }
@@ -122,7 +122,7 @@ bool kjTreeToEntIdVector(ConnectionInfo* ciP, KjNode* kNodeP, std::vector<ngsiv2
 
     if (typeP == NULL)
     {
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Missing field in EntityInfo object", "type", OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "Missing field in EntityInfo object", "type", OrionldDetailsString);
       return false;
     }
 
@@ -131,7 +131,7 @@ bool kjTreeToEntIdVector(ConnectionInfo* ciP, KjNode* kNodeP, std::vector<ngsiv2
 
     if (orionldUriExpand(orionldState.contextP, typeP, typeExpanded, sizeof(typeExpanded), &details) == false)
     {
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Error during URI expansion of entity type", details, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "Error during URI expansion of entity type", details, OrionldDetailsString);
       return false;
     }
     typeP = typeExpanded;

--- a/src/lib/orionld/kjTree/kjTreeToNotification.cpp
+++ b/src/lib/orionld/kjTree/kjTreeToNotification.cpp
@@ -55,7 +55,7 @@ static bool formatExtract(ConnectionInfo* ciP, char* format, ngsiv2::Subscriptio
   else
   {
     LM_E(("Invalid value for Notification::format: '%s'", format));
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid value for Notification::format", format, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Invalid value for Notification::format", format, OrionldDetailsString);
     return false;
   }
 
@@ -129,7 +129,7 @@ bool kjTreeToNotification(ConnectionInfo* ciP, KjNode* kNodeP, ngsiv2::Subscript
     }
     else
     {
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Unknown Notification field", itemP->name, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "Unknown Notification field", itemP->name, OrionldDetailsString);
       return false;
     }
   }

--- a/src/lib/orionld/kjTree/kjTreeToRegistration.cpp
+++ b/src/lib/orionld/kjTree/kjTreeToRegistration.cpp
@@ -82,7 +82,7 @@ bool kjTreeToRegistration(ConnectionInfo* ciP, ngsiv2::Registration* regP, char*
   if ((urlCheck((char*) regP->id.c_str(), NULL) == false) && (urnCheck((char*) regP->id.c_str(), NULL) == false))
   {
     LM_W(("Bad Input (Registration::id is not a URI)"));
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Registration::id is not a URI", regP->id.c_str(), OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Registration::id is not a URI", regP->id.c_str(), OrionldDetailsString);
     ciP->httpStatusCode = SccBadRequest;
     return false;
   }
@@ -103,7 +103,7 @@ bool kjTreeToRegistration(ConnectionInfo* ciP, ngsiv2::Registration* regP, char*
   if (orionldState.payloadTypeNode == NULL)
   {
     LM_W(("Bad Input (Mandatory field missing: Registration::type)"));
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Mandatory field missing", "Registration::type", OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Mandatory field missing", "Registration::type", OrionldDetailsString);
     ciP->httpStatusCode = SccBadRequest;
     return false;
   }
@@ -111,8 +111,7 @@ bool kjTreeToRegistration(ConnectionInfo* ciP, ngsiv2::Registration* regP, char*
   if (strcmp(orionldState.payloadTypeNode->value.s, "ContextSourceRegistration") != 0)
   {
     LM_W(("Bad Input (Registration type must have the value /Registration/)"));
-    orionldErrorResponseCreate(ciP,
-                               OrionldBadRequestData,
+    orionldErrorResponseCreate(OrionldBadRequestData,
                                "Registration::type must have a value of /ContextSourceRegistration/",
                                orionldState.payloadTypeNode->value.s,
                                OrionldDetailsString);
@@ -191,7 +190,7 @@ bool kjTreeToRegistration(ConnectionInfo* ciP, ngsiv2::Registration* regP, char*
           }
           else
           {
-            orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid field for Registration::information::entities", eNodeP->name, OrionldDetailsString);
+            orionldErrorResponseCreate(OrionldBadRequestData, "Invalid field for Registration::information::entities", eNodeP->name, OrionldDetailsString);
             return false;
           }
         }
@@ -261,7 +260,7 @@ bool kjTreeToRegistration(ConnectionInfo* ciP, ngsiv2::Registration* regP, char*
       //
       // FIXME: Add to Property vector - To be fixed when we decide to break the data model of Orion APIv2
       //
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid field for Registration - ngsi-ld still follows Orion APIv2 data model", kNodeP->name, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "Invalid field for Registration - ngsi-ld still follows Orion APIv2 data model", kNodeP->name, OrionldDetailsString);
       return false;
     }
   }
@@ -270,7 +269,7 @@ bool kjTreeToRegistration(ConnectionInfo* ciP, ngsiv2::Registration* regP, char*
   if (entitiesPresent == false)
   {
     LM_E(("At least one 'entity' must be present"));
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "At least one 'entity' must be present", NULL, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "At least one 'entity' must be present", NULL, OrionldDetailsString);
     return false;
   }
 

--- a/src/lib/orionld/kjTree/kjTreeToStringList.cpp
+++ b/src/lib/orionld/kjTree/kjTreeToStringList.cpp
@@ -58,7 +58,7 @@ bool kjTreeToStringList(ConnectionInfo* ciP, KjNode* kNodeP, std::vector<std::st
 
     if (orionldUriExpand(orionldState.contextP, attributeP->value.s, expanded, sizeof(expanded), &details) == false)
     {
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Error during URI expansion of entity type", details, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "Error during URI expansion of entity type", details, OrionldDetailsString);
       delete stringListP;  // ?
       return false;
     }

--- a/src/lib/orionld/kjTree/kjTreeToSubscription.cpp
+++ b/src/lib/orionld/kjTree/kjTreeToSubscription.cpp
@@ -115,7 +115,7 @@ bool kjTreeToSubscription(ConnectionInfo* ciP, ngsiv2::Subscription* subP, char*
   if ((urlCheck((char*) subP->id.c_str(), NULL) == false) && (urnCheck((char*) subP->id.c_str(), NULL) == false))
   {
     LM_W(("Bad Input (Subscription::id is not a URI)"));
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Subscription::id is not a URI", subP->id.c_str(), OrionldDetailsAttribute);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Subscription::id is not a URI", subP->id.c_str(), OrionldDetailsAttribute);
     ciP->httpStatusCode = SccBadRequest;
     return false;
   }
@@ -137,7 +137,7 @@ bool kjTreeToSubscription(ConnectionInfo* ciP, ngsiv2::Subscription* subP, char*
   if (orionldState.payloadTypeNode == NULL)
   {
     LM_W(("Bad Input (Mandatory field missing: Subscription::type)"));
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Mandatory field missing", "Subscription::type", OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Mandatory field missing", "Subscription::type", OrionldDetailsString);
     ciP->httpStatusCode = SccBadRequest;
     return false;
   }
@@ -145,7 +145,7 @@ bool kjTreeToSubscription(ConnectionInfo* ciP, ngsiv2::Subscription* subP, char*
   if (!SCOMPARE13(orionldState.payloadTypeNode->value.s, 'S', 'u', 'b', 's', 'c', 'r', 'i', 'p', 't', 'i', 'o', 'n', 0))
   {
     LM_W(("Bad Input (subscription type must have the value /Subscription/)"));
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid value for Subscription::type", orionldState.payloadTypeNode->value.s, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Invalid value for Subscription::type", orionldState.payloadTypeNode->value.s, OrionldDetailsString);
     ciP->httpStatusCode = SccBadRequest;
     return false;
   }
@@ -215,7 +215,7 @@ bool kjTreeToSubscription(ConnectionInfo* ciP, ngsiv2::Subscription* subP, char*
         delete scopeP->stringFilterP;
         delete scopeP;
 
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid value for Subscription::q", kNodeP->value.s, OrionldDetailsString);
+        orionldErrorResponseCreate(OrionldBadRequestData, "Invalid value for Subscription::q", kNodeP->value.s, OrionldDetailsString);
         return false;
       }
 
@@ -228,7 +228,7 @@ bool kjTreeToSubscription(ConnectionInfo* ciP, ngsiv2::Subscription* subP, char*
         delete scopeP->stringFilterP;
         delete scopeP;
 
-        orionldErrorResponseCreate(ciP, OrionldInternalError, "Internal Error", "Unable to render StringFilter", OrionldDetailsString);
+        orionldErrorResponseCreate(OrionldInternalError, "Internal Error", "Unable to render StringFilter", OrionldDetailsString);
         return false;
       }
 
@@ -298,7 +298,7 @@ bool kjTreeToSubscription(ConnectionInfo* ciP, ngsiv2::Subscription* subP, char*
     }
     else
     {
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid field for Subscription", kNodeP->name, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "Invalid field for Subscription", kNodeP->name, OrionldDetailsString);
       return false;
     }
   }
@@ -306,21 +306,21 @@ bool kjTreeToSubscription(ConnectionInfo* ciP, ngsiv2::Subscription* subP, char*
   if ((entitiesPresent == false) && (watchedAttributesPresent == false))
   {
     LM_E(("At least one of 'entities' and 'watchedAttributes' must be present"));
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "At least one of 'entities' and 'watchedAttributes' must be present", NULL, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "At least one of 'entities' and 'watchedAttributes' must be present", NULL, OrionldDetailsString);
     return false;
   }
 
   if ((timeIntervalP != NULL) && (watchedAttributesPresent == true))
   {
     LM_E(("Both 'timeInterval' and 'watchedAttributes' present"));
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Both 'timeInterval' and 'watchedAttributes' present", NULL, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Both 'timeInterval' and 'watchedAttributes' present", NULL, OrionldDetailsString);
     return false;
   }
 
   if (notificationP == NULL)
   {
     LM_E(("Notification Parameters missing in Subscription"));
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Mandatory Field Missing", "Subscription::notification", OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Mandatory Field Missing", "Subscription::notification", OrionldDetailsString);
     return false;
   }
 

--- a/src/lib/orionld/kjTree/kjTreeToSubscriptionExpression.cpp
+++ b/src/lib/orionld/kjTree/kjTreeToSubscriptionExpression.cpp
@@ -70,7 +70,7 @@ bool kjTreeToSubscriptionExpression(ConnectionInfo* ciP, KjNode* kNodeP, Subscri
       }
       else
       {
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid value type (not String nor Array)", "GeoQuery::coordinates", OrionldDetailsString);
+        orionldErrorResponseCreate(OrionldBadRequestData, "Invalid value type (not String nor Array)", "GeoQuery::coordinates", OrionldDetailsString);
         return false;
       }
       LM_T(LmtGeoJson, ("coordinatesNodeP->type: %s", kjValueType(coordinatesNodeP->type)));
@@ -87,26 +87,26 @@ bool kjTreeToSubscriptionExpression(ConnectionInfo* ciP, KjNode* kNodeP, Subscri
     }
     else
     {
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Unknown GeoQuery field", itemP->name, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "Unknown GeoQuery field", itemP->name, OrionldDetailsString);
       return false;
     }
   }
 
   if (geometryP == NULL)
   {
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "GeoQuery::geometry missing in Subscription", NULL, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "GeoQuery::geometry missing in Subscription", NULL, OrionldDetailsString);
     return false;
   }
 
   if (coordinatesNodeP == NULL)
   {
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "GeoQuery::coordinates missing in Subscription", NULL, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "GeoQuery::coordinates missing in Subscription", NULL, OrionldDetailsString);
     return false;
   }
 
   if (georelP == NULL)
   {
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "GeoQuery::georel missing in Subscription", NULL, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "GeoQuery::georel missing in Subscription", NULL, OrionldDetailsString);
     return false;
   }
 

--- a/src/lib/orionld/kjTree/kjTreeToTimeInterval.cpp
+++ b/src/lib/orionld/kjTree/kjTreeToTimeInterval.cpp
@@ -62,7 +62,7 @@ bool kjTreeToTimeInterval(ConnectionInfo* ciP, KjNode* kNodeP, OrionldTimeInterv
     }
     else
     {
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Unexpected field in TimeInterval", intervalItemP->name, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "Unexpected field in TimeInterval", intervalItemP->name, OrionldDetailsString);
       ciP->httpStatusCode = SccBadRequest;
       return false;
     }
@@ -71,21 +71,21 @@ bool kjTreeToTimeInterval(ConnectionInfo* ciP, KjNode* kNodeP, OrionldTimeInterv
   if ((startP == NULL) || (endP == NULL))
   {
     const char* missing = (startP == NULL)? "TimeInterval::start" : "TimeInterval::end";
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Missing field in TimeInterval", missing, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Missing field in TimeInterval", missing, OrionldDetailsString);
     ciP->httpStatusCode = SccBadRequest;
     return false;
   }
 
   if ((intervalP->start = parse8601Time(startP->value.s)) == -1)
   {
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid ISO8601 time string", startP->value.s, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Invalid ISO8601 time string", startP->value.s, OrionldDetailsString);
     ciP->httpStatusCode = SccBadRequest;
     return false;
   }
 
   if ((intervalP->end = parse8601Time(endP->value.s)) == -1)
   {
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid ISO8601 time string", endP->value.s, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Invalid ISO8601 time string", endP->value.s, OrionldDetailsString);
     ciP->httpStatusCode = SccBadRequest;
     return false;
   }

--- a/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
@@ -249,7 +249,7 @@ int orionldMhdConnectionInit
   if (ciP->verb == NOVERB)
   {
     LM_T(LmtVerb, ("NOVERB for (%s)", method));
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "not a valid verb", method, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "not a valid verb", method, OrionldDetailsString);
     ciP->httpStatusCode   = SccBadRequest;
     return MHD_YES;
   }
@@ -283,8 +283,7 @@ int orionldMhdConnectionInit
     //
     if ((strcmp(ciP->httpHeaders.contentType.c_str(), "application/json") != 0) && (strcmp(ciP->httpHeaders.contentType.c_str(), "application/ld+json") != 0))
     {
-      orionldErrorResponseCreate(ciP,
-                                 OrionldBadRequestData,
+      orionldErrorResponseCreate(OrionldBadRequestData,
                                  "unsupported format of payload",
                                  "only application/json and application/ld+json are supported",
                                  OrionldDetailsString);
@@ -330,7 +329,7 @@ int orionldMhdConnectionInit
   if ((ciP->verb != POST) && (ciP->verb != GET) && (ciP->verb != DELETE) && (ciP->verb != PATCH))
   {
     LM_T(LmtVerb, ("The verb '%s' is not supported by NGSI-LD", method));
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Verb not supported by NGSI-LD", method, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Verb not supported by NGSI-LD", method, OrionldDetailsString);
     ciP->httpStatusCode = SccBadRequest;
   }
 

--- a/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
@@ -130,7 +130,7 @@ static bool contentTypeCheck(ConnectionInfo* ciP)
   {
     LM_E(("Bad Input (%s: %s)", errorTitle, errorDetails));
 
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, errorTitle, errorDetails, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, errorTitle, errorDetails, OrionldDetailsString);
     ciP->httpStatusCode = SccBadRequest;
 
     return false;
@@ -215,7 +215,7 @@ static bool acceptHeaderExtractAndCheck(ConnectionInfo* ciP)
     const char* details = "HTTP Header /Accept/ contains neither 'application/json' nor 'application/ld+json'";
 
     LM_W(("Bad Input (HTTP Header /Accept/ contains neither 'application/json' nor 'application/ld+json')"));
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, title, details, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, title, details, OrionldDetailsString);
     ciP->httpStatusCode = SccNotAcceptable;
 
     return false;
@@ -256,7 +256,7 @@ static OrionLdRestService* serviceLookup(ConnectionInfo* ciP)
       ciP->httpStatusCode = SccBadVerb;
     else
     {
-      orionldErrorResponseCreate(ciP, OrionldInvalidRequest, "Service Not Found", orionldState.urlPath, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldInvalidRequest, "Service Not Found", orionldState.urlPath, OrionldDetailsString);
       ciP->httpStatusCode = SccContextElementNotFound;
     }
   }
@@ -275,7 +275,7 @@ static bool payloadEmptyCheck(ConnectionInfo* ciP)
   // No payload?
   if (ciP->payload == NULL)
   {
-    orionldErrorResponseCreate(ciP, OrionldInvalidRequest, "payload missing", NULL, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldInvalidRequest, "payload missing", NULL, OrionldDetailsString);
     ciP->httpStatusCode = SccBadRequest;
     return false;
   }
@@ -283,7 +283,7 @@ static bool payloadEmptyCheck(ConnectionInfo* ciP)
   // Empty payload?
   if (ciP->payload[0] == 0)
   {
-    orionldErrorResponseCreate(ciP, OrionldInvalidRequest, "payload missing", NULL, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldInvalidRequest, "payload missing", NULL, OrionldDetailsString);
     ciP->httpStatusCode = SccBadRequest;
     return false;
   }
@@ -352,7 +352,7 @@ static bool payloadParseAndExtractSpecialFields(ConnectionInfo* ciP, bool* conte
   //
   if (orionldState.requestTree == NULL)
   {
-    orionldErrorResponseCreate(ciP, OrionldInvalidRequest, "JSON Parse Error", orionldState.kjsonP->errorString, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldInvalidRequest, "JSON Parse Error", orionldState.kjsonP->errorString, OrionldDetailsString);
     ciP->httpStatusCode = SccBadRequest;
     return false;
   }
@@ -362,7 +362,7 @@ static bool payloadParseAndExtractSpecialFields(ConnectionInfo* ciP, bool* conte
   //
   if ((orionldState.requestTree->type == KjObject) && (orionldState.requestTree->value.firstChildP == NULL))
   {
-    orionldErrorResponseCreate(ciP, OrionldInvalidRequest, "Empty Object", "{}", OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldInvalidRequest, "Empty Object", "{}", OrionldDetailsString);
     ciP->httpStatusCode = SccBadRequest;
     return false;
   }
@@ -372,7 +372,7 @@ static bool payloadParseAndExtractSpecialFields(ConnectionInfo* ciP, bool* conte
   //
   if ((orionldState.requestTree->type == KjArray) && (orionldState.requestTree->value.firstChildP == NULL))
   {
-    orionldErrorResponseCreate(ciP, OrionldInvalidRequest, "Empty Array", "[]", OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldInvalidRequest, "Empty Array", "[]", OrionldDetailsString);
     ciP->httpStatusCode = SccBadRequest;
     return false;
   }
@@ -406,7 +406,7 @@ static bool payloadParseAndExtractSpecialFields(ConnectionInfo* ciP, bool* conte
         if (orionldState.payloadContextNode != NULL)
         {
           LM_W(("Bad Input (duplicated attribute: '@context'"));
-          orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Duplicated field", "@context", OrionldDetailsString);
+          orionldErrorResponseCreate(OrionldBadRequestData, "Duplicated field", "@context", OrionldDetailsString);
           return false;
         }
         orionldState.payloadContextNode = attrNodeP;
@@ -421,7 +421,7 @@ static bool payloadParseAndExtractSpecialFields(ConnectionInfo* ciP, bool* conte
         if (orionldState.payloadIdNode != NULL)
         {
           LM_W(("Bad Input (duplicated attribute: 'Entity:id'"));
-          orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Duplicated field", "Entity:id", OrionldDetailsString);
+          orionldErrorResponseCreate(OrionldBadRequestData, "Duplicated field", "Entity:id", OrionldDetailsString);
           return false;
         }
 
@@ -437,7 +437,7 @@ static bool payloadParseAndExtractSpecialFields(ConnectionInfo* ciP, bool* conte
         if (orionldState.payloadTypeNode != NULL)
         {
           LM_W(("Bad Input (duplicated attribute: 'Entity:type'"));
-          orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Duplicated field", "Entity:type", OrionldDetailsString);
+          orionldErrorResponseCreate(OrionldBadRequestData, "Duplicated field", "Entity:type", OrionldDetailsString);
           return false;
         }
 
@@ -448,7 +448,7 @@ static bool payloadParseAndExtractSpecialFields(ConnectionInfo* ciP, bool* conte
         char* details;
         if (orionldValidName(orionldState.payloadTypeNode->value.s, &details) == false)
         {
-          orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid entity type name", details, OrionldDetailsString);
+          orionldErrorResponseCreate(OrionldBadRequestData, "Invalid entity type name", details, OrionldDetailsString);
           return false;
         }
         LM_T(LmtContext, ("Found Entity::type in the payload (%p)", orionldState.payloadTypeNode));
@@ -477,7 +477,7 @@ static bool payloadParseAndExtractSpecialFields(ConnectionInfo* ciP, bool* conte
         if (orionldState.payloadContextNode != NULL)
         {
           LM_W(("Bad Input (duplicated attribute: '@context'"));
-          orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Duplicated field", "@context", OrionldDetailsString);
+          orionldErrorResponseCreate(OrionldBadRequestData, "Duplicated field", "@context", OrionldDetailsString);
           return false;
         }
 
@@ -497,7 +497,7 @@ static bool payloadParseAndExtractSpecialFields(ConnectionInfo* ciP, bool* conte
     // A @context in the payload must be a JSON String, Array, or an Object
     if ((orionldState.payloadContextNode->type != KjString) && (orionldState.payloadContextNode->type != KjArray) && (orionldState.payloadContextNode->type != KjObject))
     {
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Not a JSON Array nor Object nor a String", "@context", OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "Not a JSON Array nor Object nor a String", "@context", OrionldDetailsString);
       ciP->httpStatusCode = SccBadRequest;
       return false;
     }
@@ -545,7 +545,7 @@ static bool linkHeaderCheck(ConnectionInfo* ciP)
 
   if (orionldState.link[0] != '<')
   {
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "invalid Link HTTP header", "link doesn't start with '<'", OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "invalid Link HTTP header", "link doesn't start with '<'", OrionldDetailsString);
     ciP->httpStatusCode = SccBadRequest;
     return false;
   }
@@ -555,14 +555,14 @@ static bool linkHeaderCheck(ConnectionInfo* ciP)
   if (linkCheck(orionldState.link, &details) == false)
   {
     LM_E(("linkCheck: %s", details));
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid Link HTTP Header", details, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Invalid Link HTTP Header", details, OrionldDetailsString);
     ciP->httpStatusCode = SccBadRequest;
     return false;
   }
 
   if ((orionldState.contextP = orionldContextCreateFromUrl(ciP, orionldState.link, OrionldUserContext, &details)) == NULL)
   {
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Failure to create context from URL", details, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Failure to create context from URL", details, OrionldDetailsString);
     ciP->httpStatusCode = SccBadRequest;
     return false;
   }
@@ -605,7 +605,7 @@ static bool contextToCache(ConnectionInfo* ciP)
   if (clonedTree == NULL)
   {
     orionldState.contextP = NULL;  // FIXME: Memleak?
-    orionldErrorResponseCreate(ciP, OrionldInternalError, "Unable to clone context tree - out of memory?", NULL, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldInternalError, "Unable to clone context tree - out of memory?", NULL, OrionldDetailsString);
     ciP->httpStatusCode = SccReceiverInternalError;
 
     return false;
@@ -648,7 +648,7 @@ static void contextToPayload(void)
 
   if (orionldState.payloadContextNode == NULL)
   {
-    orionldErrorResponseCreate(NULL, OrionldInternalError, "Out of memory", NULL, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldInternalError, "Out of memory", NULL, OrionldDetailsString);
     return;
   }
 
@@ -681,7 +681,7 @@ static void contextToPayload(void)
 
       if (contextNode == NULL)
       {
-        orionldErrorResponseCreate(NULL, OrionldInternalError, "Out of memory", NULL, OrionldDetailsString);
+        orionldErrorResponseCreate(OrionldInternalError, "Out of memory", NULL, OrionldDetailsString);
         return;
       }
 
@@ -843,7 +843,7 @@ int orionldMhdConnectionTreat(ConnectionInfo* ciP)
   // The only exception is 405 that has no payload - the info comes in the "Accepted" HTTP header.
   //
   if ((ciP->httpStatusCode >= 400) && (orionldState.responseTree == NULL) && (ciP->httpStatusCode != 405))
-    orionldErrorResponseCreate(ciP, OrionldInternalError, "Unknown Error", "The reason for this error is unknown", OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldInternalError, "Unknown Error", "The reason for this error is unknown", OrionldDetailsString);
 
   //
   // On error, the Content-Type is always "application/json" and there is NO Link header
@@ -919,7 +919,7 @@ int orionldMhdConnectionTreat(ConnectionInfo* ciP)
     else
     {
       LM_E(("Error allocating buffer for response payload"));
-      orionldErrorResponseCreate(ciP, OrionldInternalError, "Out of memory", NULL, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldInternalError, "Out of memory", NULL, OrionldDetailsString);
     }
   }
 

--- a/src/lib/orionld/serviceRoutines/orionldDeleteAttribute.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldDeleteAttribute.cpp
@@ -59,7 +59,7 @@ bool orionldDeleteAttribute(ConnectionInfo* ciP)
     // Get the long name of the Context Attribute name
     if (orionldUriExpand(orionldState.contextP, orionldState.wildcard[1], longAttrName, sizeof(longAttrName), &details) == false)
     {
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, details, type, OrionldDetailsAttribute);
+      orionldErrorResponseCreate(OrionldBadRequestData, details, type, OrionldDetailsAttribute);
       return false;
     }
     attrNameP = longAttrName;
@@ -72,7 +72,7 @@ bool orionldDeleteAttribute(ConnectionInfo* ciP)
   if (mongoAttributeExists(orionldState.wildcard[0], attrNameP, orionldState.tenant) == false)
   {
     ciP->httpStatusCode = SccContextElementNotFound;
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Attribute Not Found", orionldState.wildcard[1], OrionldDetailsAttribute);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Attribute Not Found", orionldState.wildcard[1], OrionldDetailsAttribute);
     return false;
   }
 
@@ -100,7 +100,7 @@ bool orionldDeleteAttribute(ConnectionInfo* ciP)
 
   if (ciP->httpStatusCode != SccOk)
   {
-    orionldErrorResponseCreate(ciP, httpStatusCodeToOrionldErrorType(ciP->httpStatusCode), "DELETE /ngsi-ld/v1/entities/*/attrs/*", orionldState.wildcard[0], OrionldDetailsString);
+    orionldErrorResponseCreate(httpStatusCodeToOrionldErrorType(ciP->httpStatusCode), "DELETE /ngsi-ld/v1/entities/*/attrs/*", orionldState.wildcard[0], OrionldDetailsString);
     ucr.release();
 
     return false;

--- a/src/lib/orionld/serviceRoutines/orionldDeleteEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldDeleteEntity.cpp
@@ -55,7 +55,7 @@ bool orionldDeleteEntity(ConnectionInfo* ciP)
 
   if ((urlCheck(orionldState.wildcard[0], &details) == false) && (urnCheck(orionldState.wildcard[0], &details) == false))
   {
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid Entity ID", details, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Invalid Entity ID", details, OrionldDetailsString);
     ciP->httpStatusCode = SccBadRequest;
     return false;
   }
@@ -75,7 +75,7 @@ bool orionldDeleteEntity(ConnectionInfo* ciP)
   {
     OrionldResponseErrorType eType = (parseData.upcrs.res.oe.code == SccContextElementNotFound)? OrionldResourceNotFound : OrionldBadRequestData;
 
-    orionldErrorResponseCreate(ciP, eType, parseData.upcrs.res.oe.details.c_str(), orionldState.wildcard[0], OrionldDetailsString);
+    orionldErrorResponseCreate(eType, parseData.upcrs.res.oe.details.c_str(), orionldState.wildcard[0], OrionldDetailsString);
     ciP->httpStatusCode = (parseData.upcrs.res.oe.code == SccContextElementNotFound)? SccContextElementNotFound : SccBadRequest;
 
     // Release allocated data

--- a/src/lib/orionld/serviceRoutines/orionldDeleteRegistration.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldDeleteRegistration.cpp
@@ -40,7 +40,7 @@ bool orionldDeleteRegistration(ConnectionInfo* ciP)
 {
   LM_T(LmtServiceRoutine, ("In orionldDeleteRegistration"));
 
-  orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Not implemented - DELETE /ngsi-ld/v1/csourceRegistrations/*", orionldState.wildcard[0], OrionldDetailsString);
+  orionldErrorResponseCreate(OrionldBadRequestData, "Not implemented - DELETE /ngsi-ld/v1/csourceRegistrations/*", orionldState.wildcard[0], OrionldDetailsString);
 
   ciP->httpStatusCode = SccNotImplemented;
 

--- a/src/lib/orionld/serviceRoutines/orionldDeleteSubscription.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldDeleteSubscription.cpp
@@ -45,7 +45,7 @@ bool orionldDeleteSubscription(ConnectionInfo* ciP)
 
   if (mongoDeleteLdSubscription(orionldState.wildcard[0], orionldState.tenant, &ciP->httpStatusCode, &details) == false)
   {
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, details, orionldState.wildcard[0], OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, details, orionldState.wildcard[0], OrionldDetailsString);
     return false;
   }
 

--- a/src/lib/orionld/serviceRoutines/orionldGetContext.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetContext.cpp
@@ -79,7 +79,7 @@ bool orionldGetContext(ConnectionInfo* ciP)
 
     if (response.errorCode.code == SccBadRequest)
     {
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Bad Request", NULL, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "Bad Request", NULL, OrionldDetailsString);
       return false;
     }
     else if (response.contextElementResponseVector.size() > 0)
@@ -96,7 +96,7 @@ bool orionldGetContext(ConnectionInfo* ciP)
 
     if (contextTree == NULL)
     {
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Context Not Found", orionldState.wildcard[0], OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "Context Not Found", orionldState.wildcard[0], OrionldDetailsString);
       ciP->httpStatusCode = SccContextElementNotFound;
       return false;
     }
@@ -107,7 +107,7 @@ bool orionldGetContext(ConnectionInfo* ciP)
 
   if (orionldState.responseTree == NULL)
   {
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "kjObject failed", "out of memory?", OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "kjObject failed", "out of memory?", OrionldDetailsString);
     ciP->httpStatusCode = SccReceiverInternalError;
     return false;
   }

--- a/src/lib/orionld/serviceRoutines/orionldGetEntities.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntities.cpp
@@ -114,8 +114,7 @@ bool orionldGetEntities(ConnectionInfo* ciP)
   {
     LM_W(("Bad Input (too broad query - entity type/id not given nor attribute list)"));
 
-    orionldErrorResponseCreate(ciP,
-                               OrionldBadRequestData,
+    orionldErrorResponseCreate(OrionldBadRequestData,
                                "too broad query",
                                "entity type/id not given nor attribute list",
                                OrionldDetailsString);
@@ -128,8 +127,7 @@ bool orionldGetEntities(ConnectionInfo* ciP)
   {
     LM_W(("Bad Input (too broad query - entity type not given nor entity id)"));
 
-    orionldErrorResponseCreate(ciP,
-                               OrionldBadRequestData,
+    orionldErrorResponseCreate(OrionldBadRequestData,
                                "too broad query",
                                "entity type not given nor entity id",
                                OrionldDetailsString);
@@ -141,7 +139,7 @@ bool orionldGetEntities(ConnectionInfo* ciP)
   if ((idPattern != NULL) && (id != NULL))
   {
     LM_W(("Bad Input (both 'idPattern' and 'id' used)"));
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Incompatible parameters", "id, idPattern", OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Incompatible parameters", "id, idPattern", OrionldDetailsString);
     ciP->httpStatusCode = SccBadRequest;
     return false;
   }
@@ -161,7 +159,7 @@ bool orionldGetEntities(ConnectionInfo* ciP)
         (strncmp(georel, "disjoint", 8)    != 0))
     {
       LM_W(("Bad Input (invalid value for georel)"));
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "invalid value for georel", georel, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "invalid value for georel", georel, OrionldDetailsString);
       ciP->httpStatusCode = SccBadRequest;
       return false;
     }
@@ -175,7 +173,7 @@ bool orionldGetEntities(ConnectionInfo* ciP)
       if ((strncmp(georelExtra, "minDistance==", 11) != 0) && (strncmp(georelExtra, "maxDistance==", 11) != 0))
       {
         LM_W(("Bad Input (invalid value for georel parameter: %s)", georelExtra));
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, "invalid value for georel parameter", georel, OrionldDetailsString);
+        orionldErrorResponseCreate(OrionldBadRequestData, "invalid value for georel parameter", georel, OrionldDetailsString);
         ciP->httpStatusCode = SccBadRequest;
         return false;
       }
@@ -188,8 +186,7 @@ bool orionldGetEntities(ConnectionInfo* ciP)
     {
       LM_W(("Bad Input (coordinates missing)"));
 
-      orionldErrorResponseCreate(ciP,
-                                 OrionldBadRequestData,
+      orionldErrorResponseCreate(OrionldBadRequestData,
                                  "no coordinates",
                                  "geometry without coordinates",
                                  OrionldDetailsString);
@@ -201,8 +198,7 @@ bool orionldGetEntities(ConnectionInfo* ciP)
     {
       LM_W(("Bad Input (georel missing)"));
 
-      orionldErrorResponseCreate(ciP,
-                                 OrionldBadRequestData,
+      orionldErrorResponseCreate(OrionldBadRequestData,
                                  "no georel",
                                  "geometry with coordinates but without georel",
                                  OrionldDetailsString);
@@ -232,7 +228,7 @@ bool orionldGetEntities(ConnectionInfo* ciP)
       delete scopeP;
 
       LM_E(("Geo: Scope::fill failed"));
-      orionldErrorResponseCreate(ciP, OrionldInternalError, "error filling a scope", errorString.c_str(), OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldInternalError, "error filling a scope", errorString.c_str(), OrionldDetailsString);
       ciP->httpStatusCode = SccBadRequest;
       return false;
     }
@@ -263,7 +259,7 @@ bool orionldGetEntities(ConnectionInfo* ciP)
   //
   if ((idVecItems > 1) && (typeVecItems > 1))
   {
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "URI params /id/ and /type/ are both lists", "Not Permitted", OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "URI params /id/ and /type/ are both lists", "Not Permitted", OrionldDetailsString);
     return false;
   }
 
@@ -275,7 +271,7 @@ bool orionldGetEntities(ConnectionInfo* ciP)
     if ((urlCheck(idVector[ix], &details) == false) && (urnCheck(idVector[ix], &details) == false))
     {
       LM_W(("Bad Input (Invalid Entity ID - Not a URL nor a URN)"));
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid Entity ID", "Not a URL nor a URN", OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "Invalid Entity ID", "Not a URL nor a URN", OrionldDetailsString);
       return false;
     }
   }
@@ -291,7 +287,7 @@ bool orionldGetEntities(ConnectionInfo* ciP)
     }
     else if (orionldUriExpand(orionldState.contextP, type, typeExpanded, sizeof(typeExpanded), &details) == false)
     {
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Error during URI expansion of entity type", details, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "Error during URI expansion of entity type", details, OrionldDetailsString);
       return false;
     }
 
@@ -314,7 +310,7 @@ bool orionldGetEntities(ConnectionInfo* ciP)
       // FIXME: Check for FQN HERE TOO (once it is decided by ETSI)
       if (orionldUriExpand(orionldState.contextP, typeVector[ix], typeExpanded, sizeof(typeExpanded), &details) == false)
       {
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Error during URI expansion of entity type", details, OrionldDetailsString);
+        orionldErrorResponseCreate(OrionldBadRequestData, "Error during URI expansion of entity type", details, OrionldDetailsString);
         return false;
       }
 
@@ -346,7 +342,7 @@ bool orionldGetEntities(ConnectionInfo* ciP)
         parseData.qcr.res.attributeList.push_back(longName);
       else
       {
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Error during URI expansion of attribute", shortName, OrionldDetailsString);
+        orionldErrorResponseCreate(OrionldBadRequestData, "Error during URI expansion of attribute", shortName, OrionldDetailsString);
         parseData.qcr.res.release();
         return false;
       }
@@ -366,14 +362,14 @@ bool orionldGetEntities(ConnectionInfo* ciP)
 
     if ((lexList = qLex(q, &title, &details)) == NULL)
     {
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, title, details, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, title, details, OrionldDetailsString);
       parseData.qcr.res.release();
       return false;
     }
 
     if ((qTree = qParse(lexList, &title, &details)) == NULL)
     {
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, title, details, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, title, details, OrionldDetailsString);
       parseData.qcr.res.release();
       return false;
     }
@@ -384,7 +380,7 @@ bool orionldGetEntities(ConnectionInfo* ciP)
     mongo::BSONObjBuilder objBuilder;
     if (qTreeToBsonObj(qTree, &objBuilder, &title, &details) == false)
     {
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, title, details, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, title, details, OrionldDetailsString);
       parseData.qcr.res.release();
       return false;
     }
@@ -539,7 +535,7 @@ bool orionldGetEntities(ConnectionInfo* ciP)
       delete sfP;
 
       parseData.qcr.res.release();
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Error parsing q StringFilter", details.c_str(), OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "Error parsing q StringFilter", details.c_str(), OrionldDetailsString);
       LM_E(("Error parsing q StringFilter"));
       return false;
     }

--- a/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
@@ -72,7 +72,7 @@ bool orionldGetEntity(ConnectionInfo* ciP)
   if ((urlCheck(orionldState.wildcard[0], &details) == false) && (urnCheck(orionldState.wildcard[0], &details) == false))
   {
     LM_W(("Bad Input (Invalid Entity ID - Not a URL nor a URN)"));
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid Entity ID", "Not a URL nor a URN", OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Invalid Entity ID", "Not a URL nor a URN", OrionldDetailsString);
     return false;
   }
 
@@ -92,7 +92,7 @@ bool orionldGetEntity(ConnectionInfo* ciP)
 
   if (response.errorCode.code == SccBadRequest)
   {
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Bad Request", NULL, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Bad Request", NULL, OrionldDetailsString);
     return false;
   }
 
@@ -133,7 +133,7 @@ bool orionldGetEntity(ConnectionInfo* ciP)
 
           if (attrList == NULL)
           {
-            orionldErrorResponseCreate(ciP, OrionldInternalError, "Out of memory", NULL, OrionldDetailsString);
+            orionldErrorResponseCreate(OrionldInternalError, "Out of memory", NULL, OrionldDetailsString);
             return false;
           }
 
@@ -147,7 +147,7 @@ bool orionldGetEntity(ConnectionInfo* ciP)
       }
       else
       {
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Error during URI expansion of attribute", shortName, OrionldDetailsString);
+        orionldErrorResponseCreate(OrionldBadRequestData, "Error during URI expansion of attribute", shortName, OrionldDetailsString);
         return false;
       }
     }

--- a/src/lib/orionld/serviceRoutines/orionldGetRegistration.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetRegistration.cpp
@@ -40,7 +40,7 @@ bool orionldGetRegistration(ConnectionInfo* ciP)
 {
   LM_T(LmtServiceRoutine, ("In orionldGetRegistration"));
 
-  orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Not implemented - GET /ngsi-ld/v1/csourceRegistrations/*", orionldState.wildcard[0], OrionldDetailsString);
+  orionldErrorResponseCreate(OrionldBadRequestData, "Not implemented - GET /ngsi-ld/v1/csourceRegistrations/*", orionldState.wildcard[0], OrionldDetailsString);
 
   ciP->httpStatusCode = SccNotImplemented;
 

--- a/src/lib/orionld/serviceRoutines/orionldGetRegistrations.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetRegistrations.cpp
@@ -39,7 +39,7 @@ bool orionldGetRegistrations(ConnectionInfo* ciP)
 {
   LM_T(LmtServiceRoutine, ("In orionldGetRegistration"));
 
-  orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Not implemented - GET /ngsi-ld/v1/csourceRegistrations", NULL, OrionldDetailsString);
+  orionldErrorResponseCreate(OrionldBadRequestData, "Not implemented - GET /ngsi-ld/v1/csourceRegistrations", NULL, OrionldDetailsString);
 
   ciP->httpStatusCode = SccNotImplemented;
 

--- a/src/lib/orionld/serviceRoutines/orionldGetSubscription.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetSubscription.cpp
@@ -54,7 +54,7 @@ bool orionldGetSubscription(ConnectionInfo* ciP)
   if (mongoGetLdSubscription(&subscription, orionldState.wildcard[0], orionldState.tenant, &ciP->httpStatusCode, &details) != true)
   {
     LM_E(("mongoGetLdSubscription error: %s", details));
-    orionldErrorResponseCreate(ciP, OrionldResourceNotFound, details, orionldState.wildcard[0], OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldResourceNotFound, details, orionldState.wildcard[0], OrionldDetailsString);
     return false;
   }
 

--- a/src/lib/orionld/serviceRoutines/orionldNotImplemented.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldNotImplemented.cpp
@@ -40,6 +40,6 @@ bool orionldNotImplemented(ConnectionInfo* ciP)
   ciP->httpStatusCode        = SccNotImplemented;
   orionldState.useLinkHeader = false;  // We don't want the Link header for version requests
 
-  orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Not Implemented", orionldState.serviceP->url, OrionldDetailsString);
+  orionldErrorResponseCreate(OrionldBadRequestData, "Not Implemented", orionldState.serviceP->url, OrionldDetailsString);
   return false;
 }

--- a/src/lib/orionld/serviceRoutines/orionldPatchAttribute.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchAttribute.cpp
@@ -46,7 +46,7 @@ bool orionldPatchAttribute(ConnectionInfo* ciP)
   if (mongoEntityExists(orionldState.wildcard[0], orionldState.tenant) == false)
   {
     ciP->httpStatusCode = SccNotFound;
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Entity does not exist", orionldState.wildcard[0], OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Entity does not exist", orionldState.wildcard[0], OrionldDetailsString);
     return false;
   }
 
@@ -54,7 +54,7 @@ bool orionldPatchAttribute(ConnectionInfo* ciP)
   if (orionldState.requestTree == NULL)
   {
     ciP->httpStatusCode = SccBadRequest;
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Payload is missing", NULL, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Payload is missing", NULL, OrionldDetailsString);
     return false;
   }
 
@@ -62,7 +62,7 @@ bool orionldPatchAttribute(ConnectionInfo* ciP)
   if  (orionldState.requestTree->type != KjObject)
   {
     ciP->httpStatusCode = SccBadRequest;
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Payload not a JSON object", kjValueType(orionldState.requestTree->type), OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Payload not a JSON object", kjValueType(orionldState.requestTree->type), OrionldDetailsString);
     return false;
   }
 
@@ -70,7 +70,7 @@ bool orionldPatchAttribute(ConnectionInfo* ciP)
   if  (orionldState.requestTree->value.firstChildP == NULL)
   {
     ciP->httpStatusCode = SccBadRequest;
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Payload is an empty JSON object", NULL, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Payload is an empty JSON object", NULL, OrionldDetailsString);
     return false;
   }
 
@@ -78,11 +78,11 @@ bool orionldPatchAttribute(ConnectionInfo* ciP)
   if (mongoAttributeExists(orionldState.wildcard[0], orionldState.wildcard[1], orionldState.tenant) == false)
   {
     ciP->httpStatusCode = SccNotFound;
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Attribute does not exist", orionldState.wildcard[1], OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Attribute does not exist", orionldState.wildcard[1], OrionldDetailsString);
     return false;
   }
 
   ciP->httpStatusCode = SccNotImplemented;
-  orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Not implemented - PATCH /ngsi-ld/v1/entities/*/attrs", orionldState.wildcard[0], OrionldDetailsString);
+  orionldErrorResponseCreate(OrionldBadRequestData, "Not implemented - PATCH /ngsi-ld/v1/entities/*/attrs", orionldState.wildcard[0], OrionldDetailsString);
   return true;
 }

--- a/src/lib/orionld/serviceRoutines/orionldPatchEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchEntity.cpp
@@ -52,7 +52,7 @@ bool orionldPatchEntity(ConnectionInfo* ciP)
   if (mongoEntityExists(entityId, orionldState.tenant) == false)
   {
     ciP->httpStatusCode = SccNotFound;
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Entity does not exist", entityId, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Entity does not exist", entityId, OrionldDetailsString);
     return false;
   }
 
@@ -60,7 +60,7 @@ bool orionldPatchEntity(ConnectionInfo* ciP)
   if (orionldState.requestTree == NULL)
   {
     ciP->httpStatusCode = SccBadRequest;
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Payload is missing", NULL, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Payload is missing", NULL, OrionldDetailsString);
     return false;
   }
 
@@ -69,7 +69,7 @@ bool orionldPatchEntity(ConnectionInfo* ciP)
   if  (orionldState.requestTree->type != KjObject)
   {
     ciP->httpStatusCode = SccBadRequest;
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Payload is not a JSON object", kjValueType(orionldState.requestTree->type), OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Payload is not a JSON object", kjValueType(orionldState.requestTree->type), OrionldDetailsString);
     return false;
   }
 
@@ -77,7 +77,7 @@ bool orionldPatchEntity(ConnectionInfo* ciP)
   if  (orionldState.requestTree->value.firstChildP == NULL)
   {
     ciP->httpStatusCode = SccBadRequest;
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Payload is an empty JSON object", NULL, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Payload is an empty JSON object", NULL, OrionldDetailsString);
     return false;
   }
 
@@ -97,7 +97,7 @@ bool orionldPatchEntity(ConnectionInfo* ciP)
       // Get the long name of the Context Attribute name
       if (orionldUriExpand(orionldState.contextP, attrNodeP->name, longAttrName, sizeof(longAttrName), &details) == false)
       {
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, details, attrNodeP->name, OrionldDetailsAttribute);
+        orionldErrorResponseCreate(OrionldBadRequestData, details, attrNodeP->name, OrionldDetailsAttribute);
         return false;
       }
       attrNameP = longAttrName;
@@ -106,7 +106,7 @@ bool orionldPatchEntity(ConnectionInfo* ciP)
     if (mongoAttributeExists(entityId, attrNameP, orionldState.tenant) == false)
     {
       ciP->httpStatusCode = SccNotFound;
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Attribute does not exist", attrNameP, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "Attribute does not exist", attrNameP, OrionldDetailsString);
       return false;
     }
   }
@@ -160,7 +160,7 @@ bool orionldPatchEntity(ConnectionInfo* ciP)
       {
         delete caP;
         mongoRequest.release();
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, details, kNodeP->name, OrionldDetailsAttribute);
+        orionldErrorResponseCreate(OrionldBadRequestData, details, kNodeP->name, OrionldDetailsAttribute);
         return false;
       }
 
@@ -192,7 +192,7 @@ bool orionldPatchEntity(ConnectionInfo* ciP)
   else
   {
     LM_E(("mongoUpdateContext: HTTP Status Code: %d", ciP->httpStatusCode));
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Internal Error", "Error from Mongo-DB backend", OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Internal Error", "Error from Mongo-DB backend", OrionldDetailsString);
     return false;
   }
 

--- a/src/lib/orionld/serviceRoutines/orionldPatchRegistration.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchRegistration.cpp
@@ -40,7 +40,7 @@ bool orionldPatchRegistration(ConnectionInfo* ciP)
 {
   LM_T(LmtServiceRoutine, ("In orionldPatchRegistration"));
 
-  orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Not implemented - PATCH /ngsi-ld/v1/csourceRegistrations/*", orionldState.wildcard[0], OrionldDetailsString);
+  orionldErrorResponseCreate(OrionldBadRequestData, "Not implemented - PATCH /ngsi-ld/v1/csourceRegistrations/*", orionldState.wildcard[0], OrionldDetailsString);
 
   ciP->httpStatusCode = SccNotImplemented;
 

--- a/src/lib/orionld/serviceRoutines/orionldPatchSubscription.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchSubscription.cpp
@@ -40,7 +40,7 @@ bool orionldPatchSubscription(ConnectionInfo* ciP)
 {
   LM_T(LmtServiceRoutine, ("In orionldPatchSubscription"));
 
-  orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Not implemented - PATCH /ngsi-ld/v1/subscriptions/*", orionldState.wildcard[0], OrionldDetailsString);
+  orionldErrorResponseCreate(OrionldBadRequestData, "Not implemented - PATCH /ngsi-ld/v1/subscriptions/*", orionldState.wildcard[0], OrionldDetailsString);
 
   ciP->httpStatusCode = SccNotImplemented;
 

--- a/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
@@ -135,13 +135,13 @@ static bool payloadCheck
   //
   if (orionldState.payloadIdNode == NULL)
   {
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Entity id is missing", "The 'id' field is mandatory", OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Entity id is missing", "The 'id' field is mandatory", OrionldDetailsString);
     return false;
   }
 
   if (orionldState.payloadTypeNode == NULL)
   {
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Entity type is missing", "The type field is mandatory", OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Entity type is missing", "The type field is mandatory", OrionldDetailsString);
     return false;
   }
 
@@ -183,7 +183,7 @@ static bool payloadCheck
       // FIXME: Make sure the type is either Property or Relationship
       if (orionldValidName(kNodeP->name, &detailsP) == false)
       {
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid Property/Relationship name", detailsP, OrionldDetailsString);
+        orionldErrorResponseCreate(OrionldBadRequestData, "Invalid Property/Relationship name", detailsP, OrionldDetailsString);
         return false;
       }
     }
@@ -230,7 +230,7 @@ bool orionldPostEntities(ConnectionInfo* ciP)
 
   if ((urlCheck(entityId, &details) == false) && (urnCheck(entityId, &details) == false))
   {
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid Entity id", "The id specified cannot be resolved to a URL or URN", OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Invalid Entity id", "The id specified cannot be resolved to a URL or URN", OrionldDetailsString);
     return false;
   }
 
@@ -240,7 +240,7 @@ bool orionldPostEntities(ConnectionInfo* ciP)
   //
   if (mongoEntityExists(entityId, orionldState.tenant) == true)
   {
-    orionldErrorResponseCreate(ciP, OrionldAlreadyExists, "Entity already exists", entityId, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldAlreadyExists, "Entity already exists", entityId, OrionldDetailsString);
     ciP->httpStatusCode = SccConflict;
     return false;
   }
@@ -297,13 +297,13 @@ bool orionldPostEntities(ConnectionInfo* ciP)
   }
   else if (expansions == -1)
   {
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid context item for 'entity type'", details, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Invalid context item for 'entity type'", details, OrionldDetailsString);
     mongoRequest.release();
     return false;
   }
   else  // expansions == 2 ... may be an incorrect context
   {
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid value of context item 'entity type'", orionldState.contextP->url, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Invalid value of context item 'entity type'", orionldState.contextP->url, OrionldDetailsString);
     mongoRequest.release();
     return false;
   }
@@ -324,7 +324,7 @@ bool orionldPostEntities(ConnectionInfo* ciP)
       // 2. Save it for future use (when creating the entity)
       if ((orionldState.overriddenCreationDate = parse8601Time(createdAtP->value.s)) == -1)
       {
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid value for 'createdAt' attribute", createdAtP->value.s, OrionldDetailsString);
+        orionldErrorResponseCreate(OrionldBadRequestData, "Invalid value for 'createdAt' attribute", createdAtP->value.s, OrionldDetailsString);
         mongoRequest.release();
         return false;
       }
@@ -339,7 +339,7 @@ bool orionldPostEntities(ConnectionInfo* ciP)
       // 2. Save it for future use (when creating the entity)
       if ((orionldState.overriddenModificationDate = parse8601Time(modifiedAtP->value.s)) == -1)
       {
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Invalid value for 'modifiedAt' attribute", modifiedAtP->value.s, OrionldDetailsString);
+        orionldErrorResponseCreate(OrionldBadRequestData, "Invalid value for 'modifiedAt' attribute", modifiedAtP->value.s, OrionldDetailsString);
         mongoRequest.release();
         return false;
       }
@@ -380,7 +380,7 @@ bool orionldPostEntities(ConnectionInfo* ciP)
           LM_E(("orionldUriExpand failed"));
           delete caP;
           mongoRequest.release();
-          orionldErrorResponseCreate(ciP, OrionldBadRequestData, details, kNodeP->name, OrionldDetailsAttribute);
+          orionldErrorResponseCreate(OrionldBadRequestData, details, kNodeP->name, OrionldDetailsAttribute);
           return false;
         }
 
@@ -414,7 +414,7 @@ bool orionldPostEntities(ConnectionInfo* ciP)
   if (ciP->httpStatusCode != SccOk)
   {
     LM_E(("mongoUpdateContext: HTTP Status Code: %d", ciP->httpStatusCode));
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Internal Error", "Error from Mongo-DB backend", OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Internal Error", "Error from Mongo-DB backend", OrionldDetailsString);
     return false;
   }
 

--- a/src/lib/orionld/serviceRoutines/orionldPostEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntity.cpp
@@ -133,7 +133,7 @@ bool kjTreeToContextElement(ConnectionInfo* ciP, KjNode* treeP, ContextElement* 
       if (orionldUriExpand(orionldState.contextP, kNodeP->name, longName, sizeof(longName), &details) == false)
       {
         delete caP;
-        orionldErrorResponseCreate(ciP, OrionldBadRequestData, details, kNodeP->name, OrionldDetailsAttribute);
+        orionldErrorResponseCreate(OrionldBadRequestData, details, kNodeP->name, OrionldDetailsAttribute);
         return false;
       }
 
@@ -447,7 +447,7 @@ bool orionldPostEntityOverwrite(ConnectionInfo* ciP)
   if (currentEntityTreeP == NULL)
   {
     ciP->httpStatusCode = SccNotFound;
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Entity does not exist", orionldState.wildcard[0], OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Entity does not exist", orionldState.wildcard[0], OrionldDetailsString);
     return false;
   }
 
@@ -464,7 +464,7 @@ bool orionldPostEntityOverwrite(ConnectionInfo* ciP)
   if (expandAttrNames(orionldState.requestTree, &details) == false)
   {
     ciP->httpStatusCode = SccReceiverInternalError;
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Can't expand attribute names", details, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Can't expand attribute names", details, OrionldDetailsString);
     return false;
   }
 
@@ -472,7 +472,7 @@ bool orionldPostEntityOverwrite(ConnectionInfo* ciP)
   if (kjTreeMergeAddNewAttrsOverwriteExisting(currentEntityTreeP, orionldState.requestTree, &title, &details) == false)
   {
     ciP->httpStatusCode = SccReceiverInternalError;
-    orionldErrorResponseCreate(ciP, OrionldInternalError, title, details, OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldInternalError, title, details, OrionldDetailsString);
     return false;
   }
 
@@ -545,7 +545,7 @@ bool orionldPostEntity(ConnectionInfo* ciP)
   if (mongoEntityExists(orionldState.wildcard[0], orionldState.tenant) == false)
   {
     ciP->httpStatusCode = SccNotFound;
-    orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Entity does not exist", orionldState.wildcard[0], OrionldDetailsString);
+    orionldErrorResponseCreate(OrionldBadRequestData, "Entity does not exist", orionldState.wildcard[0], OrionldDetailsString);
     return false;
   }
 
@@ -633,7 +633,7 @@ bool orionldPostEntity(ConnectionInfo* ciP)
     else
     {
       LM_E(("mongoUpdateContext: HTTP Status Code: %d", ciP->httpStatusCode));
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Internal Error", "Error from Mongo-DB Backend", OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "Internal Error", "Error from Mongo-DB Backend", OrionldDetailsString);
     }
 
     retValue = false;

--- a/src/lib/orionld/serviceRoutines/orionldPostRegistrations.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostRegistrations.cpp
@@ -79,7 +79,7 @@ bool orionldPostRegistrations(ConnectionInfo* ciP)
 
   // if (!registration.id.empty())
   // {
-  //   orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Registration already exists", regIdP, OrionldDetailsString);
+  //   orionldErrorResponseCreate(OrionldBadRequestData, "Registration already exists", regIdP, OrionldDetailsString);
   //   return false;
   // }
 

--- a/src/lib/orionld/serviceRoutines/orionldPostSubscriptions.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostSubscriptions.cpp
@@ -113,7 +113,7 @@ bool orionldPostSubscriptions(ConnectionInfo* ciP)
 
     if (mongoGetLdSubscription(&subscription, subIdP, orionldState.tenant, &ciP->httpStatusCode, &details) == true)
     {
-      orionldErrorResponseCreate(ciP, OrionldBadRequestData, "Subscription already exists", subIdP, OrionldDetailsString);
+      orionldErrorResponseCreate(OrionldBadRequestData, "Subscription already exists", subIdP, OrionldDetailsString);
       return false;
     }
   }


### PR DESCRIPTION
Removed first parameter (`ConnectionInfo* ciP`) from `orionldErrorResponseCreate()`