### PR TITLE
Bug/issue 241 part ii

### DIFF
--- a/src/lib/orionld/kjTree/kjTreeFromNotification.cpp
+++ b/src/lib/orionld/kjTree/kjTreeFromNotification.cpp
@@ -49,6 +49,39 @@ extern "C"
 
 // -----------------------------------------------------------------------------
 //
+// debugContextElement - FIXME: Remove this function
+//
+void debugContextElement(ContextElement* ceP)
+{
+  LM_TMP(("NOTIF: Entity ID:   %s", ceP->entityId.id.c_str()));
+  LM_TMP(("NOTIF: Entity TYPE: %s", ceP->entityId.type.c_str()));
+
+  for (unsigned int aIx = 0; aIx < ceP->contextAttributeVector.size(); aIx++)
+  {
+    ContextAttribute*  aP       = ceP->contextAttributeVector[aIx];
+    const char*        attrName = aP->name.c_str();
+
+    LM_TMP(("NOTIF: Attribute %d:", aIx, attrName));
+    LM_TMP(("NOTIF:   Name:        %s",   attrName));
+    LM_TMP(("NOTIF:   Type:        %s",   aP->type.c_str()));
+    LM_TMP(("NOTIF:   Value Type:  %s",   valueTypeName(aP->valueType)));
+    LM_TMP(("NOTIF:   Metadatas:   %llu", aP->metadataVector.size()));
+
+    for (unsigned int ix = 0; ix < aP->metadataVector.size(); ix++)
+    {
+      Metadata* mdP = aP->metadataVector[ix];
+
+      LM_TMP(("NOTIF:   Metadata %d:", ix));
+      LM_TMP(("NOTIF:     Name:  %s", mdP->name.c_str()));
+      LM_TMP(("NOTIF:     Type:  %s", mdP->type.c_str()));
+    }
+  }
+}
+
+
+
+// -----------------------------------------------------------------------------
+//
 // kjTreeFromNotification -
 //
 KjNode* kjTreeFromNotification(NotifyContextRequest* ncrP, const char* context, MimeType mimeType, RenderFormat renderFormat, char** detailsP)
@@ -130,6 +163,10 @@ KjNode* kjTreeFromNotification(NotifyContextRequest* ncrP, const char* context, 
     alias = orionldAliasLookup(contextP, ceP->entityId.type.c_str());
     nodeP = kjString(orionldState.kjsonP, "type", alias);
     kjChildAdd(objectP, nodeP);
+
+    // <DEBUG>
+    debugContextElement(ceP);
+    // </DEBUG>
 
     // Attributes
     LM_TMP(("NOTIF: Adding %d attributes to the Notification kjTree", (int) ceP->contextAttributeVector.size()));

--- a/src/lib/orionld/serviceRoutines/orionldPostEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntity.cpp
@@ -715,25 +715,17 @@ static bool subscriptionMatchCallback
 #if 0
   if (throttlingP != NULL)
   {
-    int      lastNotification  = 0;
-    KjNode*  lastFailureP      = kjLookup(subscriptionTree, "lastFailure");
-    KjNode*  lastSuccessP      = kjLookup(subscriptionTree, "lastSuccess");
+    KjNode*  lastNotificationP = kjLookup(subscriptionTree, "lastNotification");
 
-    LM_TMP(("NFY: Throttling: %llu", throttlingP->value.i));
-
-    if (lastFailureP != NULL)
-      lastNotification = lastFailureP->value.i;
-    if (lastSuccessP != NULL)
+    if (lastNotificationP != NULL)
     {
-      if (lastSuccessP->value.i > lastNotification)
-        lastNotification = lastSuccessP->value.i;
-    }
+      now = time(NULL);
 
-    now = time(NULL);
-    if (now < lastNotification + throttlingP->value.i)
-    {
-      LM_TMP(("NFY: No notification to be sent due to throttling (%d). Now: %d, lastNotification: %d", throttlingP->value.i, now, lastNotification));
-      return false;
+      if (lastNotificationP->value.i + throttlingP->value.i > now)
+      {
+        LM_TMP(("NFY: No notification to be sent due to throttling (%d). Now: %d, lastNotification: %d", throttlingP->value.i, now, lastNotification));
+        return false;
+      }
     }
   }
 #endif

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0241_location-in-notifications.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0241_location-in-notifications.test
@@ -21,7 +21,7 @@
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
 --NAME--
-Notifications - response of normalized format subscription (nested JSON problem)
+Notifications - correct representation of location inside notifications
 
 --SHELL-INIT--
 export BROKER=orionld
@@ -32,46 +32,17 @@ accumulatorStart --pretty-print
 --SHELL--
 
 #
-# 01. Create an Entity urn:ngsi-ld:Vehicle:A4501, with both Property and Relationship with metadata
+# 01. Create an Entity urn:ngsi-ld:Vehicle:A4501, with a 'location' property
 # 02. Create a subscription matching the entity
-# 03. Dump the accumulator to see the initial notification
+# 03. Dump the accumulator to see the initial notification, make sure the 'location' property is OK
 # 04. See the entity in mongo
 #
 
-echo "01. Create an Entity urn:ngsi-ld:Vehicle:A4501, with both Property and Relationship with metadata"
-echo "================================================================================================="
+echo "01. Create an Entity urn:ngsi-ld:Vehicle:A4501, with a 'location' property"
+echo "=========================================================================="
 payload='{
   "id": "urn:ngsi-ld:Vehicle:A4501",
   "type": "Vehicle",
-  "brandName": {
-    "type": "Property",
-    "value": "Mercedes"
-  },
-  "isParked": {
-    "type": "Relationship",
-    "object": "urn:ngsi-ld:OffStreetParking:Downtown1",
-    "observedAt": "2018-12-04T12:00:00Z",
-    "providedBy": {
-      "type": "Relationship",
-      "object": "urn:ngsi-ld:Person:Bob"
-    },
-    "subProp": {
-      "type": "Property",
-      "value": "prop-subProp"
-    }
-  },
-  "prop": {
-    "type": "Property",
-    "value": "prop with sub-prop",
-    "providedBy": {
-      "type": "Relationship",
-      "object": "urn:ngsi-ld:Person:Bob2"
-    },
-    "subProp": {
-      "type": "Property",
-      "value": "prop-subProp"
-    }
-  },
   "location": {
     "type": "GeoProperty",
     "value": {
@@ -82,9 +53,7 @@ payload='{
       ]
     }
   },
-  "@context": [
-    "http://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
-  ]
+  "@context": [ "http://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld" ]
 }'
 orionCurl --url /ngsi-ld/v1/entities --payload "$payload" -H "Content-Type: application/ld+json"
 echo
@@ -116,10 +85,11 @@ echo
 echo
 
 
-echo "03. Dump the accumulator to see the initial notification"
-echo "========================================================"
+echo "03. Dump the accumulator to see the initial notification, make sure the 'location' property is OK"
+echo "================================================================================================="
 sleep 1
 accumulatorDump
+accumulatorReset
 echo
 echo
 
@@ -132,8 +102,8 @@ echo
 
 
 --REGEXPECT--
-01. Create an Entity urn:ngsi-ld:Vehicle:A4501, with both Property and Relationship with metadata
-=================================================================================================
+01. Create an Entity urn:ngsi-ld:Vehicle:A4501, with a 'location' property
+==========================================================================
 HTTP/1.1 201 Created
 Content-Length: 0
 Link: REGEX(.*)
@@ -151,11 +121,11 @@ Date: REGEX(.*)
 
 
 
-03. Dump the accumulator to see the initial notification
-========================================================
+03. Dump the accumulator to see the initial notification, make sure the 'location' property is OK
+=================================================================================================
 POST http://REGEX(.*)/notify
 Fiware-Servicepath: /
-Content-Length: 858
+Content-Length: 381
 User-Agent: orion/REGEX(.*)
 Ngsiv2-Attrsformat: normalized
 Host: REGEX(.*)
@@ -166,24 +136,7 @@ Content-Type: application/ld+json
     "@context": "http://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld", 
     "data": [
         {
-            "brandName": {
-                "type": "Property", 
-                "value": "Mercedes"
-            }, 
             "id": "urn:ngsi-ld:Vehicle:A4501", 
-            "isParked": {
-                "object": "urn:ngsi-ld:OffStreetParking:Downtown1", 
-                "observedAt": "2018-12-04T12:00:00Z", 
-                "providedBy": {
-                    "object": "urn:ngsi-ld:Person:Bob", 
-                    "type": "Relationship"
-                }, 
-                "subProp": {
-                    "type": "Property", 
-                    "value": "prop-subProp"
-                }, 
-                "type": "Relationship"
-            }, 
             "location": {
                 "type": "GeoProperty", 
                 "value": {
@@ -193,18 +146,6 @@ Content-Type: application/ld+json
                     ], 
                     "type": "Point"
                 }
-            }, 
-            "prop": {
-                "providedBy": {
-                    "object": "urn:ngsi-ld:Person:Bob2", 
-                    "type": "Relationship"
-                }, 
-                "subProp": {
-                    "type": "Property", 
-                    "value": "prop-subProp"
-                }, 
-                "type": "Property", 
-                "value": "prop with sub-prop"
             }, 
             "type": "Vehicle"
         }
@@ -229,68 +170,14 @@ MongoDB server version: REGEX(.*)
 		"servicePath" : "/"
 	},
 	"attrNames" : [
-		"https://uri.etsi.org/ngsi-ld/default-context/brandName",
-		"https://uri.etsi.org/ngsi-ld/default-context/isParked",
-		"https://uri.etsi.org/ngsi-ld/default-context/prop",
 		"location"
 	],
 	"attrs" : {
-		"https://uri=etsi=org/ngsi-ld/default-context/brandName" : {
-			"type" : "Property",
-			"creDate" : REGEX(.*),
-			"modDate" : REGEX(.*),
-			"value" : "Mercedes",
-			"mdNames" : [ ]
-		},
-		"https://uri=etsi=org/ngsi-ld/default-context/isParked" : {
-			"type" : "Relationship",
-			"creDate" : REGEX(.*),
-			"modDate" : REGEX(.*),
-			"value" : "urn:ngsi-ld:OffStreetParking:Downtown1",
-			"md" : {
-				"observedAt" : {
-					"value" : 1543924800
-				},
-				"https://uri=etsi=org/ngsi-ld/default-context/providedBy" : {
-					"type" : "Relationship",
-					"value" : "urn:ngsi-ld:Person:Bob"
-				},
-				"https://uri=etsi=org/ngsi-ld/default-context/subProp" : {
-					"type" : "Property",
-					"value" : "prop-subProp"
-				}
-			},
-			"mdNames" : [
-				"observedAt",
-				"https://uri.etsi.org/ngsi-ld/default-context/providedBy",
-				"https://uri.etsi.org/ngsi-ld/default-context/subProp"
-			]
-		},
-		"https://uri=etsi=org/ngsi-ld/default-context/prop" : {
-			"type" : "Property",
-			"creDate" : REGEX(.*),
-			"modDate" : REGEX(.*),
-			"value" : "prop with sub-prop",
-			"md" : {
-				"https://uri=etsi=org/ngsi-ld/default-context/providedBy" : {
-					"type" : "Relationship",
-					"value" : "urn:ngsi-ld:Person:Bob2"
-				},
-				"https://uri=etsi=org/ngsi-ld/default-context/subProp" : {
-					"type" : "Property",
-					"value" : "prop-subProp"
-				}
-			},
-			"mdNames" : [
-				"https://uri.etsi.org/ngsi-ld/default-context/providedBy",
-				"https://uri.etsi.org/ngsi-ld/default-context/subProp"
-			]
-		},
 		"location" : {
 			"type" : "GeoProperty",
 			"creDate" : REGEX(.*),
 			"modDate" : REGEX(.*),
-			"value" : {
+			"value" : {	
 				"type" : "Point",
 				"coordinates" : [
 					-8.5,

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0241_notifications.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0241_notifications.test
@@ -32,13 +32,13 @@ accumulatorStart --pretty-print
 --SHELL--
 
 #
-# 01. Create an Entity urn:ngsi-ld:Vehicle:A4501
+# 01. Create an Entity urn:ngsi-ld:Vehicle:A4501, with both Property and Relationship with metadata
 # 02. Create a subscription matching the entity
 # 03. Dump the accumulator to see the initial notification, then reset the accumulator
 #
 
-echo "01. Create an Entity urn:ngsi-ld:Vehicle:A4501"
-echo "=============================================="
+echo "01. Create an Entity urn:ngsi-ld:Vehicle:A4501, with both Property and Relationship with metadata"
+echo "================================================================================================="
 payload='{
   "id": "urn:ngsi-ld:Vehicle:A4501",
   "type": "Vehicle",
@@ -53,6 +53,22 @@ payload='{
     "providedBy": {
       "type": "Relationship",
       "object": "urn:ngsi-ld:Person:Bob"
+    },
+    "subProp": {
+      "type": "Property",
+      "value": "prop-subProp"
+    }
+  },
+  "prop": {
+    "type": "Property",
+    "value": "prop with sub-prop",
+    "providedBy": {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:Person:Bob2"
+    },
+    "subProp": {
+      "type": "Property",
+      "value": "prop-subProp"
     }
   },
   "@context": [
@@ -106,8 +122,8 @@ echo
 
 
 --REGEXPECT--
-01. Create an Entity urn:ngsi-ld:Vehicle:A4501
-==============================================
+01. Create an Entity urn:ngsi-ld:Vehicle:A4501, with both Property and Relationship with metadata
+=================================================================================================
 HTTP/1.1 201 Created
 Content-Length: 0
 Link: REGEX(.*)
@@ -129,7 +145,7 @@ Date: REGEX(.*)
 ====================================================================================
 POST http://REGEX(.*)/notify
 Fiware-Servicepath: /
-Content-Length: 539
+Content-Length: 773
 User-Agent: orion/REGEX(.*)
 Ngsiv2-Attrsformat: normalized
 Host: REGEX(.*)
@@ -152,7 +168,23 @@ Content-Type: application/ld+json
                     "object": "urn:ngsi-ld:Person:Bob",
                     "type": "Relationship"
                 },
+                "subProp": {
+                    "type": "Property", 
+                    "value": "prop-subProp"
+                }, 
                 "type": "Relationship"
+            }, 
+            "prop": {
+                "providedBy": {
+                    "object": "urn:ngsi-ld:Person:Bob2", 
+                    "type": "Relationship"
+                }, 
+                "subProp": {
+                    "type": "Property", 
+                    "value": "prop-subProp"
+                }, 
+                "type": "Property", 
+                "value": "prop with sub-prop"
             }, 
             "type": "Vehicle"
         }
@@ -178,7 +210,8 @@ MongoDB server version: REGEX(.*)
 	},
 	"attrNames" : [
 		"https://uri.etsi.org/ngsi-ld/default-context/brandName",
-		"https://uri.etsi.org/ngsi-ld/default-context/isParked"
+		"https://uri.etsi.org/ngsi-ld/default-context/isParked",
+		"https://uri.etsi.org/ngsi-ld/default-context/prop"
 	],
 	"attrs" : {
 		"https://uri=etsi=org/ngsi-ld/default-context/brandName" : {
@@ -200,11 +233,36 @@ MongoDB server version: REGEX(.*)
 				"https://uri=etsi=org/ngsi-ld/default-context/providedBy" : {
 					"type" : "Relationship",
 					"value" : "urn:ngsi-ld:Person:Bob"
+				},
+				"https://uri=etsi=org/ngsi-ld/default-context/subProp" : {
+					"type" : "Property",
+					"value" : "prop-subProp"
 				}
 			},
 			"mdNames" : [
 				"observedAt",
-				"https://uri.etsi.org/ngsi-ld/default-context/providedBy"
+				"https://uri.etsi.org/ngsi-ld/default-context/providedBy",
+				"https://uri.etsi.org/ngsi-ld/default-context/subProp"
+			]
+		},
+		"https://uri=etsi=org/ngsi-ld/default-context/prop" : {
+			"type" : "Property",
+			"creDate" : REGEX(.*),
+			"modDate" : REGEX(.*),
+			"value" : "prop with sub-prop",
+			"md" : {
+				"https://uri=etsi=org/ngsi-ld/default-context/providedBy" : {
+					"type" : "Relationship",
+					"value" : "urn:ngsi-ld:Person:Bob2"
+				},
+				"https://uri=etsi=org/ngsi-ld/default-context/subProp" : {
+					"type" : "Property",
+					"value" : "prop-subProp"
+				}
+			},
+			"mdNames" : [
+				"https://uri.etsi.org/ngsi-ld/default-context/providedBy",
+				"https://uri.etsi.org/ngsi-ld/default-context/subProp"
 			]
 		}
 	},


### PR DESCRIPTION
Fixed second part of #241 (I hope :))

Fixed a bug about GeoProperty in notifications.
Also, ignoring the metadata "location" of GeoProperties - that is added by "old orion" to describe the unit of the geo-coords. As the unit isn't the correct one for orionld, this field is ignored in ngsi-ld notifications.

