### PR TITLE
Bug/ngsild test suite errors

### DIFF
--- a/src/lib/orionld/common/orionldRequestSend.h
+++ b/src/lib/orionld/common/orionldRequestSend.h
@@ -40,7 +40,8 @@ extern bool orionldRequestSend
   int                     tmoInMilliSeconds,
   char**                  detailsPP,
   bool*                   tryAgainP,
-  bool*                   downloadFailedP
+  bool*                   downloadFailedP,
+  const char*             acceptHeader
 );
 
 #endif  // SRC_LIB_ORIONLD_COMMON_ORIONLDREQUESTSEND_H_

--- a/src/lib/orionld/common/urlCheck.cpp
+++ b/src/lib/orionld/common/urlCheck.cpp
@@ -97,11 +97,8 @@ bool urlCheck(char* url, char** detailsPP)
   }
 
   if (*urlP == 0)
-  {
-    if (detailsPP != NULL)
-      *detailsPP = (char*) "URL parse error - no slash found after IP address";
-    return false;
-  }
+    return true;
+
   ip[toIx] = 0;
 
   // FIXME: Check that 'ip' is a valid IP address
@@ -131,12 +128,10 @@ bool urlCheck(char* url, char** detailsPP)
       portNumberString[toIx++] = *urlP;
       ++urlP;
     }
+
     if (*urlP == 0)
-    {
-      if (detailsPP != NULL)
-        *detailsPP = (char*) "URL parse error - no slash found after port number";
-      return false;
-    }
+      return true;
+
     portNumberString[toIx] = 0;
 
     for (char* portCharP = portNumberString; *portCharP != 0; ++portCharP)
@@ -155,6 +150,9 @@ bool urlCheck(char* url, char** detailsPP)
   //
   if (*urlP != '/')
   {
+    if (*urlP == 0)
+      return true;
+
     if (detailsPP != NULL)
       *detailsPP = (char*) "URL parse error - no slash found to start the URL PATH";
     return false;

--- a/src/lib/orionld/common/urlParse.cpp
+++ b/src/lib/orionld/common/urlParse.cpp
@@ -116,10 +116,8 @@ bool urlParse
   }
 
   if (url[urlIx] == 0)
-  {
-    *detailsPP = (char*) "URL parse error - no slash found after IP address";
-    return false;
-  }
+    return true;
+
   ip[toIx] = 0;
 
 
@@ -138,11 +136,10 @@ bool urlParse
     {
       portNumberString[toIx++] = url[urlIx++];
     }
+
     if (url[urlIx] == 0)
-    {
-      *detailsPP = (char*) "URL parse error - no slash found after port number";
-      return false;
-    }
+      return true;
+
     portNumberString[toIx] = 0;
     *portP = atoi(portNumberString);
   }

--- a/src/lib/orionld/context/orionldContextDownloadAndParse.cpp
+++ b/src/lib/orionld/context/orionldContextDownloadAndParse.cpp
@@ -112,7 +112,7 @@ KjNode* orionldContextDownloadAndParse(Kjson* kjsonP, const char* url, bool useI
     bool tryAgain = false;
     bool reqOk;
 
-    reqOk = orionldRequestSend(&httpResponse, url, contextDownloadTimeout, detailsPP, &tryAgain, downloadFailedP);
+    reqOk = orionldRequestSend(&httpResponse, url, contextDownloadTimeout, detailsPP, &tryAgain, downloadFailedP, "Accept: application/ld+json");
     if (reqOk == true)
     {
       ok = true;

--- a/test/functionalTest/cases/0000_ngsild/ngsild_testsuite-query_by_type_right_@context.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_testsuite-query_by_type_right_@context.test
@@ -1,0 +1,110 @@
+# Copyright 2019 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+NGSILD-TestSuite: Name prefixes test  query by type. Right @context
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+brokerStart CB 0-255
+
+--SHELL--
+
+#
+# 01. Creation of entity of type T_Query, using context https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld
+# 02. Query by type T_Query, using the very same context - make sure the entity is found
+#
+
+echo "01. Creation of entity of type T_Query, using context https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld"
+echo "================================================================================================================================="
+payload='{
+    "id": "urn:ngsi-ld:T:I123k467:Context",
+    "type": "ex:T_Query",
+    "ex:P100": {
+      "type": "Property",
+      "value": 12
+    },
+    "R100": {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:T2:6789"
+    },
+    "schema:name": {
+      "type": "Property",
+      "value": "XX"
+    },
+    "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld"
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload" -H "Content-Type: application/ld+json"
+echo
+echo
+
+
+echo "02. Query by type T_Query, using the very same context - make sure the entity is found"
+echo "======================================================================================"
+orionCurl --url /ngsi-ld/v1/entities?type=ex:T_Query -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+echo
+echo
+
+
+--REGEXPECT--
+01. Creation of entity of type T_Query, using context https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld
+=================================================================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:T:I123k467:Context
+Date: REGEX(.*)
+
+
+
+02. Query by type T_Query, using the very same context - make sure the entity is found
+======================================================================================
+HTTP/1.1 200 OK
+Content-Length: 205
+Content-Type: application/json
+Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+[
+    {
+        "P100": {
+            "type": "Property",
+            "value": 12
+        },
+        "R100": {
+            "object": "urn:ngsi-ld:T2:6789",
+            "type": "Relationship"
+        },
+        "id": "urn:ngsi-ld:T:I123k467:Context",
+        "schema:name": {
+            "type": "Property",
+            "value": "XX"
+        },
+        "type": "T_Query"
+    }
+]
+
+
+--TEARDOWN--
+brokerStop CB
+accumulatorStop
+dbDrop CB

--- a/test/functionalTest/cases/0000_ngsild/ngsild_testsuite-simple_subscription_to_concrete_attribute.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_testsuite-simple_subscription_to_concrete_attribute.test
@@ -1,0 +1,182 @@
+# Copyright 2019 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+NGSILD-TestSuite: Should send a notification. Simple subscription to concrete attribute. Subsequent update
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+brokerStart CB 0-255
+accumulatorStart --pretty-print
+
+--SHELL--
+
+#
+# FIXME: Once notifications for non-mongoBackend requests are implemented, this functest needs to be modified
+#
+# 01. Creation of entity
+# 02. Creation of subscription - initial notification should be received by the accumulator
+# 03. Dump and reset accumulator. See one notification
+# 04. Update the entity - provoking a notification - except ... notifications for POST /entities/attrs without 'options=noOverwrite' hasn't been implemented
+# 05. Dump accumulator. See no notifications
+#
+
+echo "01. Creation of entity"
+echo "======================"
+payload='{
+  "id": "urn:ngsi-ld:Vehicle:V1234",
+  "type": "Vehicle",
+  "speed": {
+    "type": "Property",
+    "value": 34
+  },
+  "brandName": {
+    "type": "Property",
+    "value": "Mercedes"
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "02. Creation of subscription - initial notification should be received by the accumulator"
+echo "========================================================================================="
+payload='{
+  "id": "urn:ngsi-ld:Subscription:mySubscription:20-09-2019:13:13:00",
+  "type": "Subscription",
+  "entities": [
+    {
+      "type": "Vehicle"
+    }
+  ],
+  "watchedAttributes": ["speed"],
+  "notification": {
+    "endpoint": {
+      "uri": "http://localhost:'$LISTENER_PORT'/notify",
+      "accept": "application/json"
+    }
+  }
+}'
+orionCurl --url /ngsi-ld/v1/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo "03. Dump and reset accumulator. See one notification"
+echo "===================================================="
+accumulatorDump
+accumulatorReset
+echo
+echo
+
+
+echo "04. Update the entity - provoking a notification - except ... notifications for POST /entities/attrs without 'options=noOverwrite' hasn't been implemented"
+echo "=========================================================================================================================================================="
+payload='{
+  "type": "Property",
+  "value": 5
+}'
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:Vehicle:V1234/attrs --payload "$payload"
+echo
+echo
+
+
+sleep 1
+echo "05. Dump accumulator. See no notifications"
+echo "=========================================="
+accumulatorDump
+echo
+echo
+
+
+--REGEXPECT--
+01. Creation of entity
+======================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:Vehicle:V1234
+Date: REGEX(.*)
+
+
+
+02. Creation of subscription - initial notification should be received by the accumulator
+=========================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:mySubscription:20-09-2019:13:13:00
+Date: REGEX(.*)
+
+
+
+03. Dump and reset accumulator. See one notification
+====================================================
+POST http://REGEX(.*)/notify
+Fiware-Servicepath: /
+Content-Length: 346
+User-Agent: orion/REGEX(.*)
+Ngsiv2-Attrsformat: normalized
+Host: REGEX(.*)
+Accept: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Content-Type: application/json; charset=utf-8
+
+{
+    "data": [
+        {
+            "brandName": {
+                "type": "Property", 
+                "value": "Mercedes"
+            }, 
+            "id": "urn:ngsi-ld:Vehicle:V1234", 
+            "speed": {
+                "type": "Property", 
+                "value": 34
+            }, 
+            "type": "Vehicle"
+        }
+    ], 
+    "id": "urn:ngsi-ld:Notification:REGEX(.*)", 
+    "notifiedAt": "REGEX(.*)", 
+    "subscriptionId": "urn:ngsi-ld:Subscription:mySubscription:20-09-2019:13:13:00", 
+    "type": "Notification"
+}
+=======================================
+
+
+04. Update the entity - provoking a notification - except ... notifications for POST /entities/attrs without 'options=noOverwrite' hasn't been implemented
+==========================================================================================================================================================
+HTTP/1.1 204 No Content
+Content-Length: 0
+Date: REGEX(.*)
+
+
+
+05. Dump accumulator. See no notifications
+==========================================
+
+
+--TEARDOWN--
+brokerStop CB
+accumulatorStop
+dbDrop CB


### PR DESCRIPTION
* Fixed a bug about type/value/object not having to be json objects
* Accepting application/ld+json for download of contexts
* Bug fix: URLs can now *not* carry a slash after IP:PORT. I.e. `http://a.b.c` is now considered a valid URL.
