### PR TITLE
bug/db-crash-at-startup-if-subs-in-db-due-to-OID

### DIFF
--- a/src/lib/mongoBackend/mongoSubCache.cpp
+++ b/src/lib/mongoBackend/mongoSubCache.cpp
@@ -119,13 +119,20 @@ int mongoSubCacheItemInsert(const char* tenant, const BSONObj& sub)
 
 #ifdef ORIONLD
   //
-  // FIXME: Check whether idField is an OID before calling OID
-  //        Should check whether the subscription was created with NGSI-LD or not
-  //        I can always check idField.toString().c_str() ...
+  // Make sure 'idField' is an OID before calling OID.
+  // Subs created with NGSI-LD aren't OIDs, so ...
+  // Using idField.OID() on a sub-id that isn't an OID gets an exception and the broker crashes.
   //
-  cSubP->subscriptionId        = strdup(idField.toString().c_str());
+  char oid[128];
+
+  strncpy(oid, idField.toString().c_str(), sizeof(oid));
+
+  if (strncmp(oid, "_id: ObjectId('", 15) == 0)
+    cSubP->subscriptionId  = strdup(idField.OID().toString().c_str());
+  else
+    cSubP->subscriptionId  = strdup(idField.toString().c_str());
 #else
-  cSubP->subscriptionId        = strdup(idField.OID().toString().c_str());
+  cSubP->subscriptionId    = strdup(idField.OID().toString().c_str());
 #endif
 
   cSubP->servicePath           = strdup(sub.hasField(CSUB_SERVICE_PATH)? getStringFieldF(sub, CSUB_SERVICE_PATH).c_str() : "/");

--- a/src/lib/mongoBackend/mongoSubCache.cpp
+++ b/src/lib/mongoBackend/mongoSubCache.cpp
@@ -123,10 +123,7 @@ int mongoSubCacheItemInsert(const char* tenant, const BSONObj& sub)
   //        Should check whether the subscription was created with NGSI-LD or not
   //        I can always check idField.toString().c_str() ...
   //
-  if (orionldState.apiVersion == NGSI_LD_V1)
-    cSubP->subscriptionId        = strdup(idField.toString().c_str());
-  else
-    cSubP->subscriptionId        = strdup(idField.OID().toString().c_str());
+  cSubP->subscriptionId        = strdup(idField.toString().c_str());
 #else
   cSubP->subscriptionId        = strdup(idField.OID().toString().c_str());
 #endif


### PR DESCRIPTION
Avoid initial crash when populating subscription cache.
The crash was due to that Orion expects a subscription id to be of type mongo::OID, but for orionld a subscription id is a URI.
Easy fix, once the problem was tracked down.
