### PR TITLE
bug/entityid-no-longer-needed-to-create-context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ env:
   matrix:
   - STAGE=compliance
   - STAGE=debian_unit
-  - STAGE=debian_functional_1_300
-  - STAGE=debian_functional_301_600
-  - STAGE=debian_functional_601_900
-  - STAGE=debian_functional_901_1200
+  - STAGE=debian_functional_1_350
+  - STAGE=debian_functional_351_630
+  - STAGE=debian_functional_631_950
+  - STAGE=debian_functional_951_1300
   - STAGE=debian_release
   - STAGE=debian_deps
 before_install:

--- a/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
@@ -534,14 +534,11 @@ static bool payloadParseAndExtractSpecialFields(ConnectionInfo* ciP, bool* conte
     *contextToBeCashedP = true;
 
     //
-    // Create the name of the context to be cached
+    // Create the name of the context to be cached - a uuid
     //
     // FIXME: This needs to be discussed in the Bindings document.
     // FIXME: What about creation of Subscriptions? Should be treated the same. Context name == sub id
     //
-    if (orionldState.payloadIdNode == NULL)
-      LM_X(1, ("Context must be created but the 'id' node in the payload is missing - we shouldn't get this far - BUG!"));
-
     char uuid[37];
 
     uuidGenerate(uuid);


### PR DESCRIPTION
Removed the check that the id node was present - no longer needed