### PR TITLE
Feature travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
         unzip -q master.zip;
         rm master.zip;
         cd NGSI-LD_TestSuite-master;  
-        export EXCLUDED_TESTS="001|003|042|080|081|126|129|130|149|";
+        export EXCLUDED_TESTS="001|003|126|129|";
         npm install;
 
       script:  >

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
         unzip -q master.zip;
         rm master.zip;
         cd NGSI-LD_TestSuite-master;  
-        export EXCLUDED_TESTS="001|003|126|129|";
+        export EXCLUDED_TESTS="001|003|";
         npm install;
 
       script:  >


### PR DESCRIPTION
Excluding less tests for the NGSI-LD Test Suite.
Now only two tests are excluded, for BATCH Update anb Create, which are not yet implemented in the Orion-LD context Broker.