### PR TITLE
task/count

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -7,3 +7,4 @@
 # Issue #XXX  Fixed a bug that impeded the creation of reistrations with only entity-type in the entities array
 # Issue #280  Entities can now have more than one GeoProperty
 # Issue #280  Turned off initial notifications (when creating NGSI-LD subscriptions)
+# Issue #280  New version for the 'count' URI parameter - in NGSI-LD 'options' isn't used for 'count

--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -1675,7 +1675,7 @@ bool entitiesQuery
     cerV->push_back(cer);
   }
 
-release:
+ release:
   LM_TMP(("GEO: Got %d results", docs));
   releaseMongoConnection(connection);
 

--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -1535,7 +1535,6 @@ bool entitiesQuery
   TIME_STAT_MONGO_READ_WAIT_START();
   DBClientBase* connection = getMongoConnection();
 
-  LM_TMP(("GEO: Calling collectionRangedQuery"));
   if (!collectionRangedQuery(connection, getEntitiesCollectionName(tenant), query, limit, offset, &cursor, countP, err))
   {
     releaseMongoConnection(connection);
@@ -1547,7 +1546,9 @@ bool entitiesQuery
   /* Process query result */
   unsigned int docs = 0;
 
-  LM_TMP(("GEO: Getting results ... or not ... ?"));
+  if (orionldState.onlyCount == true)  // If only 'count', we can avoid to perform the "real" query
+    goto release;
+
   while (moreSafe(cursor))
   {
     BSONObj  r;
@@ -1673,6 +1674,8 @@ bool entitiesQuery
     cer->statusCode.fill(SccOk);
     cerV->push_back(cer);
   }
+
+release:
   LM_TMP(("GEO: Got %d results", docs));
   releaseMongoConnection(connection);
 

--- a/src/lib/orionld/common/orionldState.cpp
+++ b/src/lib/orionld/common/orionldState.cpp
@@ -123,6 +123,7 @@ void orionldStateInit(void)
   orionldState.forwardAttrsCompacted   = true;
   orionldState.delayedKjFreeVecSize    = sizeof(orionldState.delayedKjFreeVec) / sizeof(orionldState.delayedKjFreeVec[0]);
   orionldState.delayedFreeVecSize      = sizeof(orionldState.delayedFreeVec) / sizeof(orionldState.delayedFreeVec[0]);
+  orionldState.uriParams.limit         = 20;
 }
 
 

--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -79,7 +79,6 @@ struct ConnectionInfo;
 typedef struct OrionldUriParamOptions
 {
   bool noOverwrite;
-  bool count;
   bool update;
   bool replace;
   bool keyValues;
@@ -103,7 +102,7 @@ typedef struct OrionldUriParams
   char* geometry;
   char* geoloc;
   char* geoproperty;
-
+  bool  count;
   // To Be Continued ...
 } OrionldUriParams;
 
@@ -230,6 +229,7 @@ typedef struct OrionldConnectionState
   // Instructions for mongoBackend
   //
   KjNode*                 creDatesP;
+  bool                    onlyCount;
 
   //
   // General Behavior

--- a/src/lib/orionld/serviceRoutines/orionldGetRegistrations.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetRegistrations.cpp
@@ -83,9 +83,9 @@ bool orionldGetRegistrations(ConnectionInfo* ciP)
     return false;
   }
 
-  if ((ciP->uriParamOptions["count"]))
+  if (orionldState.uriParams.count == true)
   {
-    ciP->httpHeader.push_back(HTTP_FIWARE_TOTAL_COUNT);
+    ciP->httpHeader.push_back("NGSILD-Results-Count");
     ciP->httpHeaderValue.push_back(toString(count));
   }
 

--- a/src/lib/orionld/serviceRoutines/orionldGetSubscriptions.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetSubscriptions.cpp
@@ -58,9 +58,9 @@ bool orionldGetSubscriptions(ConnectionInfo* ciP)
 
   mongoGetLdSubscriptions(ciP, &subVec, orionldState.tenant, (long long*) &count, &oe);
 
-  if ((ciP->uriParamOptions["count"]))
+  if (orionldState.uriParams.count == true)
   {
-    ciP->httpHeader.push_back(HTTP_FIWARE_TOTAL_COUNT);
+    ciP->httpHeader.push_back("NGSILD-Results-Count");
     ciP->httpHeaderValue.push_back(toString(count));
   }
 

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -201,6 +201,7 @@ int uriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, const ch
         ciP->answer         = error.smartRender(ciP->apiVersion);
 
 #ifdef ORIONLD
+        LM_E(("Invalid value for URI parameter 'limit': '%s'", val));
         orionldErrorResponseCreate(OrionldBadRequestData, "Invalid value for URI parameter /limit/", "must be an integer value >= 1");
         orionldState.httpStatusCode = SccBadRequest;
 #endif
@@ -218,6 +219,7 @@ int uriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, const ch
       ciP->answer         = error.smartRender(ciP->apiVersion);
 
 #ifdef ORIONLD
+        LM_E(("Invalid value for URI parameter 'limit': '%s'", val));
         orionldErrorResponseCreate(OrionldBadRequestData, "Invalid value for URI parameter /limit/", "must be an integer value <= 1000");
         orionldState.httpStatusCode = SccBadRequest;
 #endif
@@ -225,14 +227,12 @@ int uriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, const ch
     }
     else if (limit == 0)
     {
-      OrionError error(SccBadRequest, std::string("Bad pagination limit: /") + value + "/ [a value of ZERO is unacceptable]");
-      ciP->httpStatusCode = error.code;
-      ciP->answer         = error.smartRender(ciP->apiVersion);
-
-#ifdef ORIONLD
-        orionldErrorResponseCreate(OrionldBadRequestData, "Invalid value for URI parameter /limit/", "must be an integer value >= 1");
-        orionldState.httpStatusCode = SccBadRequest;
-#endif
+      if (orionldState.apiVersion != NGSI_LD_V1)
+      {
+        OrionError error(SccBadRequest, std::string("Bad pagination limit: /") + value + "/ [a value of ZERO is unacceptable]");
+        ciP->httpStatusCode = error.code;
+        ciP->answer         = error.smartRender(ciP->apiVersion);
+      }
       return MHD_YES;
     }
   }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get.test
@@ -40,6 +40,7 @@ brokerStart CB 212-249
 # 07. GET all entities with id E1, see entity E1 only
 # 08. GET all entities with id E.*, see all four entities
 # 09. GET all entities with id E5, see empty array
+# 10. GET all entities with id E.* with count and limit==0 - see empty array and count==4
 #
 
 echo "01. POST /ngsi-ld/v1/entities::http://a.b.c/entity/E1, with test context, and type T"
@@ -129,7 +130,7 @@ echo
 
 echo "08. GET all entities with id E.*, see all four entities"
 echo "======================================================="
-orionCurl --url '/ngsi-ld/v1/entities?idPattern=http://a.b.c/entity/E.*&prettyPrint=yes&type=T,T2&options=count' --noPayloadCheck -H "Accept: application/ld+json"  -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+orionCurl --url '/ngsi-ld/v1/entities?idPattern=http://a.b.c/entity/E.*&prettyPrint=yes&type=T,T2&count=true' --noPayloadCheck -H "Accept: application/ld+json"  -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -141,6 +142,11 @@ echo
 echo
 
 
+echo "10. GET all entities with id E.* with count and limit==0 - see empty array and count==4"
+echo "======================================================================================="
+orionCurl --url '/ngsi-ld/v1/entities?idPattern=http://a.b.c/entity/E.*&prettyPrint=yes&type=T,T2&count=true&limit=0' --noPayloadCheck -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+echo
+echo
 
 --REGEXPECT--
 01. POST /ngsi-ld/v1/entities::http://a.b.c/entity/E1, with test context, and type T
@@ -265,7 +271,7 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 873
 Content-Type: application/ld+json
-Fiware-Total-Count: 4
+NGSILD-Results-Count: 4
 Date: REGEX(.*)
 
 [
@@ -314,6 +320,18 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 3
 Content-Type: application/ld+json
+Date: REGEX(.*)
+
+[]
+
+
+
+10. GET all entities with id E.* with count and limit==0 - see empty array and count==4
+=======================================================================================
+HTTP/1.1 200 OK
+Content-Length: 3
+Content-Type: application/json
+NGSILD-Results-Count: 4
 Date: REGEX(.*)
 
 []

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_get_with_mismatch_in_type_due_to_contexts.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_get_with_mismatch_in_type_due_to_contexts.test
@@ -124,7 +124,6 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 2
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_get_with_type_as_FQN.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_get_with_type_as_FQN.test
@@ -179,7 +179,6 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 2
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []
@@ -269,7 +268,6 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 2
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_retrieval_with_attribute_in_filter.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_retrieval_with_attribute_in_filter.test
@@ -220,7 +220,6 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 2
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []
@@ -286,7 +285,6 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 2
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []

--- a/test/functionalTest/cases/0000_ngsild/ngsild_geoproperty.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_geoproperty.test
@@ -396,7 +396,6 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 3
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []

--- a/test/functionalTest/cases/0000_ngsild/ngsild_geoqueries-point.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_geoqueries-point.test
@@ -171,7 +171,6 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 2
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []

--- a/test/functionalTest/cases/0000_ngsild/ngsild_geoqueries-polygon.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_geoqueries-polygon.test
@@ -203,7 +203,6 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 2
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []
@@ -240,7 +239,6 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 2
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_q-and.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_q-and.test
@@ -196,7 +196,6 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 3
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []

--- a/test/functionalTest/cases/0000_ngsild/ngsild_query_condition_over_compound_value.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_query_condition_over_compound_value.test
@@ -203,7 +203,6 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 3
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []
@@ -215,7 +214,6 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 3
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []

--- a/test/functionalTest/cases/0000_ngsild/ngsild_query_condition_over_deep_compound_value.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_query_condition_over_deep_compound_value.test
@@ -121,7 +121,6 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 3
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []

--- a/test/functionalTest/cases/0000_ngsild/ngsild_query_condition_over_observedAt.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_query_condition_over_observedAt.test
@@ -215,7 +215,6 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 3
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []
@@ -331,7 +330,6 @@ Date: REGEX(.*)
 HTTP/1.1 200 OK
 Content-Length: 3
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []

--- a/test/functionalTest/cases/0000_ngsild/ngsild_query_entities_geo_error.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_query_entities_geo_error.test
@@ -196,7 +196,6 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 2
 Content-Type: application/json
-Link: <https://fiware.github.io/data-models/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []

--- a/test/functionalTest/cases/0000_ngsild/ngsild_query_with_type_mismatch.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_query_with_type_mismatch.test
@@ -203,7 +203,6 @@ bye
 HTTP/1.1 200 OK
 Content-Length: 2
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []

--- a/test/functionalTest/cases/0000_ngsild/ngsild_registration_get_error_handling.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_registration_get_error_handling.test
@@ -60,12 +60,12 @@ echo
 01. GET  /ngsi-ld/v1/csourceRegistrations GET limit = 0
 =======================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 152
+Content-Length: 175
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "detail": "must be an integer value >= 1",
+    "detail": "must be an integer value >= 1, if /count/ is not set",
     "title": "Invalid value for URI parameter /limit/",
     "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
 }
@@ -88,12 +88,12 @@ Date: REGEX(.*)
 03. GET  /ngsi-ld/v1/csourceRegistrations GET limit = abc
 =========================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 152
+Content-Length: 175
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "detail": "must be an integer value >= 1",
+    "detail": "must be an integer value >= 1, if /count/ is not set",
     "title": "Invalid value for URI parameter /limit/",
     "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
 }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_registration_get_success.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_registration_get_success.test
@@ -36,7 +36,7 @@ brokerStart CB
 # 04. GET  /ngsi-ld/v1/csourceRegistrations GET limit:5 csourceRegistration
 # 05. GET  /ngsi-ld/v1/csourceRegistrations GET limit:5/offset:0 csourceRegistration
 # 06. GET  /ngsi-ld/v1/csourceRegistrations GET limit:5/offset:1 csourceRegistration
-# 07. GET  /ngsi-ld/v1/csourceRegistrations GET options=count csourceRegistration
+# 07. GET  /ngsi-ld/v1/csourceRegistrations with count
 # 08. GET  /ngsi-ld/v1/csourceRegistrations GET limit:1/offset:11 csourceRegistration
 # 09. GET  /ngsi-ld/v1/csourceRegistrations GET limit:1/offset:5 and with options=sysAttrs
 #
@@ -148,9 +148,9 @@ echo
 echo
 
 
-echo "07. GET  /ngsi-ld/v1/csourceRegistrations GET options=count csourceRegistration"
-echo "==============================================================================="
-orionCurl --url '/ngsi-ld/v1/csourceRegistrations?limit=3&options=count' -H 'Link: <http://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+echo "07. GET  /ngsi-ld/v1/csourceRegistrations with count"
+echo "===================================================="
+orionCurl --url '/ngsi-ld/v1/csourceRegistrations?limit=3&count=true' -H 'Link: <http://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -2713,13 +2713,13 @@ Date: REGEX(.*)
 ]
 
 
-07. GET  /ngsi-ld/v1/csourceRegistrations GET options=count csourceRegistration
-===============================================================================
+07. GET  /ngsi-ld/v1/csourceRegistrations with count
+====================================================
 HTTP/1.1 200 OK
 Content-Length: 2370
 Content-Type: application/json
 Link: <http://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
-Fiware-Total-Count: 10
+NGSILD-Results-Count: 10
 Date: REGEX(.*)
 
 [

--- a/test/functionalTest/cases/0000_ngsild/ngsild_url_parse.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_url_parse.test
@@ -242,7 +242,6 @@ echo
 HTTP/1.1 200 OK
 Content-Length: 2
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 []


### PR DESCRIPTION
New version for the 'count' URI parameter.
In NGSI-LD:
*  'options' isn't used for 'count', instead a separate URI parameter is used (names 'count')
* The new name of the response HTTP header is NGSILD-Results-Count
