### PR TITLE
Refactor: pcheckEntity+pcheckName

### DIFF
--- a/src/lib/orionld/common/CMakeLists.txt
+++ b/src/lib/orionld/common/CMakeLists.txt
@@ -38,7 +38,6 @@ SET (SOURCES
     qParse.cpp
     qTreePresent.cpp
     qTreeToBsonObj.cpp
-    orionldEntityPayloadCheck.cpp
     uuidGenerate.cpp
     orionldServerConnect.cpp
     dotForEq.cpp

--- a/src/lib/orionld/payloadCheck/CMakeLists.txt
+++ b/src/lib/orionld/payloadCheck/CMakeLists.txt
@@ -23,6 +23,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
 SET (SOURCES
      pcheckEntityInfo.cpp
      pcheckEntities.cpp
+     pcheckEntity.cpp
      pcheckGeoType.cpp
      pcheckGeoqCoordinates.cpp
      pcheckGeoqGeorel.cpp
@@ -35,6 +36,7 @@ SET (SOURCES
      pcheckInformation.cpp
      pcheckTimeInterval.cpp
      pcheckRegistration.cpp
+     pcheckName.cpp
 )
 
 # Include directories

--- a/src/lib/orionld/payloadCheck/pcheckEntity.cpp
+++ b/src/lib/orionld/payloadCheck/pcheckEntity.cpp
@@ -20,7 +20,7 @@
 * For those usages not covered by this license please contact with
 * orionld at fiware dot org
 *
-* Author: Gabriel Quaresma
+* Author: Ken Zangelin, Gabriel Quaresma
 */
 #include "logMsg/logMsg.h"                                       // LM_*
 #include "logMsg/traceLevels.h"                                  // Lmt*
@@ -37,7 +37,6 @@ extern "C"
 #include "orionTypes/OrionValueType.h"                           // orion::ValueType
 #include "orionTypes/UpdateActionType.h"                         // ActionType
 #include "parse/CompoundValueNode.h"                             // CompoundValueNode
-#include "ngsi/ContextAttribute.h"                               // ContextAttribute
 #include "ngsi10/UpdateContextRequest.h"                         // UpdateContextRequest
 #include "ngsi10/UpdateContextResponse.h"                        // UpdateContextResponse
 #include "mongoBackend/mongoUpdateContext.h"                     // mongoUpdateContext
@@ -50,48 +49,8 @@ extern "C"
 #include "orionld/common/urlCheck.h"                             // urlCheck
 #include "orionld/common/urnCheck.h"                             // urnCheck
 #include "orionld/common/orionldState.h"                         // orionldState
-#include "orionld/common/orionldEntityPayloadCheck.h"            // Own interface
-
-
-
-// -----------------------------------------------------------------------------
-//
-// orionldValidName -
-//
-bool orionldValidName(char* name, char** detailsPP)
-{
-  if (name == NULL)
-  {
-    *detailsPP = (char*) "empty name";
-    return false;
-  }
-
-  for (; *name != 0; ++name)
-  {
-    //
-    // Invalid chars:
-    //   '=',
-    //   '[',
-    //   ']',
-    //   '&',
-    //   '?',
-    //   '"',
-    //   ''',
-    //   '\b',
-    //   '\t',
-    //   '\n', and
-    //   '#'
-    //
-    if ((*name == '=') || (*name == '[') || (*name == ']') || (*name == '&') || (*name == '?') || (*name == '"') ||
-        (*name == '\'') || (*name == '\b') || (*name == '\t') || (*name == '\n') || (*name == '#'))
-    {
-      *detailsPP = (char*) "invalid character in name";
-      return false;
-    }
-  }
-
-  return true;
-}
+#include "orionld/payloadCheck/pcheckName.h"                     // pcheckName
+#include "orionld/payloadCheck/pcheckEntity.h"                   // Own interface
 
 
 
@@ -128,9 +87,9 @@ static bool checkEntityIdFieldExists(void)
 
 // -----------------------------------------------------------------------------
 //
-// orionldEntityPayloadCheck -
+// pcheckEntity -
 //
-bool orionldEntityPayloadCheck
+bool pcheckEntity
 (
   KjNode*          kNodeP,
   KjNode**         locationNodePP,
@@ -229,7 +188,7 @@ bool orionldEntityPayloadCheck
     {
       if (strcmp(kNodeP->name, "@context") != 0)
       {
-        if (orionldValidName(kNodeP->name, &detailsP) == false)
+        if (pcheckName(kNodeP->name, &detailsP) == false)
         {
           orionldErrorResponseCreate(OrionldBadRequestData, "Invalid Property/Relationship name", detailsP);
           return false;

--- a/src/lib/orionld/payloadCheck/pcheckEntity.h
+++ b/src/lib/orionld/payloadCheck/pcheckEntity.h
@@ -1,0 +1,50 @@
+#ifndef SRC_LIB_ORIONLD_PAYLOADCHECK_PCHECKENTITY_H_
+#define SRC_LIB_ORIONLD_PAYLOADCHECK_PCHECKENTITY_H_
+
+/*
+*
+* Copyright 2019 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+extern "C"
+{
+#include "kjson/KjNode.h"                                      // KjNode
+}
+
+
+
+// -----------------------------------------------------------------------------
+//
+// pcheckEntity -
+//
+extern bool pcheckEntity
+(
+  KjNode*          kNodeP,
+  KjNode**         locationNodePP,
+  KjNode**         observationSpaceNodePP,
+  KjNode**         operationSpaceNodePP,
+  KjNode**         createdAtPP,
+  KjNode**         modifiedAtPP,
+  bool             isBatchOperation
+);
+
+#endif  // SRC_LIB_ORIONLD_PAYLOADCHECK_PCHECKENTITY_H_

--- a/src/lib/orionld/payloadCheck/pcheckName.cpp
+++ b/src/lib/orionld/payloadCheck/pcheckName.cpp
@@ -1,0 +1,69 @@
+/*
+*
+* Copyright 2019 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+#include "logMsg/logMsg.h"                                       // LM_*
+#include "logMsg/traceLevels.h"                                  // Lmt*
+
+#include "orionld/payloadCheck/pcheckName.h"                     // Own interface
+
+
+
+// -----------------------------------------------------------------------------
+//
+// pcheckName -
+//
+bool pcheckName(char* name, char** detailsPP)
+{
+  if (name == NULL)
+  {
+    *detailsPP = (char*) "empty name";
+    return false;
+  }
+
+  for (; *name != 0; ++name)
+  {
+    //
+    // Invalid chars:
+    //   '=',
+    //   '[',
+    //   ']',
+    //   '&',
+    //   '?',
+    //   '"',
+    //   ''',
+    //   '\b',
+    //   '\t',
+    //   '\n', and
+    //   '#'
+    //
+    if ((*name == '=') || (*name == '[') || (*name == ']') || (*name == '&') || (*name == '?') || (*name == '"') ||
+        (*name == '\'') || (*name == '\b') || (*name == '\t') || (*name == '\n') || (*name == '#'))
+    {
+      *detailsPP = (char*) "invalid character in name";
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/src/lib/orionld/payloadCheck/pcheckName.h
+++ b/src/lib/orionld/payloadCheck/pcheckName.h
@@ -1,5 +1,5 @@
-#ifndef SRC_LIB_ORIONLD_COMMON_ORIONLDENTITYPAYLOADCHECK_H_
-#define SRC_LIB_ORIONLD_COMMON_ORIONLDENTITYPAYLOADCHECK_H_
+#ifndef SRC_LIB_ORIONLD_PAYLOADCHECK_PCHECKNAME_H_
+#define SRC_LIB_ORIONLD_PAYLOADCHECK_PCHECKNAME_H_
 
 /*
 *
@@ -23,36 +23,19 @@
 * For those usages not covered by this license please contact with
 * orionld at fiware dot org
 *
-* Author: Gabriel Quaresma
+* Author: Ken Zangelin
 */
 extern "C"
 {
-#include "kjson/KjNode.h"                                        // KjNode
+#include "kjson/KjNode.h"                                      // KjNode
 }
 
 
 
 // -----------------------------------------------------------------------------
 //
-// orionldValidName -
+// pcheckEntity -
 //
-extern bool orionldValidName(char* name, char** detailsPP);
+extern bool pcheckName(char* name, char** detailsPP);
 
-
-
-// -----------------------------------------------------------------------------
-//
-// orionldEntityPayloadCheck -
-//
-extern bool orionldEntityPayloadCheck
-(
-  KjNode*          kNodeP,
-  KjNode**         locationNodePP,
-  KjNode**         observationSpaceNodePP,
-  KjNode**         operationSpaceNodePP,
-  KjNode**         createdAtPP,
-  KjNode**         modifiedAtPP,
-  bool             isBatchOperation
-);
-
-#endif  // SRC_LIB_ORIONLD_COMMON_ORIONLDENTITYPAYLOADCHECK_H_
+#endif  // SRC_LIB_ORIONLD_PAYLOADCHECK_PCHECKNAME_H_

--- a/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
@@ -50,7 +50,7 @@ extern "C"
 #include "orionld/common/CHECK.h"                                // CHECK
 #include "orionld/common/orionldState.h"                         // orionldState, orionldHostName
 #include "orionld/common/uuidGenerate.h"                         // uuidGenerate
-#include "orionld/common/orionldEntityPayloadCheck.h"            // orionldValidName  - FIXME: Own file for "orionldValidName()"!
+#include "orionld/payloadCheck/pcheckName.h"                     // pcheckName
 #include "orionld/context/orionldCoreContext.h"                  // ORIONLD_CORE_CONTEXT_URL
 #include "orionld/context/orionldContextFromUrl.h"               // orionldContextFromUrl
 #include "orionld/context/orionldContextFromTree.h"              // orionldContextFromTree
@@ -411,7 +411,7 @@ static bool payloadParseAndExtractSpecialFields(ConnectionInfo* ciP, bool* conte
         STRING_CHECK(orionldState.payloadTypeNode, "entity type");
 
         char* detail;
-        if (orionldValidName(orionldState.payloadTypeNode->value.s, &detail) == false)
+        if (pcheckName(orionldState.payloadTypeNode->value.s, &detail) == false)
         {
           orionldErrorResponseCreate(OrionldBadRequestData, "Invalid entity type name", detail);
           return false;

--- a/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
@@ -51,7 +51,7 @@ extern "C"
 #include "orionld/common/urlCheck.h"                             // urlCheck
 #include "orionld/common/urnCheck.h"                             // urnCheck
 #include "orionld/common/orionldState.h"                         // orionldState
-#include "orionld/common/orionldEntityPayloadCheck.h"            // orionldEntityPayloadCheck
+#include "orionld/payloadCheck/pcheckEntity.h"                   // pcheckEntity
 #include "orionld/context/orionldContextItemExpand.h"            // orionldContextItemExpand
 #include "orionld/kjTree/kjTreeToContextAttribute.h"             // kjTreeToContextAttribute
 #include "orionld/mongoBackend/mongoEntityExists.h"              // mongoEntityExists
@@ -74,7 +74,7 @@ bool orionldPostEntities(ConnectionInfo* ciP)
   KjNode*  createdAtP         = NULL;
   KjNode*  modifiedAtP        = NULL;
 
-  if (orionldEntityPayloadCheck(orionldState.requestTree->value.firstChildP, &locationP, &observationSpaceP, &operationSpaceP, &createdAtP, &modifiedAtP, false) == false)
+  if (pcheckEntity(orionldState.requestTree->value.firstChildP, &locationP, &observationSpaceP, &operationSpaceP, &createdAtP, &modifiedAtP, false) == false)
     return false;
 
   char*    entityId           = orionldState.payloadIdNode->value.s;


### PR DESCRIPTION
Moved pcheckEntity+pcheckName from common/orionldEntityPayloadCheck.cpp to:
* payloadCheck/pcheckEntity
* payloadCheck/pcheckName
