### PR TITLE
task/forward-attrs-uri-param-as-alias

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
 * Issue #310 - Arrays of one element must be reduced to a single item, unless the @context states otherwise
 * Issue #307 - Check validity of property-of-property
+* Issue #XXX - NGSI-LD style forwarding of GET /ngsi-ld/v1/entities/{EID}

--- a/src/lib/orionld/common/orionldRequestSend.cpp
+++ b/src/lib/orionld/common/orionldRequestSend.cpp
@@ -98,6 +98,7 @@ bool orionldRequestSend
   uint16_t                port,
   const char*             urlPath,
   int                     tmoInMilliSeconds,
+  const char*             linkHeader,
   char**                  detailPP,
   bool*                   tryAgainP,
   bool*                   downloadFailedP,
@@ -175,6 +176,17 @@ bool orionldRequestSend
   curl_easy_setopt(cc.curl, CURLOPT_FOLLOWLOCATION, 1L);                   // Follow redirections
 
   struct curl_slist* headers = NULL;
+
+  if (linkHeader != NULL)
+  {
+    char linkHeaderString[512];
+
+    snprintf(linkHeaderString, sizeof(linkHeaderString), "Link: %s", linkHeader);
+    headers = curl_slist_append(headers, linkHeaderString);
+    curl_easy_setopt(cc.curl, CURLOPT_HTTPHEADER, headers);
+
+    LM_TMP(("KZ: Link Header: %s", linkHeader));
+  }
 
   if (acceptHeader != NULL)
   {

--- a/src/lib/orionld/common/orionldRequestSend.h
+++ b/src/lib/orionld/common/orionldRequestSend.h
@@ -41,6 +41,7 @@ extern bool orionldRequestSend
   uint16_t                port,
   const char*             urlPath,
   int                     tmoInMilliSeconds,
+  const char*             linkHeader,
   char**                  detailPP,
   bool*                   tryAgainP,
   bool*                   downloadFailedP,

--- a/src/lib/orionld/context/orionldContextDownload.cpp
+++ b/src/lib/orionld/context/orionldContextDownload.cpp
@@ -92,7 +92,7 @@ char* orionldContextDownload(const char* url, bool* downloadFailedP, OrionldProb
     //
     bool tryAgain = false;
 
-    reqOk = orionldRequestSend(&orionldState.httpResponse, protocol, ip, port, urlPath, contextDownloadTimeout, &pdP->detail, &tryAgain, downloadFailedP, "Accept: application/ld+json");
+    reqOk = orionldRequestSend(&orionldState.httpResponse, protocol, ip, port, urlPath, contextDownloadTimeout, NULL, &pdP->detail, &tryAgain, downloadFailedP, "Accept: application/ld+json");
     if (reqOk == true)
       break;
 

--- a/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
@@ -24,7 +24,7 @@
 */
 extern "C"
 {
-#include "kbase/kMacros.h"                                       // K_VEC_SIZE
+#include "kbase/kMacros.h"                                       // K_VEC_SIZE, K_FT
 #include "kbase/kStringSplit.h"                                  // kStringSplit
 #include "kbase/kStringArrayJoin.h"                              // kStringArrayJoin
 #include "kbase/kStringArrayLookup.h"                            // kStringArrayLookup
@@ -47,10 +47,25 @@ extern "C"
 #include "orionld/common/orionldState.h"                         // orionldState
 #include "orionld/common/orionldErrorResponse.h"                 // orionldErrorResponseCreate
 #include "orionld/common/orionldRequestSend.h"                   // orionldRequestSend
+#include "orionld/context/orionldContextItemAliasLookup.h"       // orionldContextItemAliasLookup
 #include "orionld/db/dbConfiguration.h"                          // dbRegistrationLookup
 #include "orionld/kjTree/kjTreeFromQueryContextResponse.h"       // kjTreeFromQueryContextResponse
 #include "orionld/context/orionldContextItemExpand.h"            // orionldContextItemExpand
 #include "orionld/serviceRoutines/orionldGetEntity.h"            // Own Interface
+
+
+
+// -----------------------------------------------------------------------------
+//
+// attrsToAlias -
+//
+static void attrsToAlias(OrionldContext* contextP, char* attrV[], int attrs)
+{
+  for (int ix = 0; ix < attrs; ix++)
+  {
+    attrV[ix] = orionldContextItemAliasLookup(contextP, attrV[ix], NULL, NULL);
+  }
+}
 
 
 
@@ -142,7 +157,7 @@ static KjNode* orionldForwardGetEntity2(KjNode* regP, char* entityId, char** uri
   char            host[128]                  = { 0 };
   char            protocol[32]               = { 0 };
   unsigned short  port                       = 0;
-  char*           uriDir;
+  char*           uriDir                     = (char*) "";
   char*           detail;
   KjNode*         entityP                    = NULL;
   int             ix                         = 0;
@@ -210,11 +225,13 @@ static KjNode* orionldForwardGetEntity2(KjNode* regP, char* entityId, char** uri
   else if ((uriParamAttrs == 0) && (registrationAttrs != 0))
   {
     newUriParamAttrsString = (char*) kaAlloc(&orionldState.kalloc, registrationAttrs * 200);
+    attrsToAlias(orionldState.contextP, registrationAttrV, registrationAttrs);
     kStringArrayJoin(newUriParamAttrsString, registrationAttrV, registrationAttrs, ",");
   }
   else if ((uriParamAttrs != 0) && (registrationAttrs == 0))
   {
     newUriParamAttrsString = (char*) kaAlloc(&orionldState.kalloc, uriParamAttrs * 200);
+    attrsToAlias(orionldState.contextP, uriParamAttrV, uriParamAttrs);
     kStringArrayJoin(newUriParamAttrsString, uriParamAttrV, uriParamAttrs, ",");
   }
   else
@@ -227,16 +244,33 @@ static KjNode* orionldForwardGetEntity2(KjNode* regP, char* entityId, char** uri
       if (kStringArrayLookup(registrationAttrV, registrationAttrs, uriParamAttrV[ix]) != -1)
         attrsV[attrs++] = uriParamAttrV[ix];
     }
+
+    attrsToAlias(orionldState.contextP, attrsV, attrs);
     kStringArrayJoin(newUriParamAttrsString, attrsV, attrs, ",");
   }
 
+
   int   size    = 256 + strlen(newUriParamAttrsString);
   char* urlPath = (char*) kaAlloc(&orionldState.kalloc, size);
+  char* uriDirP = (char*) ((uriDir == NULL)? "" : uriDir);
+
+
+  //
+  // If the uri directory (from the rgistration) ends in a slash, then have it removed.
+  // It is added in the snpintf further down
+  //
+  if (uriDirP != NULL)
+  {
+    int slen = strlen(uriDirP);
+    if (uriDirP[slen - 1] == '/')
+      uriDirP[slen - 1] = 0;
+  }
 
   if (*newUriParamAttrsString != 0)
-    snprintf(urlPath, size, "/ngsi-ld/v1/entities/%s?attrs=%s", entityId, newUriParamAttrsString);
+    snprintf(urlPath, size, "%s/ngsi-ld/v1/entities/%s?attrs=%s", uriDirP, entityId, newUriParamAttrsString);
   else
-    snprintf(urlPath, size, "/ngsi-ld/v1/entities/%s", entityId);
+    snprintf(urlPath, size, "%s/ngsi-ld/v1/entities/%s", uriDirP, entityId);
+
 
   //
   // Sending the Forwarded request
@@ -250,7 +284,17 @@ static KjNode* orionldForwardGetEntity2(KjNode* regP, char* entityId, char** uri
   bool reqOk;
   bool downloadFailed;
 
-  reqOk = orionldRequestSend(&orionldState.httpResponse, protocol, host, port, urlPath, 5000, &detail, &tryAgain, &downloadFailed, "Accept: application/json");
+  LM_TMP(("KZ: forwarding to %s:%d '%s'", host, port, urlPath));
+  LM_TMP(("KZ: newUriParamAttrsString: %s", newUriParamAttrsString));
+  if (orionldState.linkHttpHeaderPresent)
+  {
+    char link[512];
+
+    snprintf(link, sizeof(link), "<%s>; rel=\"http://www.w3.org/ns/json-ld#context\"; type=\"application/ld+json\"", orionldState.link);
+    reqOk = orionldRequestSend(&orionldState.httpResponse, protocol, host, port, urlPath, 5000, link, &detail, &tryAgain, &downloadFailed, "Accept: application/json");
+  }
+  else
+    reqOk = orionldRequestSend(&orionldState.httpResponse, protocol, host, port, urlPath, 5000, NULL, &detail, &tryAgain, &downloadFailed, "Accept: application/json");
 
   if (reqOk)
     entityP = kjParse(orionldState.kjsonP, orionldState.httpResponse.buf);

--- a/test/functionalTest/cases/0000_ngsild/ngsild_forward_get_entity-attrs-only-uriAttrs.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_forward_get_entity-attrs-only-uriAttrs.test
@@ -45,6 +45,7 @@ brokerStart CP1
 # 03. See the registration in mongo
 # 04. Create entity urn:ngsi-ld:entities:E1 in CP1, with attributes P1, P2, R1, and R1
 # 05. Ask CB to GET entity urn:ngsi-ld:entities:E1?attrs=P1,R2 - provoke a forward request of GET urn:ngsi-ld:entities:E1?attrs=P1,R2 to CP1
+# 06. Do the same GET, but with a Link HTTP header, with a @context that redefines P1 and R2 => no hits and no attrs are returned
 #
 
 echo "01. Create entity urn:ngsi-ld:entities:E1 in CB, without attributes"
@@ -117,6 +118,13 @@ echo
 echo "05. Ask CB to GET entity urn:ngsi-ld:entities:E1?attrs=P1,R2 - provoke a forward request of GET urn:ngsi-ld:entities:E1?attrs=P1,R2 to CP1"
 echo "=========================================================================================================================================="
 orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entities:E1?attrs=P1,R2
+echo
+echo
+
+
+echo "06. Do the same GET, but with	a Link HTTP header, with a @context that redefines P1 and R2 => no hits and no attrs are returned"
+echo "==============================================================================================================================="
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entities:E1?attrs=P1,R2 -H "Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>;"' rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -201,7 +209,21 @@ Date: REGEX(.*)
 }
 
 
---TEARDOWN--
+06. Do the same GET, but with	a Link HTTP header, with a @context that redefines P1 and R2 => no hits and no attrs are returned
+===============================================================================================================================
+HTTP/1.1 200 OK
+Content-Length: 43
+Content-Type: application/json
+Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+{
+    "id": "urn:ngsi-ld:entities:E1",
+    "type": "T"
+}
+
+
+--TEARDOWN---
 brokerStop CB
 brokerStop CP1
 dbDrop CB


### PR DESCRIPTION
Supposedly fixed three things:
* Forward Link header'
* short attr names in attrs URI param
* using the URL PATH from the registration when forwarding