### PR TITLE
Allowing most characters in attribute names for NGSI-LD requests

### DIFF
--- a/src/lib/orionld/common/orionldEntityPayloadCheck.cpp
+++ b/src/lib/orionld/common/orionldEntityPayloadCheck.cpp
@@ -72,26 +72,25 @@ bool orionldValidName(char* name, char** detailsPP)
   for (; *name != 0; ++name)
   {
     //
-    // Valid chars:
-    //   o a-z: 97-122
-    //   o A-Z: 65-90
-    //   o 0-9: 48-57
-    //   o '_': 95
+    // Invalid chars:
+    //   '=',
+    //   '[',
+    //   ']',
+    //   '&',
+    //   '?',
+    //   '"',
+    //   ''',
+    //   '\b',
+    //   '\t',
+    //   '\n', and
+    //   '#'
     //
-
-    if ((*name >= 'a') && (*name <= 'z'))
-      continue;
-    if ((*name >= 'A') && (*name <= 'Z'))
-      continue;
-    if ((*name >= '0') && (*name <= '9'))
-      continue;
-    if (*name == '_')
-      continue;
-    if (*name == ':')
-      continue;
-
-    *detailsPP = (char*) "invalid character in name";
-    return false;
+    if ((*name == '=') || (*name == '[') || (*name == ']') || (*name == '&') || (*name == '?') || (*name == '"') ||
+        (*name == '\'') || (*name == '\b') || (*name == '\t') || (*name == '\n') || (*name == '#'))
+    {
+      *detailsPP = (char*) "invalid character in name";
+      return false;
+    }
   }
 
   return true;

--- a/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
@@ -283,6 +283,7 @@ static bool payloadEmptyCheck(ConnectionInfo* ciP)
 }
 
 
+
 // -----------------------------------------------------------------------------
 //
 // kjNodeDecouple -

--- a/src/lib/orionld/serviceRoutines/orionldGetEntities.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntities.cpp
@@ -36,7 +36,6 @@ extern "C"
 
 #include "serviceRoutines/postQueryContext.h"                  // V1 service routine that does the whole work ...
 #include "rest/ConnectionInfo.h"                               // ConnectionInfo
-#include "mongoBackend/mongoQueryContext.h"                    // mongoQueryContext
 #include "orionld/common/SCOMPARE.h"                           // SCOMPAREx
 #include "orionld/common/urlCheck.h"                           // urlCheck
 #include "orionld/common/urnCheck.h"                           // urnCheck

--- a/src/lib/rest/StringFilter.cpp
+++ b/src/lib/rest/StringFilter.cpp
@@ -464,7 +464,7 @@ bool StringFilterItem::valueGet
   {
     if (forbiddenChars(s, ""))
     {
-      LM_E(("forbidden characters in String Filter"));
+      LM_E(("forbidden characters in String Filter '%s'", s));
       *errorStringP = std::string("forbidden characters in String Filter");
       return false;
     }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_strange_chars_in_attr_names.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_strange_chars_in_attr_names.test
@@ -1,0 +1,118 @@
+# Copyright 2019 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Strange characters in attribute names during entity creation
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+brokerStart CB 212-249
+
+--SHELL--
+
+#
+# 01. Create an entity with attributes that have strange characters
+# 02. GET the entity just to see the funny char in the attribute names
+# 03. GET All entities, just to see how GET /entities respond
+#
+echo "01. Create an entity with attributes that have strange characters"
+echo "================================================================="
+payload='{
+  "id": "http://a.b.c/entity/E1",
+  "type": "xxx",
+  "Straße": {
+    "type": "Property",
+    "value": "Strasse"
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "02. GET the entity just to see the funny char in the attribute names"
+echo "===================================================================="
+orionCurl --url /ngsi-ld/v1/entities/http://a.b.c/entity/E1
+echo
+echo
+
+
+echo "03. GET All entities, just to see how GET /entities respond"
+echo "==========================================================="
+orionCurl --url /ngsi-ld/v1/entities?type=xxx
+echo
+echo
+
+
+--REGEXPECT--
+01. Create an entity with attributes that have strange characters
+=================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Location: /ngsi-ld/v1/entities/http://a.b.c/entity/E1
+Date: REGEX(.*)
+
+
+
+02. GET the entity just to see the funny char in the attribute names
+====================================================================
+HTTP/1.1 200 OK
+Content-Length: 92
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+{
+    "Stra\u00dfe": {
+        "type": "Property",
+        "value": "Strasse"
+    },
+    "id": "http://a.b.c/entity/E1",
+    "type": "xxx"
+}
+
+
+03. GET All entities, just to see how GET /entities respond
+===========================================================
+HTTP/1.1 200 OK
+Content-Length: 94
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+[
+    {
+        "Stra\u00dfe": {
+            "type": "Property",
+            "value": "Strasse"
+        },
+        "id": "http://a.b.c/entity/E1",
+        "type": "xxx"
+    }
+]
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
This is a new request from ETSI to allow for (among other languages) Japanese characters in attribute names. 

New set of forbidden characters:
 * =
 * [
 * ]
 * &
 * ?
 * "
 * '
 * \b
 * \t
 * \n
 * `#`