### PR TITLE
Checking registrations for empty sub-arrays of the 'information' array

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,5 @@
 * Issue #310 - Arrays of one element must be reduced to a single item, unless the @context states otherwise
 * Issue #307 - Check validity of property-of-property
 * Issue #XXX - NGSI-LD style forwarding of GET /ngsi-ld/v1/entities/{EID}
+* Issue #XXX - Registrations with empty arrays inside information are now rejected, as per spec.
+

--- a/src/lib/orionld/kjTree/kjTreeToRegistration.cpp
+++ b/src/lib/orionld/kjTree/kjTreeToRegistration.cpp
@@ -96,6 +96,12 @@ static bool kjTreeToRegistrationInformation(ConnectionInfo* ciP, KjNode* regInfo
       if (SCOMPARE9(infoNodeP->name, 'e', 'n', 't', 'i', 't', 'i', 'e', 's', 0))
       {
         DUPLICATE_CHECK(entitiesP, "Registration::information::entities", infoNodeP);
+        if (infoNodeP->value.firstChildP == NULL)
+        {
+          orionldErrorResponseCreate(OrionldBadRequestData, "Empty Array", "information::entities");
+          return false;
+        }
+
         if (kjTreeToEntIdVector(ciP, infoNodeP, &regP->dataProvided.entities) == false)
         {
           LM_E(("kjTreeToEntIdVector failed"));
@@ -105,6 +111,12 @@ static bool kjTreeToRegistrationInformation(ConnectionInfo* ciP, KjNode* regInfo
       else if (SCOMPARE11(infoNodeP->name, 'p', 'r', 'o', 'p', 'e', 'r', 't', 'i', 'e', 's', 0))
       {
         DUPLICATE_CHECK(propertiesP, "Registration::information::properties", infoNodeP);
+        if (infoNodeP->value.firstChildP == NULL)
+        {
+          orionldErrorResponseCreate(OrionldBadRequestData, "Empty Array", "information::properties");
+          return false;
+        }
+
         for (KjNode* propP = infoNodeP->value.firstChildP; propP != NULL; propP = propP->next)
         {
           STRING_CHECK(propP, "PropertyInfo::name");
@@ -116,6 +128,12 @@ static bool kjTreeToRegistrationInformation(ConnectionInfo* ciP, KjNode* regInfo
       else if (SCOMPARE14(infoNodeP->name, 'r', 'e', 'l', 'a', 't', 'i', 'o', 'n', 's', 'h', 'i', 'p', 's', 0))
       {
         DUPLICATE_CHECK(relationshipsP, "Registration::information::relationships", infoNodeP);
+
+        if (infoNodeP->value.firstChildP == NULL)
+        {
+          orionldErrorResponseCreate(OrionldBadRequestData, "Empty Array", "information::relationships");
+          return false;
+        }
 
         for (KjNode* relP = infoNodeP->value.firstChildP; relP != NULL; relP = relP->next)
         {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_registration_create.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_registration_create.test
@@ -43,6 +43,9 @@ brokerStart CB
 # 04. Create R1 registration with embedded context
 # 05. See the R1 registration in mongo
 # 06. Create R2 registration without @Context Attribute
+# 07. Attempt to create a registration with an empty array for 'properties' inside 'information' - see error
+# 08. Attempt to create a registration with an empty array for 'relationaships' inside 'information' - see error
+# 09. Attempt to create a registration with an empty array for 'entities' inside 'information' - see error
 #
 
 echo "01. Create a registration with ALL fields"
@@ -228,6 +231,73 @@ payload='{
         "type": "T"
       }],
       "properties": ["p1", "p2"],
+      "relationships": ["rel1"]
+    }
+  ],
+  "endpoint": "http://my.csource.org:1026"
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations -X POST --payload "$payload" -H "Content-Type: application/json"
+echo
+echo
+
+
+echo "07. Attempt to create a registration with an empty array for 'properties' inside 'information' - see error"
+echo "=========================================================================================================="
+payload='{
+  "id": "urn:ngsi-ld:ContextSourceRegistration:R3",
+  "type": "ContextSourceRegistration",
+  "information": [
+    {
+      "entities": [
+        {
+          "id": "urn:ngsi-ld:entity:E1",
+          "type": "T"
+        }
+      ],
+      "properties": [],
+      "relationships": ["rel1"]
+    }
+  ],
+  "endpoint": "http://my.csource.org:1026"
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations -X POST --payload "$payload" -H "Content-Type: application/json"
+echo
+echo
+
+
+echo "08. Attempt to create a registration with an empty array for 'relationaships' inside 'information' - see error"
+echo "=============================================================================================================="
+payload='{
+  "id": "urn:ngsi-ld:ContextSourceRegistration:R3",
+  "type": "ContextSourceRegistration",
+  "information": [
+    {
+      "entities": [
+        {
+          "id": "urn:ngsi-ld:entity:E1",
+          "type": "T"
+        }
+      ],
+      "properties": [ "prop1" ],
+      "relationships": []
+    }
+  ],
+  "endpoint": "http://my.csource.org:1026"
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations -X POST --payload "$payload" -H "Content-Type: application/json"
+echo
+echo
+
+
+echo "09. Attempt to create a registration with an empty array for 'entities' inside 'information' - see error"
+echo "========================================================================================================"
+payload='{
+  "id": "urn:ngsi-ld:ContextSourceRegistration:R3",
+  "type": "ContextSourceRegistration",
+  "information": [
+    {
+      "entities": [ ],
+      "properties": [ "prop1" ],
       "relationships": ["rel1"]
     }
   ],
@@ -684,6 +754,48 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http:/
 Location: /ngsi-ld/v1/csourceRegistrations/urn:ngsi-ld:ContextSourceRegistration:R2
 Date: REGEX(.*)
 
+
+
+07. Attempt to create a registration with an empty array for 'properties' inside 'information' - see error
+==========================================================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 118
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "information::properties",
+    "title": "Empty Array",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+08. Attempt to create a registration with an empty array for 'relationaships' inside 'information' - see error
+==============================================================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 121
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "information::relationships",
+    "title": "Empty Array",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+09. Attempt to create a registration with an empty array for 'entities' inside 'information' - see error
+========================================================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 116
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "information::entities",
+    "title": "Empty Array",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
 
 
 --TEARDOWN--


### PR DESCRIPTION
Registrations with empty arrays inside **information** are now rejected, as per spec.