### PR TITLE
Task/dataset id entity creation

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -10,3 +10,6 @@
 # Issue #280  New version for the 'count' URI parameter - in NGSI-LD 'options' isn't used for 'count
 # Issue #280  Implemented POST /ngsi-ld/v1/entityOperations/update
 # Issue #XXX  Fixed bug in context cache that didn't save some contexts in the cache and made them downloading each and every time
+# Issue #280  New DB layer for GET /entities/{EID}
+# Issue #280  datasetId supported for creation of entities
+# Issue	#280  datasetId	supported for retrieval of entities

--- a/src/app/orionld/orionld.cpp
+++ b/src/app/orionld/orionld.cpp
@@ -112,6 +112,7 @@ extern "C"
 #include "orionld/context/orionldContextCacheRelease.h"     // orionldContextCacheRelease
 #include "orionld/rest/orionldServiceInit.h"                // orionldServiceInit
 #include "orionld/db/dbInit.h"                              // dbInit
+#include "orionld/mqtt/mqttRelease.h"                       // mqttRelease
 
 #include "orionld/version.h"
 #include "orionld/orionRestServices.h"
@@ -566,6 +567,9 @@ void exitFunc(void)
   // Free the tenant list
   for (unsigned int ix = 0; ix < tenants; ix++)
     free(tenantV[ix]);
+
+  // Disconnect from all MQTT btokers and free the connections
+  mqttRelease();
 }
 
 

--- a/src/lib/logMsg/logMsg.cpp
+++ b/src/lib/logMsg/logMsg.cpp
@@ -1081,6 +1081,7 @@ const char* longTypeName(char type)
   case 'F':  return "DEBUG";
   case 'I':  return "INFO";
   case 'S':  return "SUMMARY";
+  case 'K':  return "TMP";
   }
 
   return "N/A";

--- a/src/lib/logMsg/logMsg.h
+++ b/src/lib/logMsg/logMsg.h
@@ -561,9 +561,9 @@ do                                                                       \
 {                                                                        \
   char* text;                                                            \
                                                                          \
-  if (LM_MASK(LogLevelWarning) && (text = lmTextGet s) != NULL)          \
+  if ((text = lmTextGet s) != NULL)                                      \
   {                                                                      \
-    lmOut(text, 'W', __FILE__, __LINE__, (char*) __FUNCTION__, 0, NULL); \
+    lmOut(text, 'K', __FILE__, __LINE__, (char*) __FUNCTION__, 0, NULL); \
     ::free(text);                                                        \
   }                                                                      \
 } while (0)

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -194,17 +194,6 @@ void ContextAttribute::valueBson(BSONObjBuilder& bsonAttr, const std::string& at
 
 /* ****************************************************************************
 *
-* ContextAttribute::~ContextAttribute - 
-*/
-ContextAttribute::~ContextAttribute()
-{
-  release();
-}
-
-
-
-/* ****************************************************************************
-*
 * ContextAttribute::ContextAttribute - 
 */
 ContextAttribute::ContextAttribute()

--- a/src/lib/ngsi/ContextAttribute.h
+++ b/src/lib/ngsi/ContextAttribute.h
@@ -79,7 +79,6 @@ public:
 
   bool                      onlyValue;                // Used when ony the value is meaningful in v2 updates of value, without regarding metadata
 
-  ~ContextAttribute();
   ContextAttribute();
   ContextAttribute(ContextAttribute* caP, bool useDefaultType = false);
   ContextAttribute(const std::string& _name, const std::string& _type, const char* _value, bool _found = true);

--- a/src/lib/orionld/common/orionldErrorResponse.cpp
+++ b/src/lib/orionld/common/orionldErrorResponse.cpp
@@ -42,6 +42,7 @@ extern "C"
 //
 static const char* errorTypeStringV[] =
 {
+  "https://uri.etsi.org/ngsi-ld/errors/OK",
   "https://uri.etsi.org/ngsi-ld/errors/InvalidRequest",
   "https://uri.etsi.org/ngsi-ld/errors/BadRequestData",
   "https://uri.etsi.org/ngsi-ld/errors/AlreadyExists",

--- a/src/lib/orionld/common/orionldRequestSend.cpp
+++ b/src/lib/orionld/common/orionldRequestSend.cpp
@@ -280,7 +280,6 @@ bool orionldRequestSend
   }
 
   // The downloaded buffer is in rBufP->buf
-  LM_T(LmtRequestSend, ("Got response: %s", rBufP->buf));
 
   release_curl_context(&cc);
 

--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -106,13 +106,13 @@ typedef struct OrionldUriParams
   char* idPattern;
   char* attrs;
   char* options;
-  int   offset;    // Not Implemented - use ciP->uriParams for now
-  int   limit;     // Not Implemented - use ciP->uriParams for now
+  int   offset;
+  int   limit;
   char* geometry;
   char* geoloc;
   char* geoproperty;
   bool  count;
-  // To Be Continued ...
+  char* datasetId;
 } OrionldUriParams;
 
 

--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -65,6 +65,14 @@ extern "C"
 
 // -----------------------------------------------------------------------------
 //
+// ORIONLD_DEFAULT_DATASET_ID -
+//
+#define ORIONLD_DEFAULT_DATASET_ID "urn:ngsi-ld:default:datasetId"
+
+
+
+// -----------------------------------------------------------------------------
+//
 // Forward declarations -
 //
 struct OrionLdRestService;
@@ -230,6 +238,7 @@ typedef struct OrionldConnectionState
   //
   KjNode*                 creDatesP;
   bool                    onlyCount;
+  KjNode*                 datasets;
 
   //
   // General Behavior

--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -90,6 +90,7 @@ typedef struct OrionldUriParamOptions
   bool update;
   bool replace;
   bool keyValues;
+  bool sysAttrs;
 } OrionldUriParamOptions;
 
 

--- a/src/lib/orionld/context/orionldContextCreate.cpp
+++ b/src/lib/orionld/context/orionldContextCreate.cpp
@@ -43,7 +43,6 @@ extern "C"
 //
 OrionldContext* orionldContextCreate(const char* url, const char* id, KjNode* tree, bool keyValues, bool toBeCloned)
 {
-  LM_TMP(("BUG: Creating a context for URL '%s'", url));
   OrionldContext* contextP = (OrionldContext*) kaAlloc(&kalloc, sizeof(OrionldContext));
 
   if (contextP == NULL)

--- a/src/lib/orionld/context/orionldContextFromTree.cpp
+++ b/src/lib/orionld/context/orionldContextFromTree.cpp
@@ -27,6 +27,7 @@ extern "C"
 #include "kalloc/kaAlloc.h"                                      // kaAlloc
 #include "kjson/KjNode.h"                                        // KjNode
 #include "kjson/kjRender.h"                                      // kjRender
+#include "kjson/kjFree.h"                                        // kjFree
 }
 
 #include "logMsg/logMsg.h"                                       // LM_*
@@ -98,7 +99,7 @@ OrionldContext* orionldContextFromTree(char* url, bool toBeCloned, KjNode* conte
       insert = false;
     }
 
-    // Need to clone the array and add it to cache before it is destroyed
+    // Need to clone the array and add it to the cache before it is destroyed
     OrionldContext* contextP = orionldContextCreate(url, NULL, contextTreeP, false, insert);
 
     contextP->context.array.items     = itemsInArray;
@@ -110,7 +111,7 @@ OrionldContext* orionldContextFromTree(char* url, bool toBeCloned, KjNode* conte
       OrionldContext* cachedContextP = NULL;
 
       if (ctxItemP->type == KjString)
-        orionldContextCacheLookup(ctxItemP->value.s);
+        cachedContextP = orionldContextCacheLookup(ctxItemP->value.s);
       else if ((ctxItemP->type != KjObject) && (ctxItemP->type != KjArray))
       {
         LM_E(("invalid type of @context array item: %s", kjValueType(ctxItemP->type)));
@@ -119,6 +120,8 @@ OrionldContext* orionldContextFromTree(char* url, bool toBeCloned, KjNode* conte
         pdP->detail = (char*) kjValueType(ctxItemP->type);
         pdP->status = 400;
 
+        if (insert == true)
+          kjFree(contextP->tree);
         return NULL;
       }
 

--- a/src/lib/orionld/context/orionldContextFromTree.cpp
+++ b/src/lib/orionld/context/orionldContextFromTree.cpp
@@ -80,15 +80,12 @@ OrionldContext* orionldContextFromTree(char* url, bool toBeCloned, KjNode* conte
 {
   int itemsInArray;
 
-  LM_TMP(("CC: contextTreeP (%s) is a JSON %s", url, kjValueType(contextTreeP->type)));
   if (contextTreeP->type == KjArray)
   {
-    LM_TMP(("CTX: @context is an array to be simplified"));
     contextTreeP = orionldContextSimplify(contextTreeP, &itemsInArray);
     if ((contextTreeP == NULL) || (contextTreeP->value.firstChildP == NULL))
     {
       // Nothing left in  the array - only Core Context was there but has been removed?
-      LM_TMP(("BUG: orionldContextSimplify returned a NULL or empty tree"));
       pdP->status = 200;
 
       return orionldCoreContextP;
@@ -102,7 +99,7 @@ OrionldContext* orionldContextFromTree(char* url, bool toBeCloned, KjNode* conte
     }
 
     // Need to clone the array and add it to cache before it is destroyed
-    OrionldContext* contextP = orionldContextCreate(url, NULL, contextTreeP, false, true);
+    OrionldContext* contextP = orionldContextCreate(url, NULL, contextTreeP, false, insert);
 
     contextP->context.array.items     = itemsInArray;
     contextP->context.array.vector    = (OrionldContext**) kaAlloc(&kalloc, itemsInArray * sizeof(OrionldContext*));
@@ -133,10 +130,7 @@ OrionldContext* orionldContextFromTree(char* url, bool toBeCloned, KjNode* conte
     }
 
     if (insert)
-    {
-      LM_TMP(("CC: Calling orionldContextCacheInsert for '%s'", contextP->url));
       orionldContextCacheInsert(contextP);
-    }
 
     return contextP;
   }
@@ -152,28 +146,19 @@ OrionldContext* orionldContextFromTree(char* url, bool toBeCloned, KjNode* conte
 
         contextP->context.array.items     = 1;
         contextP->context.array.vector    = (OrionldContext**) kaAlloc(&kalloc, 1 * sizeof(OrionldContext*));
-        LM_TMP(("CC: Calling orionldContextFromUrl for '%s' (url == '%s')", contextTreeP->value.s, url));
         contextP->context.array.vector[0] = orionldContextFromUrl(contextTreeP->value.s, pdP);
-
-        LM_TMP(("CC: Calling orionldContextCacheInsert for '%s'", contextP->url));
-        // orionldContextCacheInsert(contextP);
       }
       return contextP;
     }
     else
     {
       OrionldContext* contextP;
-      LM_TMP(("CC: Calling orionldContextFromUrl for '%s'", contextTreeP->value.s));
       contextP = orionldContextFromUrl(contextTreeP->value.s, pdP);
-      LM_TMP(("CC: After orionldContextFromUrl for '%s'", contextTreeP->value.s));
       return contextP;
     }
   }
   else if (contextTreeP->type == KjObject)
-  {
-    LM_TMP(("CC: The tree is an object, so, we call orionldContextFromObject"));
     return orionldContextFromObject(url, toBeCloned, contextTreeP, pdP);
-  }
 
 
   //

--- a/src/lib/orionld/context/orionldContextItemValueLookup.cpp
+++ b/src/lib/orionld/context/orionldContextItemValueLookup.cpp
@@ -40,7 +40,9 @@ OrionldContextItem* orionldContextItemValueLookup(OrionldContext* contextP, cons
 {
   OrionldContextItem* itemP = NULL;
 
-  if (contextP->keyValues == true)
+  if (contextP == NULL)
+    return NULL;
+  else if (contextP->keyValues == true)
     itemP = (OrionldContextItem*) khashItemLookup(contextP->context.hash.valueHashTable, longname);
   else
   {

--- a/src/lib/orionld/context/orionldContextPrefixExpand.cpp
+++ b/src/lib/orionld/context/orionldContextPrefixExpand.cpp
@@ -103,8 +103,11 @@ char* orionldContextPrefixExpand(OrionldContext* contextP, const char* str, char
     return (char*) str;
 
   // Never expand anything xxx://
-  if ((colonP[1] == '/') && (colonP[2] == '/'))  // takes care of http:// and https:// and any other "xxx://"
-    return (char*) str;
+  if (colonP != NULL)
+  {
+    if ((colonP[1] == '/') && (colonP[2] == '/'))  // takes care of http:// and https:// and any other "xxx://"
+      return (char*) str;
+  }
 
   //
   // "Valid" colon found - need to replace a prefix

--- a/src/lib/orionld/db/dbConfiguration.cpp
+++ b/src/lib/orionld/db/dbConfiguration.cpp
@@ -37,6 +37,7 @@ extern "C"
 // Function pointers for the DB interface
 //
 DbEntityLookupFunction                    dbEntityLookup;
+DbEntityRetrieveFunction                  dbEntityRetrieve;
 DbEntityLookupManyFunction                dbEntityLookupMany;
 DbEntityAttributeLookupFunction           dbEntityAttributeLookup;
 DbEntityAttributesDeleteFunction          dbEntityAttributesDelete;

--- a/src/lib/orionld/db/dbConfiguration.h
+++ b/src/lib/orionld/db/dbConfiguration.h
@@ -63,6 +63,7 @@ typedef bool    (*DbSubscriptionMatchCallback)(const char* entityId, KjNode* sub
 // Function pointer types for the DB interface
 //
 typedef KjNode* (*DbEntityLookupFunction)(const char* entityId);
+typedef KjNode* (*DbEntityRetrieveFunction)(const char* entityId, char** attrs, bool attrMandatory);
 typedef KjNode* (*DbEntityLookupManyFunction)(KjNode* requestTree);
 typedef KjNode* (*DbEntityAttributeLookupFunction)(const char* entityId, const char* attributeName);
 typedef bool    (*DbEntityAttributesDeleteFunction)(const char* entityId, char** attrNameV, int vecSize);
@@ -90,6 +91,7 @@ typedef bool    (*DbGeoIndexCreate)(const char* tenant, const char* attrName);
 // Function pointers for the DB interface
 //
 extern DbEntityLookupFunction                    dbEntityLookup;
+extern DbEntityRetrieveFunction                  dbEntityRetrieve;
 extern DbEntityLookupManyFunction                dbEntityLookupMany;
 extern DbEntityAttributeLookupFunction           dbEntityAttributeLookup;
 extern DbEntityAttributesDeleteFunction          dbEntityAttributesDelete;

--- a/src/lib/orionld/db/dbConfiguration.h
+++ b/src/lib/orionld/db/dbConfiguration.h
@@ -63,7 +63,7 @@ typedef bool    (*DbSubscriptionMatchCallback)(const char* entityId, KjNode* sub
 // Function pointer types for the DB interface
 //
 typedef KjNode* (*DbEntityLookupFunction)(const char* entityId);
-typedef KjNode* (*DbEntityRetrieveFunction)(const char* entityId, char** attrs, bool attrMandatory);
+typedef KjNode* (*DbEntityRetrieveFunction)(const char* entityId, char** attrs, bool attrMandatory, bool sysAttrs, bool keyValues);
 typedef KjNode* (*DbEntityLookupManyFunction)(KjNode* requestTree);
 typedef KjNode* (*DbEntityAttributeLookupFunction)(const char* entityId, const char* attributeName);
 typedef bool    (*DbEntityAttributesDeleteFunction)(const char* entityId, char** attrNameV, int vecSize);

--- a/src/lib/orionld/db/dbConfiguration.h
+++ b/src/lib/orionld/db/dbConfiguration.h
@@ -63,7 +63,7 @@ typedef bool    (*DbSubscriptionMatchCallback)(const char* entityId, KjNode* sub
 // Function pointer types for the DB interface
 //
 typedef KjNode* (*DbEntityLookupFunction)(const char* entityId);
-typedef KjNode* (*DbEntityRetrieveFunction)(const char* entityId, char** attrs, bool attrMandatory, bool sysAttrs, bool keyValues);
+typedef KjNode* (*DbEntityRetrieveFunction)(const char* entityId, char** attrs, bool attrMandatory, bool sysAttrs, bool keyValues, const char* datasetId);
 typedef KjNode* (*DbEntityLookupManyFunction)(KjNode* requestTree);
 typedef KjNode* (*DbEntityAttributeLookupFunction)(const char* entityId, const char* attributeName);
 typedef bool    (*DbEntityAttributesDeleteFunction)(const char* entityId, char** attrNameV, int vecSize);

--- a/src/lib/orionld/db/dbInit.cpp
+++ b/src/lib/orionld/db/dbInit.cpp
@@ -46,6 +46,7 @@
 #include "orionld/mongoCppLegacy/mongoCppLegacyEntitiesGet.h"              // mongoCppLegacyEntitiesGet
 #include "orionld/mongoCppLegacy/mongoCppLegacyEntityTypesFromRegistrationsGet.h"  // mongoCppLegacyEntityTypesFromRegistrationsGet
 #include "orionld/mongoCppLegacy/mongoCppLegacyGeoIndexCreate.h"           // mongoCppLegacyGeoIndexCreate
+#include "orionld/mongoCppLegacy/mongoCppLegacyEntityRetrieve.h"           // mongoCppLegacyEntityRetrieve
 
 #elif DB_DRIVER_MONGOC
 #include "orionld/mongoc/mongocInit.h"                                     // mongocInit
@@ -68,8 +69,8 @@
 void dbInit(const char* dbHost, const char* dbName)
 {
 #if DB_DRIVER_MONGO_CPP_LEGACY
-
   dbEntityLookup                           = mongoCppLegacyEntityLookup;
+  dbEntityRetrieve                         = mongoCppLegacyEntityRetrieve;
   dbEntityAttributeLookup                  = mongoCppLegacyEntityAttributeLookup;
   dbEntityAttributesDelete                 = mongoCppLegacyEntityAttributesDelete;
   dbEntityUpdate                           = mongoCppLegacyEntityUpdate;

--- a/src/lib/orionld/mongoCppLegacy/CMakeLists.txt
+++ b/src/lib/orionld/mongoCppLegacy/CMakeLists.txt
@@ -46,6 +46,7 @@ SET (SOURCES
     mongoCppLegacyDbStringFieldGet.cpp
     mongoCppLegacyDbArrayFieldGet.cpp
     mongoCppLegacyDbFieldGet.cpp
+    mongoCppLegacyEntityRetrieve.cpp
 )
 
 # Include directories

--- a/src/lib/orionld/mongoCppLegacy/mongoCppLegacyDbFieldGet.cpp
+++ b/src/lib/orionld/mongoCppLegacy/mongoCppLegacyDbFieldGet.cpp
@@ -47,3 +47,30 @@ mongo::BSONElement mongoCppLegacyDbFieldGet(const mongo::BSONObj* boP, const cha
 
   return boP->getField(fieldName);
 }
+
+
+
+// -----------------------------------------------------------------------------
+//
+// mongoCppLegacyDbObjectFieldGet -
+//
+// FIXME: avoid to send object on the stack!!!
+//
+mongo::BSONObj mongoCppLegacyDbObjectFieldGet(const mongo::BSONObj* boP, const char* fieldName)
+{
+  bool present = boP->hasField(fieldName);
+  
+  if (present == false)
+  {
+    LM_E(("Runtime Error (field '%s' is missing in BSONObj '%s'", fieldName, boP->toString().c_str()));
+    return mongo::BSONObj();
+  }
+
+  mongo::BSONType type = boP->getField(fieldName).type();
+
+  if (type == mongo::Object)
+    return boP->getObjectField(fieldName);
+
+  LM_E(("Runtime Error (field '%s' was supposed to be a string but type=%d", type));
+  return mongo::BSONObj();
+}

--- a/src/lib/orionld/mongoCppLegacy/mongoCppLegacyDbFieldGet.cpp
+++ b/src/lib/orionld/mongoCppLegacy/mongoCppLegacyDbFieldGet.cpp
@@ -59,7 +59,7 @@ mongo::BSONElement mongoCppLegacyDbFieldGet(const mongo::BSONObj* boP, const cha
 mongo::BSONObj mongoCppLegacyDbObjectFieldGet(const mongo::BSONObj* boP, const char* fieldName)
 {
   bool present = boP->hasField(fieldName);
-  
+
   if (present == false)
   {
     LM_E(("Runtime Error (field '%s' is missing in BSONObj '%s'", fieldName, boP->toString().c_str()));

--- a/src/lib/orionld/mongoCppLegacy/mongoCppLegacyDbObjectFieldGet.h
+++ b/src/lib/orionld/mongoCppLegacy/mongoCppLegacyDbObjectFieldGet.h
@@ -1,5 +1,5 @@
-#ifndef SRC_LIB_ORIONLD_MONGOCPPLEGACY_MONGOCPPLEGACYDBFIELDGET_H_
-#define SRC_LIB_ORIONLD_MONGOCPPLEGACY_MONGOCPPLEGACYDBFIELDGET_H_
+#ifndef SRC_LIB_ORIONLD_MONGOCPPLEGACY_MONGOCPPLEGACYDBOBJECTFIELDGET_H_
+#define SRC_LIB_ORIONLD_MONGOCPPLEGACY_MONGOCPPLEGACYDBOBJECTFIELDGET_H_
 
 /*
 *
@@ -25,16 +25,16 @@
 *
 * Author: Ken Zangelin
 */
-#include "mongo/client/dbclient.h"                             // mongo::BSONElement
+#include "mongo/client/dbclient.h"                             // mongo::BSONObj
 
 
 
 // -----------------------------------------------------------------------------
 //
-// mongoCppLegacyDbFieldGet -
+// mongoCppLegacyDbObjectFieldGet -
 //
 // FIXME: avoid to send object on the stack!!!
 //
-extern mongo::BSONElement mongoCppLegacyDbFieldGet(const mongo::BSONObj* boP, const char* fieldName);
+extern mongo::BSONObj mongoCppLegacyDbObjectFieldGet(const mongo::BSONObj* boP, const char* fieldName);
 
-#endif  // SRC_LIB_ORIONLD_MONGOCPPLEGACY_MONGOCPPLEGACYDBFIELDGET_H_
+#endif  // SRC_LIB_ORIONLD_MONGOCPPLEGACY_MONGOCPPLEGACYDBOBJECTFIELDGET_H_

--- a/src/lib/orionld/mongoCppLegacy/mongoCppLegacyEntityListLookupWithIdTypeCreDate.cpp
+++ b/src/lib/orionld/mongoCppLegacy/mongoCppLegacyEntityListLookupWithIdTypeCreDate.cpp
@@ -29,7 +29,6 @@
 extern "C"
 {
 #include "kjson/KjNode.h"                                                // KjNode
-#include "kjson/kjRender.h"                                              // kjRender - TMP
 #include "kjson/kjBuilder.h"                                             // kjArray, ...
 }
 
@@ -117,9 +116,6 @@ KjNode* mongoCppLegacyEntityListLookupWithIdTypeCreDate(KjNode* entityIdsArray)
     kjChildAdd(entityTree, idNodeP);
     kjChildAdd(entityTree, typeNodeP);
     kjChildAdd(entityTree, creDateNodeP);
-
-    char debugBuffer[512];
-    kjRender(orionldState.kjsonP, entityTree, debugBuffer, sizeof(debugBuffer));
 
     // Create the entity array if it doesn't already exist
     if (entitiesArray == NULL)

--- a/src/lib/orionld/mongoCppLegacy/mongoCppLegacyEntityLookup.cpp
+++ b/src/lib/orionld/mongoCppLegacy/mongoCppLegacyEntityLookup.cpp
@@ -54,16 +54,16 @@ KjNode* mongoCppLegacyEntityLookup(const char* entityId)
 
 
   //
-  // Populate filter - only Entity ID for this operation
+  // Populate 'queryBuilder' - only Entity ID for this operation
   //
-  mongo::BSONObjBuilder  filter;
-  filter.append("_id.id", entityId);
+  mongo::BSONObjBuilder  queryBuilder;
+  queryBuilder.append("_id.id", entityId);
 
 
   // semTake()
   mongo::DBClientBase*                  connectionP = getMongoConnection();
   std::auto_ptr<mongo::DBClientCursor>  cursorP;
-  mongo::Query                          query(filter.obj());
+  mongo::Query                          query(queryBuilder.obj());
 
   cursorP = connectionP->query(collectionPath, query);
 
@@ -79,6 +79,7 @@ KjNode* mongoCppLegacyEntityLookup(const char* entityId)
     kjTree = dbDataToKjTree(&bsonObj, &title, &details);
     if (kjTree == NULL)
       LM_E(("%s: %s", title, details));
+    break;
   }
 
   releaseMongoConnection(connectionP);

--- a/src/lib/orionld/mongoCppLegacy/mongoCppLegacyEntityRetrieve.cpp
+++ b/src/lib/orionld/mongoCppLegacy/mongoCppLegacyEntityRetrieve.cpp
@@ -1,0 +1,251 @@
+/*
+*
+* Copyright 2019 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+#include "mongo/client/dbclient.h"                                  // MongoDB C++ Client Legacy Driver
+
+extern "C"
+{
+#include "kbase/kMacros.h"                                          // K_FT
+#include "kjson/KjNode.h"                                           // KjNode
+#include "kjson/kjLookup.h"                                         // kjLookup
+#include "kjson/kjBuilder.h"                                        // kjObject, ...
+#include "kjson/kjRender.h"                                         // kjRender
+}
+
+#include "logMsg/logMsg.h"                                          // LM_*
+#include "logMsg/traceLevels.h"                                     // Lmt*
+
+#include "mongoBackend/MongoGlobal.h"                               // getMongoConnection, releaseMongoConnection, ...
+#include "orionld/common/eqForDot.h"                                // eqForDot
+#include "orionld/db/dbCollectionPathGet.h"                         // dbCollectionPathGet
+#include "orionld/db/dbConfiguration.h"                             // dbDataToKjTree
+#include "orionld/mongoCppLegacy/mongoCppLegacyDbStringFieldGet.h"  // mongoCppLegacyDbStringFieldGet
+#include "orionld/mongoCppLegacy/mongoCppLegacyDbObjectFieldGet.h"  // mongoCppLegacyDbObjectFieldGet
+#include "orionld/mongoCppLegacy/mongoCppLegacyEntityRetrieve.h"    // Own interface
+
+
+
+// ----------------------------------------------------------------------------
+//
+// mongoCppLegacyEntityRetrieve -
+//
+// PARAMERTERS
+//   entityId        ID of the entity to be retrieved
+//   attrs           array of attribute names, terminated by a NULL pointer
+//   attrMandatory   If true - the entity is found only if any of the attributes in 'attrs'
+//                   is present in the entity
+//
+KjNode* mongoCppLegacyEntityRetrieve(const char* entityId, char** attrs, bool attrMandatory)
+{
+  char    collectionPath[256];
+  KjNode* attrTree  = NULL;
+  KjNode* dbTree    = NULL;
+
+  dbCollectionPathGet(collectionPath, sizeof(collectionPath), "entities");
+
+
+  //
+  // Populate 'queryBuilder' - only Entity ID for this operation
+  //
+  mongo::BSONObjBuilder  queryBuilder;
+  queryBuilder.append("_id.id", entityId);
+
+
+  // 1. Get _id - make a kj tree
+  // 2. Get attrs - make a kj tree
+  // 3. Change "value" to "object" for all attributes that are "Relationship"
+  // 4. Get @dataset - make a tree
+  // 5. Move every dataset attribute values to its corresponding attribute in attrs
+  // 6. Merge _id and attrs into one single tree
+  //
+
+
+  // semTake()
+  mongo::DBClientBase*                  connectionP = getMongoConnection();
+  std::auto_ptr<mongo::DBClientCursor>  cursorP;
+  mongo::Query                          query(queryBuilder.obj());
+  mongo::BSONObj                        retFieldsObj;
+  mongo::BSONObjBuilder                 retFieldsBuilder;
+
+  retFieldsBuilder.append("attrs", 1);
+  retFieldsBuilder.append("@datasets", 1);
+  retFieldsObj = retFieldsBuilder.obj();
+
+  //
+  // Querying mongo and retrieving the results
+  //
+  LM_TMP(("NQ: Making the query"));
+  cursorP = connectionP->query(collectionPath, query, 0, 0, &retFieldsObj);
+  LM_TMP(("NQ: Retrieving the results"));
+
+  while (cursorP->more())
+  {
+    LM_TMP(("NQ: Calling nextSafe"));
+    mongo::BSONObj  bsonObj = cursorP->nextSafe();
+    char*           title;
+    char*           details;
+
+    LM_TMP(("NQ: Calling dbDataToKjTree"));
+    dbTree = dbDataToKjTree(&bsonObj, &title, &details);
+    if (dbTree == NULL)
+      LM_E(("%s: %s", title, details));
+    break;
+  }
+
+  releaseMongoConnection(connectionP);
+  // semGive()
+
+  if (dbTree == NULL)
+  {
+    // Entity nt found
+    return NULL;
+  }
+
+  // <DEBUG>
+  char buf[1024];
+  kjRender(orionldState.kjsonP, dbTree, buf, sizeof(buf));
+  LM_TMP(("NQ: DB-Tree: %s", buf));
+  // </DEBUG>
+  
+  int      includedAttributes = 0;
+  KjNode*  dbAttrsP           = kjLookup(dbTree, "attrs");      // Must be there
+  KjNode*  dbDataSetsP        = kjLookup(dbTree, "@datasets");  // May not be there
+
+  if (dbAttrsP == NULL)
+  {
+    LM_E(("Internal Error (field 'attrs' not found for entity '%s')", entityId));
+    return NULL;
+  }
+
+  //
+  // Attributes may be found both in dbAttrsP abd in dbDataSetsP
+  //
+  if (attrs == NULL)     // Include all attributes in the response
+  {
+    attrTree = dbAttrsP;
+
+    //
+    // Add "@datasets" to the attributes
+    //
+    
+  }
+  else
+  {
+    attrTree = kjObject(orionldState.kjsonP, NULL);
+
+    int     ix = 0;
+    KjNode* attrP;
+    KjNode* datasetP;
+
+    while (attrs[ix] != NULL)
+    {
+      attrP    = kjLookup(dbAttrsP, attrs[ix]);
+      datasetP = (dbDataSetsP == NULL)? NULL : kjLookup(dbDataSetsP, attrs[ix]);
+
+      if ((datasetP != NULL) && (attrP != NULL))
+      {
+        kjChildRemove(dbDataSetsP, datasetP);
+        kjChildAdd(attrTree, datasetP);
+
+        kjChildRemove(dbAttrsP, attrP);
+        kjChildAdd(datasetP, attrP);
+        ++includedAttributes;
+      }
+      else if (attrP != NULL)
+      {
+        kjChildRemove(dbAttrsP, attrP);
+        kjChildAdd(attrTree, attrP);
+        ++includedAttributes;
+      }
+      else if (datasetP != NULL)
+      {
+        kjChildRemove(dbDataSetsP, datasetP);
+        kjChildAdd(attrTree, datasetP);
+      }
+
+      ++ix;
+    }
+      
+    //
+    // Change "value" to "object" for all attributes that are "Relationship".
+    // Note that the "object" field of a Relationship is stored in the database under the field "value".
+    // That fact is fixed here, by renaming the "value" to "object" for attr with type == Relationship.
+    // This depends on the database model and thus should be fixed in the database layer.
+    //
+    for (KjNode* attrP = attrTree->value.firstChildP; attrP != NULL; attrP = attrP->next)
+    {
+      if (attrP->type == KjObject)
+      {
+        KjNode* typeP = kjLookup(attrP, "type");
+
+        if (typeP == NULL)
+        {
+          LM_E(("Database Error (field 'type' not found for attribute '%s' of entity '%s')", attrP->name, entityId));
+          return NULL;
+        }
+
+        if (strcmp(typeP->value.s, "Relationship") == 0)
+        {
+          KjNode* objectP = kjLookup(attrP, "value");
+
+          if (objectP == NULL)
+          {
+            LM_E(("Database Error (field 'value' not found for attribute '%s' of entity '%s')", attrP->name, entityId));
+            return NULL;
+          }
+
+          objectP->name = (char*) "object";
+        }
+      }
+      else  // KjArray
+      {
+        LM_TMP(("ToDo: change 'value' for 'object' in all instances of attribute '%s'", attrP->name));
+      }
+    }
+  }
+
+  if ((includedAttributes == 0) && (attrMandatory == true))
+  {
+    // 404 not found ...
+    // The Entity exists, but it doesn't have ANY of the attributes in attrsP
+    return NULL;
+  }
+
+  KjNode* idP = kjLookup(dbTree, "_id");
+
+  if (idP == NULL)
+  {
+    LM_E(("Internal Error (field '_id' not found for entity '%s')", entityId));
+    return NULL;
+  }
+
+  // Merge idP and attrTree
+  if (attrTree != NULL)
+  {
+    idP->lastChild->next = attrTree->value.firstChildP;
+    idP->lastChild       = attrTree->lastChild;
+  }
+      
+  return idP;
+}

--- a/src/lib/orionld/mongoCppLegacy/mongoCppLegacyEntityRetrieve.h
+++ b/src/lib/orionld/mongoCppLegacy/mongoCppLegacyEntityRetrieve.h
@@ -1,5 +1,5 @@
-#ifndef SRC_LIB_ORIONLD_MONGOCPPLEGACY_MONGOCPPLEGACYDBFIELDGET_H_
-#define SRC_LIB_ORIONLD_MONGOCPPLEGACY_MONGOCPPLEGACYDBFIELDGET_H_
+#ifndef SRC_LIB_ORIONLD_MONGOCPPLEGACY_MONGOCPPLEGACYENTITYRETRIEVE_H_
+#define SRC_LIB_ORIONLD_MONGOCPPLEGACY_MONGOCPPLEGACYENTITYRETRIEVE_H_
 
 /*
 *
@@ -25,16 +25,23 @@
 *
 * Author: Ken Zangelin
 */
-#include "mongo/client/dbclient.h"                             // mongo::BSONElement
+extern "C"
+{
+#include "kjson/KjNode.h"                                        // KjNode
+}
 
 
 
-// -----------------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 //
-// mongoCppLegacyDbFieldGet -
+// mongoCppLegacyEntityRetrieve -
 //
-// FIXME: avoid to send object on the stack!!!
+// PARAMERTERS
+//   entityId        ID of the entity to be retrieved
+//   attrs           array of attribute names, terminated by a NULL pointer
+//   attrMandatory   If true - the entity is found only if any of the attributes in 'attrs'
+//                   is present in the entity
 //
-extern mongo::BSONElement mongoCppLegacyDbFieldGet(const mongo::BSONObj* boP, const char* fieldName);
+extern KjNode* mongoCppLegacyEntityRetrieve(const char* entityId, char** attrs, bool attrMandatory);
 
-#endif  // SRC_LIB_ORIONLD_MONGOCPPLEGACY_MONGOCPPLEGACYDBFIELDGET_H_
+#endif  // SRC_LIB_ORIONLD_MONGOCPPLEGACY_MONGOCPPLEGACYENTITYRETRIEVE_H_

--- a/src/lib/orionld/mongoCppLegacy/mongoCppLegacyEntityRetrieve.h
+++ b/src/lib/orionld/mongoCppLegacy/mongoCppLegacyEntityRetrieve.h
@@ -42,6 +42,14 @@ extern "C"
 //   attrMandatory   If true - the entity is found only if any of the attributes in 'attrs'
 //                   is present in the entity
 //
-extern KjNode* mongoCppLegacyEntityRetrieve(const char* entityId, char** attrs, bool attrMandatory, bool sysAttrs, bool keyValues);
+extern KjNode* mongoCppLegacyEntityRetrieve
+(
+  const char*  entityId,
+  char**       attrs,
+  bool         attrMandatory,
+  bool         sysAttrs,
+  bool         keyValues,
+  const char*  datasetId
+);
 
 #endif  // SRC_LIB_ORIONLD_MONGOCPPLEGACY_MONGOCPPLEGACYENTITYRETRIEVE_H_

--- a/src/lib/orionld/mongoCppLegacy/mongoCppLegacyEntityRetrieve.h
+++ b/src/lib/orionld/mongoCppLegacy/mongoCppLegacyEntityRetrieve.h
@@ -42,6 +42,6 @@ extern "C"
 //   attrMandatory   If true - the entity is found only if any of the attributes in 'attrs'
 //                   is present in the entity
 //
-extern KjNode* mongoCppLegacyEntityRetrieve(const char* entityId, char** attrs, bool attrMandatory);
+extern KjNode* mongoCppLegacyEntityRetrieve(const char* entityId, char** attrs, bool attrMandatory, bool sysAttrs, bool keyValues);
 
 #endif  // SRC_LIB_ORIONLD_MONGOCPPLEGACY_MONGOCPPLEGACYENTITYRETRIEVE_H_

--- a/src/lib/orionld/mqtt/CMakeLists.txt
+++ b/src/lib/orionld/mqtt/CMakeLists.txt
@@ -30,6 +30,7 @@ SET (SOURCES
     mqttConnectionList.cpp
     mqttConnectionLookup.cpp
     mqttNotification.cpp
+    mqttRelease.cpp
 )
 
 # Include directories

--- a/src/lib/orionld/mqtt/mqttRelease.cpp
+++ b/src/lib/orionld/mqtt/mqttRelease.cpp
@@ -1,0 +1,52 @@
+/*
+*
+* Copyright 2019 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+#include <stdlib.h>                                            // free
+
+#include "orionld/mqtt/MqttConnection.h"                       // MqttConnection
+#include "orionld/mqtt/mqttConnectionList.h"                   // mqttConnectionList
+#include "orionld/mqtt/mqttRelease.h"                          // Own Interface
+
+
+
+// -----------------------------------------------------------------------------
+//
+// mqttRelease -
+//
+void mqttRelease(void)
+{
+  if (mqttConnectionList == NULL)
+    return;
+
+  for (int ix = 0; ix < mqttConnectionListIx; ix++)
+  {
+    MqttConnection* mcP = &mqttConnectionList[ix];
+    
+    MQTTClient_disconnect(&mcP->client, 10000);
+    MQTTClient_destroy(&mcP->client);
+  }
+
+  free(mqttConnectionList);
+  mqttConnectionList = NULL;
+}

--- a/src/lib/orionld/mqtt/mqttRelease.cpp
+++ b/src/lib/orionld/mqtt/mqttRelease.cpp
@@ -42,7 +42,7 @@ void mqttRelease(void)
   for (int ix = 0; ix < mqttConnectionListIx; ix++)
   {
     MqttConnection* mcP = &mqttConnectionList[ix];
-    
+
     MQTTClient_disconnect(&mcP->client, 10000);
     MQTTClient_destroy(&mcP->client);
   }

--- a/src/lib/orionld/mqtt/mqttRelease.h
+++ b/src/lib/orionld/mqtt/mqttRelease.h
@@ -1,0 +1,40 @@
+#ifndef SRC_LIB_ORIONLD_MQTT_MQTTRELEASE_H_
+#define SRC_LIB_ORIONLD_MQTT_MQTTRELEASE_H_
+
+/*
+*
+* Copyright 2019 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+#include "orionld/mqtt/MqttConnection.h"                       // MqttConnection
+#include "orionld/mqtt/mqttConnectionList.h"                   // mqttConnectionList
+#include "orionld/mqtt/mqttRelease.h"                          // Own Interface
+
+
+
+// -----------------------------------------------------------------------------
+//
+// mqttRelease -
+//
+extern void mqttRelease(void);
+
+#endif  // SRC_LIB_ORIONLD_MQTT_MQTTRELEASE_H_

--- a/src/lib/orionld/payloadCheck/pcheckEntity.cpp
+++ b/src/lib/orionld/payloadCheck/pcheckEntity.cpp
@@ -91,29 +91,35 @@ static bool checkEntityIdFieldExists(void)
 //
 bool pcheckEntity
 (
-  KjNode*          kNodeP,
-  KjNode**         locationNodePP,
-  KjNode**         observationSpaceNodePP,
-  KjNode**         operationSpaceNodePP,
-  KjNode**         createdAtPP,
-  KjNode**         modifiedAtPP,
-  bool             isBatchOperation
+  KjNode*   kNodeP,
+  KjNode**  datasetAttrsP,
+  KjNode**  locationNodePP,
+  KjNode**  observationSpaceNodePP,
+  KjNode**  operationSpaceNodePP,
+  KjNode**  createdAtPP,
+  KjNode**  modifiedAtPP,
+  bool      isBatchOperation
 )
 {
   if (isBatchOperation == false)
   {
     OBJECT_CHECK(orionldState.requestTree, "toplevel");
+
     //
-    // Check presence of mandatory fields
+    // Check presence of mandatory fields "id" and "type"
     //
-    if (checkEntityIdFieldExists() == false) return false;
+    if (checkEntityIdFieldExists() == false)
+      return false;
   }
+
   char*    detailsP;
   KjNode*  locationNodeP          = NULL;
   KjNode*  observationSpaceNodeP  = NULL;
   KjNode*  operationSpaceNodeP    = NULL;
   KjNode*  createdAtP             = NULL;
   KjNode*  modifiedAtP            = NULL;
+  KjNode*  batchIdP               = NULL;
+  KjNode*  batchTypeP             = NULL;
 
   //
   // Check for duplicated items and that data types are correct
@@ -124,38 +130,16 @@ bool pcheckEntity
     {
       if (strcmp(kNodeP->name, "id") == 0)
       {
-        orionldState.payloadIdNode = kNodeP;
-
-        if (orionldState.payloadIdNode->type != KjString)
-        {
-          orionldErrorResponseCreate(OrionldBadRequestData, "Invalid Entity Id", "Must be a JSON String");
-          return false;
-        }
-
-        if ((urlCheck(orionldState.payloadIdNode->value.s, &detailsP) == false) && (urnCheck(orionldState.payloadIdNode->value.s, &detailsP) == false))
-        {
-          orionldErrorResponseCreate(OrionldBadRequestData, "Invalid Entity id", "The id specified cannot be resolved to a URL or URN");
-          return false;
-        }
-        //
-        // If the entity already exists, an error should be returned
-        //
-        // if (mongoEntityExists(orionldState.payloadIdNode->value.s, orionldState.tenant) == true)
-        // {
-        //   orionldErrorResponseCreate(OrionldAlreadyExists, "Entity already exists", orionldState.payloadIdNode->value.s);
-        //   orionldState.httpStatusCode = SccConflict;
-        //   return false;
-        // }
+        DUPLICATE_CHECK(batchIdP, "id", kNodeP);
+        STRING_CHECK(batchIdP, "id");
+        URI_CHECK(batchIdP, "id");
+        orionldState.payloadIdNode = kNodeP;  // FIXME: Is this necessary?
       }
       else if (strcmp(kNodeP->name, "type") == 0)
       {
-        orionldState.payloadTypeNode = kNodeP;
-
-        if (orionldState.payloadTypeNode->type != KjString)
-        {
-          orionldErrorResponseCreate(OrionldBadRequestData, "Invalid Entity Type", "Must be a JSON String");
-          return false;
-        }
+        DUPLICATE_CHECK(batchTypeP, "type", kNodeP);
+        STRING_CHECK(batchTypeP, "type");
+        orionldState.payloadTypeNode = kNodeP;  // FIXME: Is this necessary?
       }
     }
 

--- a/src/lib/orionld/payloadCheck/pcheckEntity.cpp
+++ b/src/lib/orionld/payloadCheck/pcheckEntity.cpp
@@ -92,7 +92,6 @@ static bool checkEntityIdFieldExists(void)
 bool pcheckEntity
 (
   KjNode*   kNodeP,
-  KjNode**  datasetAttrsP,
   KjNode**  locationNodePP,
   KjNode**  observationSpaceNodePP,
   KjNode**  operationSpaceNodePP,

--- a/src/lib/orionld/payloadCheck/pcheckEntity.h
+++ b/src/lib/orionld/payloadCheck/pcheckEntity.h
@@ -39,6 +39,7 @@ extern "C"
 extern bool pcheckEntity
 (
   KjNode*          kNodeP,
+  KjNode**         datasetAttrsP,
   KjNode**         locationNodePP,
   KjNode**         observationSpaceNodePP,
   KjNode**         operationSpaceNodePP,

--- a/src/lib/orionld/payloadCheck/pcheckEntity.h
+++ b/src/lib/orionld/payloadCheck/pcheckEntity.h
@@ -39,7 +39,6 @@ extern "C"
 extern bool pcheckEntity
 (
   KjNode*          kNodeP,
-  KjNode**         datasetAttrsP,
   KjNode**         locationNodePP,
   KjNode**         observationSpaceNodePP,
   KjNode**         operationSpaceNodePP,

--- a/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
@@ -193,6 +193,7 @@ static void optionsParse(const char* options)
       else if (strcmp(optionStart, "replace")     == 0)  orionldState.uriParamOptions.replace     = true;
       else if (strcmp(optionStart, "noOverwrite") == 0)  orionldState.uriParamOptions.noOverwrite = true;
       else if (strcmp(optionStart, "keyValues")   == 0)  orionldState.uriParamOptions.keyValues   = true;
+      else if (strcmp(optionStart, "sysAttrs")    == 0)  orionldState.uriParamOptions.sysAttrs    = true;
       else
       {
         LM_W(("Unknown 'options' value: %s", optionStart));

--- a/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
@@ -239,17 +239,11 @@ static int orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* 
     optionsParse(value);
   }
   else if (SCOMPARE12(key, 'g', 'e', 'o', 'p', 'r', 'o', 'p', 'e', 'r', 't', 'y', 0))
-  {
-    LM_TMP(("GEO: Got a geoproperty URI Param: %s", value));
     orionldState.uriParams.geoproperty = (char*) value;
-  }
   else if (SCOMPARE6(key, 'c', 'o', 'u', 'n', 't', 0))
   {
     if (strcmp(value, "true") == 0)
-    {
-      LM_TMP(("COUNT: the URI parameter 'count' is set to 'true'"));
       orionldState.uriParams.count = true;
-    }
     else if (strcmp(value, "false") != 0)
     {
       LM_W(("Bad Input (invalid value for URI parameter 'count': %s)", value));
@@ -257,6 +251,12 @@ static int orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* 
       orionldState.httpStatusCode = SccBadRequest;
       return false;
     }
+  }
+  else if (SCOMPARE10(key, 'd', 'a', 't', 'a', 's', 'e', 't', 'I', 'd', 0))
+  {
+    orionldState.uriParams.datasetId = (char*) value;
+    LM_TMP(("NQ: URI param datasetId == %s", orionldState.uriParams.datasetId));
+    // Check that it's a URI
   }
 
   return MHD_YES;

--- a/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
@@ -791,7 +791,7 @@ int orionldMhdConnectionTreat(ConnectionInfo* ciP)
     if (pd.status == 200)  // got an array with only Core Context
       orionldState.contextP = orionldCoreContextP;
 
-    if ((orionldState.contextP == NULL) || (pd.status >= 400))
+    if (pd.status >= 400)
     {
       LM_W(("Bad Input? (%s: %s (type == %d, status = %d))", pd.title, pd.detail, pd.type, pd.status));
       orionldErrorResponseFromProblemDetails(&pd);

--- a/src/lib/orionld/serviceRoutines/orionldGetEntities.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntities.cpp
@@ -389,5 +389,7 @@ bool orionldGetEntities(ConnectionInfo* ciP)
     ciP->httpHeaderValue.push_back(cV);
   }
 
+  mongoRequest.release();
+
   return true;
 }

--- a/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
@@ -32,7 +32,6 @@ extern "C"
 #include "kjson/KjNode.h"                                        // KjNode
 #include "kjson/kjBuilder.h"                                     // kjObject, ...
 #include "kjson/kjParse.h"                                       // kjParse
-#include "kjson/kjRender.h"                                      // kjRender
 }
 
 #include "logMsg/logMsg.h"                                       // LM_*
@@ -287,7 +286,6 @@ static KjNode* orionldForwardGetEntityPart(KjNode* registrationP, char* entityId
 //
 static KjNode* orionldForwardGetEntity(ConnectionInfo* ciP, char* entityId, KjNode* regArrayP, KjNode* responseP, bool needEntityType)
 {
-  LM_TMP(("lastChild at %p", responseP->lastChild));
   //
   // If URI param 'attrs' was used, split the attr-names into an array and expanmd according to @context
   //
@@ -325,20 +323,13 @@ static KjNode* orionldForwardGetEntity(ConnectionInfo* ciP, char* entityId, KjNo
       {
         next = nodeP->next;
 
-        char buf[1024];
-        kjRender(orionldState.kjsonP, responseP, buf, sizeof(buf));
-        LM_TMP(("NQ: Response so far: %s", buf));
-
         if (SCOMPARE3(nodeP->name, 'i', 'd', 0))
         {
         }
         else if (SCOMPARE5(nodeP->name, 't', 'y', 'p', 'e', 0))
         {
-          LM_TMP(("NQ: Found a type"));
           if (needEntityType)
           {
-            LM_TMP(("NQ: Need a type"));
-
             //
             // We're taking the entity::type from the Response to the forwarded request
             // because no local entity was found.
@@ -349,12 +340,7 @@ static KjNode* orionldForwardGetEntity(ConnectionInfo* ciP, char* entityId, KjNo
           }
         }
         else
-        {
-          LM_TMP(("NQ: Adding '%s' to response", nodeP->name));
-          LM_TMP(("NQ: responseP at %p", responseP));
-          LM_TMP(("NQ: nodeP     at %p", nodeP));
           kjChildAdd(responseP, nodeP);
-        }
 
         nodeP = next;
       }
@@ -409,7 +395,6 @@ bool orionldGetEntity(ConnectionInfo* ciP)
   KjNode*  regArray;
   // bool     keyValues = orionldState.uriParamOptions.keyValues;
 
-  LM_TMP(("NQ: In"));
   //
   // Make sure the ID (orionldState.wildcard[0]) is a valid URI
   //
@@ -493,7 +478,6 @@ bool orionldGetEntity(ConnectionInfo* ciP)
   if (regArray != NULL)
   {
     bool needEntityType = false;
-    LM_TMP(("NQ: There are matching registrations ..."));
 
     if (orionldState.responseTree == NULL)
     {
@@ -505,7 +489,6 @@ bool orionldGetEntity(ConnectionInfo* ciP)
       needEntityType = true;  // Get it from Forward-response
     }
 
-    LM_TMP(("NQ: Calling orionldForwardGetEntity"));
     orionldForwardGetEntity(ciP, orionldState.wildcard[0], regArray, orionldState.responseTree, needEntityType);
   }
 

--- a/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
@@ -386,8 +386,7 @@ bool orionldGetEntity(ConnectionInfo* ciP)
 
   LM_T(LmtServiceRoutine, ("In orionldGetEntity: %s", orionldState.wildcard[0]));
 
-#if 1
-  bool                  keyValues = ciP->uriParamOptions[OPT_KEY_VALUES];
+  bool                  keyValues = orionldState.uriParamOptions.keyValues;  // ciP->uriParamOptions[OPT_KEY_VALUES];
   EntityId              entityId(orionldState.wildcard[0], "", "false", false);
   QueryContextRequest   request;
   QueryContextResponse  response;
@@ -422,63 +421,6 @@ bool orionldGetEntity(ConnectionInfo* ciP)
     // Create response by converting "QueryContextResponse response" into a KJson tree
     orionldState.responseTree = kjTreeFromQueryContextResponse(ciP, true, orionldState.uriParams.attrs, keyValues, &response);
   }
-#else
-  //
-  // Use dbEntityLookup() instead of mongoQueryContext()
-  //
-  //
-  // FIXME
-  // dbEntityLookup (mongoCppLegacyEntityLookup) uses dbDataToKjTree, which makes a complete copy of the tree in mongo:
-  // {
-  //   "_id": {
-  //     "id": "urn:ngsi-ld:E09",
-  //     "type": "https://uri.etsi.org/ngsi-ld/default-context/T",
-  //     "servicePath": "/"
-  //   },
-  //   "attrNames": [
-  //     "https://uri.etsi.org/ngsi-ld/default-context/P1"
-  //   ],
-  //   "attrs": {
-  //     "https://uri=etsi=org/ngsi-ld/default-context/P1": {
-  //       "type": "Property",
-  //       "creDate": 1579884546,
-  //       "modDate": 1579884546,
-  //       "value": {
-  //         "@type": "DateTime",
-  //         "@value": "2018-12-04T12:00:00"
-  //       },
-  //       "mdNames": []
-  //     }
-  //   },
-  //   "creDate": 1579884546,
-  //   "modDate": 1579884546,
-  //   "lastCorrelator": ""
-  // }
-  //
-  // Instead of:
-  // {
-  //   "id": "urn:ngsi-ld:E09",
-  //   "type": "T",
-  //   "P1": {
-  //     "type": "Property",
-  //     "value": {
-  //     "@type": "DateTime",
-  //     "@value": "2018-12-04T12:00:00"
-  //   }
-  // }
-  //
-  // To fix this:
-  // - Call a less generic function to create the KjNode tree (dbEntityDataToKjTree) that
-  //   - Removes "_id", "servicePath", "attrNames", "mdNames", "creDate", "modDate", "lastCorrelator"
-  // - Compact the attribute names and the entity id
-  // - keyValues
-  // - sysAttrs
-  //
-  // With all this done, I could stop using mongoBackend for this (and similar with all GET operations)
-  //
-  KjNode* entityWithDatabaseStructure = dbEntityLookup(orionldState.wildcard[0]);
-  orionldState.responseTree = kjTreeFromEntityWithDatabaseStructure(entityWithDatabaseStructure, keyValues, sysAttrs);
-#endif
 
   if ((orionldState.responseTree == NULL) && (regArray == NULL))
   {

--- a/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
@@ -467,7 +467,7 @@ bool orionldGetEntity(ConnectionInfo* ciP)
   if (orionldState.uriParams.attrs != NULL)
     attrsP = (char**) attrsListToArray(orionldState.uriParams.attrs, attrs, 100);
 
-  orionldState.responseTree = dbEntityRetrieve(orionldState.wildcard[0], attrsP, false, orionldState.uriParamOptions.sysAttrs, orionldState.uriParamOptions.keyValues);
+  orionldState.responseTree = dbEntityRetrieve(orionldState.wildcard[0], attrsP, false, orionldState.uriParamOptions.sysAttrs, orionldState.uriParamOptions.keyValues, orionldState.uriParams.datasetId);
 #endif
 
   if ((orionldState.responseTree == NULL) && (regArray == NULL))

--- a/src/lib/orionld/serviceRoutines/orionldPatchAttribute.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchAttribute.cpp
@@ -399,7 +399,10 @@ bool orionldPatchAttribute(ConnectionInfo* ciP)
   mongoRequest.contextElementVector.push_back(ceP);
 
   if (kjTreeToEntity(&mongoRequest, mergedP) == false)
+  {
+    mongoRequest.release();
     return false;
+  }
 
 
   //
@@ -423,8 +426,10 @@ bool orionldPatchAttribute(ConnectionInfo* ciP)
   {
     LM_E(("mongoUpdateContext: HTTP Status Code: %d", orionldState.httpStatusCode));
     orionldErrorResponseCreate(OrionldBadRequestData, "Internal Error", "Error from Mongo-DB backend");
+    mongoRequest.release();
     return false;
   }
 
+  mongoRequest.release();
   return true;
 }

--- a/src/lib/orionld/serviceRoutines/orionldPatchEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchEntity.cpp
@@ -28,7 +28,6 @@ extern "C"
 #include "kjson/KjNode.h"                                        // KjNode
 #include "kjson/kjLookup.h"                                      // kjLookup
 #include "kjson/kjBuilder.h"                                     // kjChildRemove
-#include "kjson/kjRender.h"                                      // kjRender
 }
 
 #include "logMsg/logMsg.h"                                       // LM_*
@@ -308,11 +307,6 @@ bool orionldPatchEntity(ConnectionInfo* ciP)
     // Steal createdAt from dbAttrP?
 
     // Remove the attribute to be updated (from dbEntityP::inDbAttrsP) and insert the attribute from the payload data
-    // <DEBUG>
-    char buf[1024];
-    kjRender(orionldState.kjsonP, dbAttrP, buf, sizeof(buf));
-    kjRender(orionldState.kjsonP, newAttrP, buf, sizeof(buf));
-
     kjChildRemove(inDbAttrsP, dbAttrP);
     kjChildAdd(inDbAttrsP, newAttrP);
     attributeUpdated(updatedP, newAttrP->name);

--- a/src/lib/orionld/serviceRoutines/orionldPatchEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchEntity.cpp
@@ -356,14 +356,20 @@ bool orionldPatchEntity(ConnectionInfo* ciP)
                                                    ciP->apiVersion,
                                                    NGSIV2_NO_FLAVOUR);
 
+  ucRequest.release();
+
   // 9. Postprocess output from mongoBackend
   if (orionldState.httpStatusCode == SccOk)
   {
     //
     // 204 or 207?
+    //
+    // 204 if all went ok (== empty list of 'not updated')
+    // 207 if something went wrong (== non-empty list of 'not updated')
+    //
     // If 207 - prepare the response payload data
     //
-    if (notUpdatedP->value.firstChildP != NULL)
+    if (notUpdatedP->value.firstChildP != NULL)  // non-empty list of 'not updated'
     {
       orionldState.responseTree = kjObject(orionldState.kjsonP, NULL);
 

--- a/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
@@ -123,7 +123,7 @@ KjNode* datasetInstances(KjNode* datasets, KjNode* attrV, char* attributeName, d
       }
     }
 
-    if ((datasetIdP == NULL) || (strcmp(datasetIdP->value.s, ORIONLD_DEFAULT_DATASET_ID) == 0))  // No datasetId
+    if (datasetIdP == NULL)  // No datasetId
     {
       if (defaultInstanceP != NULL)  // Already found an instance without datasetId ?
       {
@@ -298,11 +298,9 @@ bool orionldPostEntities(ConnectionInfo* ciP)
           mongoRequest.release();
           return false;
         }
-        else
-        {
-          kNodeP = next;
-          continue;
-        }
+
+        kNodeP = next;
+        continue;
       }
 
       //
@@ -341,31 +339,26 @@ bool orionldPostEntities(ConnectionInfo* ciP)
       STRING_CHECK(datasetIdP, "datasetId");
       URI_CHECK(datasetIdP, "datasetId");
 
-      if (strcmp(datasetIdP->value.s, ORIONLD_DEFAULT_DATASET_ID) != 0)
-      {
-        kjChildRemove(orionldState.requestTree, kNodeP);
-        kjChildAdd(datasets, kNodeP);
+      kjChildRemove(orionldState.requestTree, kNodeP);
+      kjChildAdd(datasets, kNodeP);
 
-        // Add createdAt and modifiedAt to the instance
-        KjNode* createdAt  = kjFloat(orionldState.kjsonP, "createdAt",  timestamp);
-        KjNode* modifiedAt = kjFloat(orionldState.kjsonP, "modifiedAt", timestamp);
-        kjChildAdd(kNodeP, createdAt);
-        kjChildAdd(kNodeP, modifiedAt);
+      // Add createdAt and modifiedAt to the instance
+      KjNode* createdAt  = kjFloat(orionldState.kjsonP, "createdAt",  timestamp);
+      KjNode* modifiedAt = kjFloat(orionldState.kjsonP, "modifiedAt", timestamp);
+      kjChildAdd(kNodeP, createdAt);
+      kjChildAdd(kNodeP, modifiedAt);
 
-        // Change to longName
-        bool   valueMayBeExpanded;
-        char*  longName = orionldContextItemExpand(orionldState.contextP, kNodeP->name, &valueMayBeExpanded, true, NULL);
+      // Change to longName
+      bool   valueMayBeExpanded;
+      char*  longName = orionldContextItemExpand(orionldState.contextP, kNodeP->name, &valueMayBeExpanded, true, NULL);
 
-        longName = kaStrdup(&orionldState.kalloc, longName);
-        dotForEq(longName);
-        kNodeP->name = longName;
+      longName = kaStrdup(&orionldState.kalloc, longName);
+      dotForEq(longName);
+      kNodeP->name = longName;
 
-        kNodeP = next;
+      kNodeP = next;
 
-        continue;
-      }
-
-      kjChildRemove(kNodeP, datasetIdP);
+      continue;
     }
 
     ContextAttribute* caP            = new ContextAttribute();

--- a/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
@@ -74,9 +74,8 @@ bool orionldPostEntities(ConnectionInfo* ciP)
   KjNode*  operationSpaceP    = NULL;
   KjNode*  createdAtP         = NULL;
   KjNode*  modifiedAtP        = NULL;
-  KjNode*  datasetAttrsP      = NULL;
 
-  if (pcheckEntity(orionldState.requestTree->value.firstChildP, &datasetAttrsP, &locationP, &observationSpaceP, &operationSpaceP, &createdAtP, &modifiedAtP, false) == false)
+  if (pcheckEntity(orionldState.requestTree->value.firstChildP, &locationP, &observationSpaceP, &operationSpaceP, &createdAtP, &modifiedAtP, false) == false)
     return false;
 
   char*    entityId           = orionldState.payloadIdNode->value.s;

--- a/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
@@ -407,6 +407,7 @@ bool orionldPostEntities(ConnectionInfo* ciP)
     {
       // kjTreeToContextAttribute calls orionldErrorResponseCreate
       LM_E(("kjTreeToContextAttribute failed: %s", detail));
+      caP->release();
       delete caP;
       mongoRequest.release();
       return false;

--- a/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
@@ -74,8 +74,9 @@ bool orionldPostEntities(ConnectionInfo* ciP)
   KjNode*  operationSpaceP    = NULL;
   KjNode*  createdAtP         = NULL;
   KjNode*  modifiedAtP        = NULL;
+  KjNode*  datasetAttrsP      = NULL;
 
-  if (pcheckEntity(orionldState.requestTree->value.firstChildP, &locationP, &observationSpaceP, &operationSpaceP, &createdAtP, &modifiedAtP, false) == false)
+  if (pcheckEntity(orionldState.requestTree->value.firstChildP, &datasetAttrsP, &locationP, &observationSpaceP, &operationSpaceP, &createdAtP, &modifiedAtP, false) == false)
     return false;
 
   char*    entityId           = orionldState.payloadIdNode->value.s;

--- a/src/lib/orionld/serviceRoutines/orionldPostEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntity.cpp
@@ -287,6 +287,7 @@ bool orionldPostEntity(ConnectionInfo* ciP)
     {
       LM_E(("kjTreeToContextAttribute(%s): %s", attrP->name, detail));
       attributeNotUpdated(notUpdatedP, attrP->name, detail);
+      free(caP);
       continue;
     }
 

--- a/src/lib/orionld/serviceRoutines/orionldPostEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntity.cpp
@@ -272,11 +272,11 @@ bool orionldPostEntity(ConnectionInfo* ciP)
   // 9. Convert the remaining attributes in orionldState.requestTree to an UpdateContextRequest to prepare for call to mongoBackend
   //
   UpdateContextRequest ucr;
-  ContextElement       ce;
+  ContextElement*      ceP = new ContextElement();
 
-  ce.entityId.id = entityId;
+  ceP->entityId.id = entityId;
 
-  ucr.contextElementVector.push_back(&ce);
+  ucr.contextElementVector.push_back(ceP);
 
   for (KjNode* attrP = orionldState.requestTree->value.firstChildP; attrP != NULL; attrP = attrP->next)
   {
@@ -287,12 +287,13 @@ bool orionldPostEntity(ConnectionInfo* ciP)
     {
       LM_E(("kjTreeToContextAttribute(%s): %s", attrP->name, detail));
       attributeNotUpdated(notUpdatedP, attrP->name, detail);
+      caP->release();
       free(caP);
       continue;
     }
 
     attributeUpdated(updatedP, attrP->name);
-    ce.contextAttributeVector.push_back(caP);
+    ceP->contextAttributeVector.push_back(caP);
   }
 
   // 10. Call mongoBackend to do the Update
@@ -329,5 +330,6 @@ bool orionldPostEntity(ConnectionInfo* ciP)
     orionldState.httpStatusCode = SccMultiStatus;
   }
 
+  ucr.release();
   return true;
 }

--- a/src/lib/orionld/types/OrionldResponseErrorType.h
+++ b/src/lib/orionld/types/OrionldResponseErrorType.h
@@ -34,6 +34,7 @@
 //
 typedef enum OrionldResponseErrorType
 {
+  OrionldOk,
   OrionldInvalidRequest,
   OrionldBadRequestData,
   OrionldAlreadyExists,

--- a/test/functionalTest/cases/0000_ngsild/ngsild_GET_with_sysAttrs.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_GET_with_sysAttrs.test
@@ -100,9 +100,9 @@ Date: REGEX(.*)
   "modifiedAt": "REGEX(.*)",
   "P1": {
     "type": "Property",
-    "value": 1,
     "createdAt": "REGEX(.*)",
-    "modifiedAt": "REGEX(.*)"
+    "modifiedAt": "REGEX(.*)",
+    "value": 1
   }
 }
 
@@ -123,9 +123,9 @@ Date: REGEX(.*)
   "modifiedAt": "REGEX(.*)",
   "P1": {
     "type": "Property",
-    "value": 1,
     "createdAt": "REGEX(.*)",
-    "modifiedAt": "REGEX(.*)"
+    "modifiedAt": "REGEX(.*)",
+    "value": 1
   }
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_add_and_modify_attr.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_add_and_modify_attr.test
@@ -143,12 +143,12 @@ Date: REGEX(.*)
   "id": "urn:ngsi-ld:T:2018-11-22T10:00:00",
   "type": "T",
   "P1": {
-    "type": "Property",
-    "value": "new"
+    "value": "new",
+    "type": "Property"
   },
   "P2": {
-    "type": "Property",
-    "value": true
+    "value": true,
+    "type": "Property"
   }
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_add_attr-noOverwrite.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_add_attr-noOverwrite.test
@@ -218,8 +218,8 @@ Date: REGEX(.*)
     "value": 11
   },
   "P2": {
-    "type": "Property",
-    "value": 42
+    "value": 42,
+    "type": "Property"
   }
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_add_attr.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_add_attr.test
@@ -147,12 +147,12 @@ Date: REGEX(.*)
     "value": 1
   },
   "P2": {
-    "type": "Property",
-    "value": "new"
+    "value": "new",
+    "type": "Property"
   },
   "P3": {
-    "type": "Property",
-    "value": false
+    "value": false,
+    "type": "Property"
   }
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_adding_attributes.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_adding_attributes.test
@@ -271,30 +271,6 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:Shelf:unit001",
   "type": "https://fiware.github.io/tutorials.Step-by-Step/schema/Shelf",
-  "https://fiware.github.io/tutorials.Step-by-Step/schema/locatedIn": {
-    "type": "Relationship",
-    "object": "urn:ngsi-ld:Building:store001",
-    "https://fiware.github.io/tutorials.Step-by-Step/schema/installedBy": {
-      "type": "Relationship",
-      "object": "urn:ngsi-ld:Person:employee001"
-    },
-    "https://fiware.github.io/tutorials.Step-by-Step/schema/statusOfWork": {
-      "type": "Property",
-      "value": "https://fiware.github.io/tutorials.Step-by-Step/schema/completed"
-    }
-  },
-  "https://fiware.github.io/tutorials.Step-by-Step/schema/maxCapacity": {
-    "type": "Property",
-    "value": 50
-  },
-  "https://fiware.github.io/tutorials.Step-by-Step/schema/stocks": {
-    "type": "Relationship",
-    "object": "urn:ngsi-ld:Product:001"
-  },
-  "name": {
-    "type": "Property",
-    "value": "Corner Unit"
-  },
   "location": {
     "type": "GeoProperty",
     "value": {
@@ -304,6 +280,30 @@ Date: REGEX(.*)
         52.554699
       ]
     }
+  },
+  "https://fiware.github.io/tutorials.Step-by-Step/schema/maxCapacity": {
+    "type": "Property",
+    "value": 50
+  },
+  "name": {
+    "type": "Property",
+    "value": "Corner Unit"
+  },
+  "https://fiware.github.io/tutorials.Step-by-Step/schema/locatedIn": {
+    "object": "urn:ngsi-ld:Building:store001",
+    "type": "Relationship",
+    "https://fiware.github.io/tutorials.Step-by-Step/schema/installedBy": {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:Person:employee001"
+    },
+    "https://fiware.github.io/tutorials.Step-by-Step/schema/statusOfWork": {
+      "type": "Property",
+      "value": "https://fiware.github.io/tutorials.Step-by-Step/schema/completed"
+    }
+  },
+  "https://fiware.github.io/tutorials.Step-by-Step/schema/stocks": {
+    "object": "urn:ngsi-ld:Product:001",
+    "type": "Relationship"
   }
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_attribute_overwrite.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_attribute_overwrite.test
@@ -113,13 +113,13 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:T:12:13:14",
   "type": "T",
-  "P1": {
-    "type": "Property",
-    "value": "Hola"
-  },
   "P2": {
     "type": "Property",
     "value": "intocable"
+  },
+  "P1": {
+    "value": "Hola",
+    "type": "Property"
   }
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert_and_contexts.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert_and_contexts.test
@@ -256,9 +256,9 @@ echo "02. Make sure the upsert took less than 5 seconds (to see that the context
 echo "======================================================================================================"
 typeset -i diffTime
 diffTime=$endTime-$startTime
-if [ $diffTime -gt 4 ]
+if [ $diffTime -gt 5 ]
 then
-  echo "The creation of the 5 entities took TOO LONG (%diffTime seconds)"
+  echo "The creation of the 5 entities took TOO LONG ($diffTime seconds)"
 else
   echo "Good - the creation of the 5 entities took less than 5 seconds"
 fi

--- a/test/functionalTest/cases/0000_ngsild/ngsild_context_in_header_or_payload_when_entity_has_a_context.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_context_in_header_or_payload_when_entity_has_a_context.test
@@ -163,11 +163,11 @@ Date: REGEX(.*)
   "P1": {
     "type": "Property",
     "value": 12,
+    "observedAt": "2018-12-04T12:00:00Z",
     "P1_R1": {
       "type": "Relationship",
       "object": "urn:ngsi-ld:T2:6789"
-    },
-    "observedAt": "2018-12-04T12:00:00Z"
+    }
   }
 }
 
@@ -187,11 +187,11 @@ Date: REGEX(.*)
   "P1": {
     "type": "Property",
     "value": 12,
+    "observedAt": "2018-12-04T12:00:00Z",
     "P1_R1": {
       "type": "Relationship",
       "object": "urn:ngsi-ld:T2:6789"
-    },
-    "observedAt": "2018-12-04T12:00:00Z"
+    }
   }
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_context_in_header_or_payload_when_entity_has_no_context.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_context_in_header_or_payload_when_entity_has_no_context.test
@@ -162,11 +162,11 @@ Date: REGEX(.*)
   "P1": {
     "type": "Property",
     "value": 12,
+    "observedAt": "2018-12-04T12:00:00Z",
     "P1_R1": {
       "type": "Relationship",
       "object": "urn:ngsi-ld:T2:6789"
-    },
-    "observedAt": "2018-12-04T12:00:00Z"
+    }
   }
 }
 
@@ -186,11 +186,11 @@ Date: REGEX(.*)
   "P1": {
     "type": "Property",
     "value": 12,
+    "observedAt": "2018-12-04T12:00:00Z",
     "P1_R1": {
       "type": "Relationship",
       "object": "urn:ngsi-ld:T2:6789"
-    },
-    "observedAt": "2018-12-04T12:00:00Z"
+    }
   }
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_datasetId_entity_creation.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_datasetId_entity_creation.test
@@ -21,7 +21,7 @@
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
 --NAME--
-Entity Creation
+Attributes with datasetId - creation
 
 --SHELL-INIT--
 export BROKER=orionld

--- a/test/functionalTest/cases/0000_ngsild/ngsild_datasetId_entity_creation.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_datasetId_entity_creation.test
@@ -97,9 +97,9 @@ Date: REGEX(.*)
 
 02. See the entity in the 'entities' collection - see zero 'normal' attributes and two datasetId attributes - name and name2	- name with TWO	instances
 =======================================================================================================================================================
-MongoDB shell version v3.6.17
-connecting to: mongodb://localhost:27017/ftest
-MongoDB server version: 3.6.17
+MongoDB shell version REGEX(.*)
+connecting to: REGEX(.*)
+MongoDB server version: REGEX(.*)
 {
 	"_id" : {
 		"id" : "urn:ngsi-ld:entities:E1",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_datasetId_entity_creation.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_datasetId_entity_creation.test
@@ -1,4 +1,4 @@
-# Copyright 2018 FIWARE Foundation e.V.
+# Copyright 2019 FIWARE Foundation e.V.
 #
 # This file is part of Orion-LD Context Broker.
 #

--- a/test/functionalTest/cases/0000_ngsild/ngsild_datasetId_entity_creation.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_datasetId_entity_creation.test
@@ -1,0 +1,172 @@
+# Copyright 2018 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Entity Creation
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+brokerStart CB 212-249
+
+--SHELL--
+
+#
+# 01. Create an entity with 4 attributes (name, name2, name3, and name4) with a mix of datasetIds
+# 02. See the entity in the 'entities' collection - see zero 'normal' attributes and two datasetId attributes - name and name2	- name with TWO	instances
+#
+
+echo "01. Create an entity with 4 attributes (name, name2, name3, and name4) with a mix of datasetIds"
+echo "==============================================================================================="
+payload='{
+  "id": "urn:ngsi-ld:entities:E1",
+  "type": "T",
+  "name": [
+    {
+      "type": "Property",
+      "value": "no dataset id"
+    },
+    {
+      "type": "Property",
+      "value": "dataset urn:ngsi-ld/dataset:1",
+      "datasetId": "urn:ngsi-ld/dataset:1"
+    },
+    {
+      "type": "Property",
+      "value": "dataset urn:ngsi-ld/dataset:2",
+      "datasetId": "urn:ngsi-ld/dataset:2"
+    }
+  ],
+  "name2": [
+    {
+      "type": "Property",
+      "value": "dataset urn:ngsi-ld/dataset:1",
+      "datasetId": "urn:ngsi-ld/dataset:1"
+    }
+  ],
+  "name3": {
+    "type": "Property",
+    "value": "no dataset id"
+  },
+  "name4": {
+    "type": "Property",
+    "value": "dataset urn:ngsi-ld/dataset:1",
+    "datasetId": "urn:ngsi-ld/dataset:1"
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "02. See the entity in the 'entities' collection - see zero 'normal' attributes and two datasetId attributes - name and name2	- name with TWO	instances"
+echo "======================================================================================================================================================="
+mongoCmd2 ftest "db.entities.findOne()"
+echo
+echo
+
+
+--REGEXPECT--
+01. Create an entity with 4 attributes (name, name2, name3, and name4) with a mix of datasetIds
+===============================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:entities:E1
+Date: REGEX(.*)
+
+
+
+02. See the entity in the 'entities' collection - see zero 'normal' attributes and two datasetId attributes - name and name2	- name with TWO	instances
+=======================================================================================================================================================
+MongoDB shell version v3.6.17
+connecting to: mongodb://localhost:27017/ftest
+MongoDB server version: 3.6.17
+{
+	"_id" : {
+		"id" : "urn:ngsi-ld:entities:E1",
+		"type" : "https://uri.etsi.org/ngsi-ld/default-context/T",
+		"servicePath" : "/"
+	},
+	"attrNames" : [
+		"https://uri=etsi=org/ngsi-ld/name",
+		"https://uri.etsi.org/ngsi-ld/default-context/name3"
+	],
+	"attrs" : {
+		"https://uri=etsi=org/ngsi-ld/name" : {
+			"type" : "Property",
+			"creDate" : REGEX(.*),
+			"modDate" : REGEX(.*),
+			"value" : "no dataset id",
+			"mdNames" : [ ]
+		},
+		"https://uri=etsi=org/ngsi-ld/default-context/name3" : {
+			"type" : "Property",
+			"creDate" : REGEX(.*),
+			"modDate" : REGEX(.*),
+			"value" : "no dataset id",
+			"mdNames" : [ ]
+		}
+	},
+	"creDate" : REGEX(.*),
+	"modDate" : REGEX(.*),
+	"lastCorrelator" : "",
+	"@datasets" : {
+		"https://uri=etsi=org/ngsi-ld/name" : [
+			{
+				"type" : "Property",
+				"value" : "dataset urn:ngsi-ld/dataset:1",
+				"datasetId" : "urn:ngsi-ld/dataset:1",
+				"createdAt" : REGEX(.*),
+				"modifiedAt" : REGEX(.*)
+			},
+			{
+				"type" : "Property",
+				"value" : "dataset urn:ngsi-ld/dataset:2",
+				"datasetId" : "urn:ngsi-ld/dataset:2",
+				"createdAt" : REGEX(.*),
+				"modifiedAt" : REGEX(.*)
+			}
+		],
+		"https://uri=etsi=org/ngsi-ld/default-context/name2" : [
+			{
+				"type" : "Property",
+				"value" : "dataset urn:ngsi-ld/dataset:1",
+				"datasetId" : "urn:ngsi-ld/dataset:1",
+				"createdAt" : REGEX(.*),
+				"modifiedAt" : REGEX(.*)
+			}
+		],
+		"https://uri=etsi=org/ngsi-ld/default-context/name4" : {
+			"type" : "Property",
+			"value" : "dataset urn:ngsi-ld/dataset:1",
+			"datasetId" : "urn:ngsi-ld/dataset:1",
+			"createdAt" : REGEX(.*),
+			"modifiedAt" : REGEX(.*)
+		}
+	}
+}
+bye
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/0000_ngsild/ngsild_datasetId_entity_retrieval.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_datasetId_entity_retrieval.test
@@ -31,18 +31,27 @@ brokerStart CB
 --SHELL--
 
 #
-# 01. Create an entity E1 with 4 attributes (name, name2, name3, and name4) with a mix of datasetIds
-# 02. GET E1 with attr 'name' - see 3 instances of 'name'
-# 03. GET E1 with attr 'name' and datasetId 'urn:ngsi-ld/dataset:1' - see just one instance of 'name'
-# 04. GET E1 with attr 'name' and datasetId 'urn:ngsi-ld/dataset:3' - see a 404 Not Found ?
+# Without using datasetId URI param
+# 01. Create an entity E1 with 3 properties (prop, prop2, and prop3) with a mix of datasetIds
+# 02. GET E1 with attr 'prop' - see 3 instances of 'prop'
+# 03. GET E1 with attr 'prop2' - see 1 instance of 'prop2'
+# 04. GET E1 with attr 'prop3' - see 1 instance of 'prop3'
+# 05. Create an entity E1 with 3 relationships (rel, rel2, and rel3) with a mix of datasetIds
+# 06. GET E1 with attr 'rel' - see 3 instances of 'rel'
+# 07. GET E1 with attr 'rel2' - see 1 instance of 'rel2'
+# 08. GET E1 with attr 'rel3' - see 1 instance of 'rel3'
+#
+# With datasetId URI param
+# 09. GET E1 with attr 'prop' and datasetId 'urn:ngsi-ld/dataset:1' - see just one instance of 'prop'
+# 10. GET E1 with attr 'prop' and datasetId 'urn:ngsi-ld/dataset:3' - see a 404 Not Found ?
 #
 
-echo "01. Create an entity E1 with 4 attributes (name, name2, name3, and name4) with a mix of datasetIds"
-echo "=================================================================================================="
+echo "01. Create an entity E1 with 3 properties (prop, prop2, and prop3) with a mix of datasetIds"
+echo "==========================================================================================="
 payload='{
   "id": "urn:ngsi-ld:entities:E1",
   "type": "T",
-  "name": [
+  "prop": [
     {
       "type": "Property",
       "value": "no dataset id"
@@ -58,21 +67,16 @@ payload='{
       "datasetId": "urn:ngsi-ld/dataset:2"
     }
   ],
-  "name2": [
+  "prop2": [
     {
       "type": "Property",
       "value": "dataset urn:ngsi-ld/dataset:1",
       "datasetId": "urn:ngsi-ld/dataset:1"
     }
   ],
-  "name3": {
+  "prop3": {
     "type": "Property",
     "value": "no dataset id"
-  },
-  "name4": {
-    "type": "Property",
-    "value": "dataset urn:ngsi-ld/dataset:1",
-    "datasetId": "urn:ngsi-ld/dataset:1"
   }
 }'
 orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
@@ -80,16 +84,87 @@ echo
 echo
 
 
-echo "02. GET E1 with attr 'name' - see 3 instances of 'name'"
+echo "02. GET E1 with attr 'prop' - see 3 instances of 'prop'"
 echo "======================================================="
-orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:entities:E1?attrs=name&prettyPrint=yes' --noPayloadCheck
+orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:entities:E1?attrs=prop&prettyPrint=yes' --noPayloadCheck
+echo
+echo
+
+
+echo "03. GET E1 with attr 'prop2' - see 1 instance of 'prop2'"
+echo "======================================================="
+orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:entities:E1?attrs=prop2&prettyPrint=yes' --noPayloadCheck
+echo
+echo
+
+
+echo "04. GET E1 with attr 'prop3' - see 1 instance of 'prop3'"
+echo "========================================================"
+orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:entities:E1?attrs=prop3&prettyPrint=yes' --noPayloadCheck
+echo
+echo
+
+
+echo "05. Create an entity E2 with 3 relationships (rel, rel2, and rel3) with a mix of datasetIds"
+echo "==========================================================================================="
+payload='{
+  "id": "urn:ngsi-ld:entities:E2",
+  "type": "T",
+  "rel": [
+    {
+      "type": "Relationship",
+      "object": "urn:no_dataset_id"
+    },
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld/dataset:1",
+      "datasetId": "urn:ngsi-ld/dataset:1"
+    },
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld/dataset:2",
+      "datasetId": "urn:ngsi-ld/dataset:2"
+    }
+  ],
+  "rel2": [
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld/dataset:1",
+      "datasetId": "urn:ngsi-ld/dataset:1"
+    }
+  ],
+  "rel3": {
+    "type": "Relationship",
+    "object": "urn:no_dataset_id"
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "06. GET E2 with attr 'rel' - see 3 instances of 'rel'"
+echo "====================================================="
+orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:entities:E2?attrs=rel&prettyPrint=yes' --noPayloadCheck
+echo
+echo
+
+
+echo "07. GET E2 with attr 'rel2' - see 1 instance of 'rel2'"
+echo "======================================================"
+echo
+echo
+
+
+echo "08. GET E2 with attr 'rel3' - see 1 instance of 'rel3'"
+echo "======================================================"
 echo
 echo
 
 
 --REGEXPECT--
-01. Create an entity E1 with 4 attributes (name, name2, name3, and name4) with a mix of datasetIds
-==================================================================================================
+01. Create an entity E1 with 3 properties (prop, prop2, and prop3) with a mix of datasetIds
+===========================================================================================
 HTTP/1.1 201 Created
 Content-Length: 0
 Location: /ngsi-ld/v1/entities/urn:ngsi-ld:entities:E1
@@ -97,10 +172,10 @@ Date: REGEX(.*)
 
 
 
-02. GET E1 with attr 'name' - see 3 instances of 'name'
+02. GET E1 with attr 'prop' - see 3 instances of 'prop'
 =======================================================
 HTTP/1.1 200 OK
-Content-Length:
+Content-Length: 399
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -108,7 +183,7 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:entities:E1",
   "type": "T",
-  "name": [
+  "prop": [
     {
       "type": "Property",
       "value": "no dataset id"
@@ -126,6 +201,93 @@ Date: REGEX(.*)
   ]
 }
 
+
+
+03. GET E1 with attr 'prop2' - see 1 instance of 'prop2'
+=======================================================
+HTTP/1.1 200 OK
+Content-Length: 182
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+{
+  "id": "urn:ngsi-ld:entities:E1",
+  "type": "T",
+  "prop2": {
+    "type": "Property",
+    "value": "dataset urn:ngsi-ld/dataset:1",
+    "datasetId": "urn:ngsi-ld/dataset:1"
+  }
+}
+
+
+
+04. GET E1 with attr 'prop3' - see 1 instance of 'prop3'
+========================================================
+HTTP/1.1 200 OK
+Content-Length: 124
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+{
+  "id": "urn:ngsi-ld:entities:E1",
+  "type": "T",
+  "prop3": {
+    "type": "Property",
+    "value": "no dataset id"
+  }
+}
+
+
+
+05. Create an entity E2 with 3 relationships (rel, rel2, and rel3) with a mix of datasetIds
+===========================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:entities:E2
+Date: REGEX(.*)
+
+
+
+06. GET E2 with attr 'rel' - see 3 instances of 'rel'
+=====================================================
+HTTP/1.1 200 OK
+Content-Length: 401
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+{
+  "id": "urn:ngsi-ld:entities:E2",
+  "type": "T",
+  "rel": [
+    {
+      "type": "Relationship",
+      "object": "urn:no_dataset_id"
+    },
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld/dataset:1",
+      "datasetId": "urn:ngsi-ld/dataset:1"
+    },
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld/dataset:2",
+      "datasetId": "urn:ngsi-ld/dataset:2"
+    }
+  ]
+}
+
+
+
+07. GET E2 with attr 'rel2' - see 1 instance of 'rel2'
+======================================================
+
+
+08. GET E2 with attr 'rel3' - see 1 instance of 'rel3'
+======================================================
 
 
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_ngsild/ngsild_datasetId_entity_retrieval.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_datasetId_entity_retrieval.test
@@ -1,0 +1,133 @@
+# Copyright 2019 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Entity Creation
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Create an entity E1 with 4 attributes (name, name2, name3, and name4) with a mix of datasetIds
+# 02. GET E1 with attr 'name' - see 3 instances of 'name'
+# 03. GET E1 with attr 'name' and datasetId 'urn:ngsi-ld/dataset:1' - see just one instance of 'name'
+# 04. GET E1 with attr 'name' and datasetId 'urn:ngsi-ld/dataset:3' - see a 404 Not Found ?
+#
+
+echo "01. Create an entity E1 with 4 attributes (name, name2, name3, and name4) with a mix of datasetIds"
+echo "=================================================================================================="
+payload='{
+  "id": "urn:ngsi-ld:entities:E1",
+  "type": "T",
+  "name": [
+    {
+      "type": "Property",
+      "value": "no dataset id"
+    },
+    {
+      "type": "Property",
+      "value": "dataset urn:ngsi-ld/dataset:1",
+      "datasetId": "urn:ngsi-ld/dataset:1"
+    },
+    {
+      "type": "Property",
+      "value": "dataset urn:ngsi-ld/dataset:2",
+      "datasetId": "urn:ngsi-ld/dataset:2"
+    }
+  ],
+  "name2": [
+    {
+      "type": "Property",
+      "value": "dataset urn:ngsi-ld/dataset:1",
+      "datasetId": "urn:ngsi-ld/dataset:1"
+    }
+  ],
+  "name3": {
+    "type": "Property",
+    "value": "no dataset id"
+  },
+  "name4": {
+    "type": "Property",
+    "value": "dataset urn:ngsi-ld/dataset:1",
+    "datasetId": "urn:ngsi-ld/dataset:1"
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "02. GET E1 with attr 'name' - see 3 instances of 'name'"
+echo "======================================================="
+orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:entities:E1?attrs=name&prettyPrint=yes' --noPayloadCheck
+echo
+echo
+
+
+--REGEXPECT--
+01. Create an entity E1 with 4 attributes (name, name2, name3, and name4) with a mix of datasetIds
+==================================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:entities:E1
+Date: REGEX(.*)
+
+
+
+02. GET E1 with attr 'name' - see 3 instances of 'name'
+=======================================================
+HTTP/1.1 200 OK
+Content-Length:
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+{
+  "id": "urn:ngsi-ld:entities:E1",
+  "type": "T",
+  "name": [
+    {
+      "type": "Property",
+      "value": "no dataset id"
+    },
+    {
+      "type": "Property",
+      "value": "dataset urn:ngsi-ld/dataset:1",
+      "datasetId": "urn:ngsi-ld/dataset:1"
+    },
+    {
+      "type": "Property",
+      "value": "dataset urn:ngsi-ld/dataset:2",
+      "datasetId": "urn:ngsi-ld/dataset:2"
+    }
+  ]
+}
+
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/0000_ngsild/ngsild_datasetId_entity_retrieval.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_datasetId_entity_retrieval.test
@@ -21,7 +21,7 @@
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
 --NAME--
-Entity Creation
+Attributes with datasetId - entity retrieval without specific datasetId
 
 --SHELL-INIT--
 export BROKER=orionld
@@ -41,9 +41,9 @@ brokerStart CB
 # 07. GET E1 with attr 'rel2' - see 1 instance of 'rel2'
 # 08. GET E1 with attr 'rel3' - see 1 instance of 'rel3'
 #
-# With datasetId URI param
-# 09. GET E1 with attr 'prop' and datasetId 'urn:ngsi-ld/dataset:1' - see just one instance of 'prop'
-# 10. GET E1 with attr 'prop' and datasetId 'urn:ngsi-ld/dataset:3' - see a 404 Not Found ?
+# Key Values
+# 09. GET E1 with attr 'prop' and options=keyValues - see 'prop' as an array with three values
+# 10. GET E2 with attr 'rel' and options=keyValues - see 'rel' as an array with three values
 #
 
 echo "01. Create an entity E1 with 3 properties (prop, prop2, and prop3) with a mix of datasetIds"
@@ -158,6 +158,20 @@ echo
 
 echo "08. GET E2 with attr 'rel3' - see 1 instance of 'rel3'"
 echo "======================================================"
+echo
+echo
+
+
+echo "09. GET E1 with attr 'prop' and options=keyValues - see 'prop' as an array with three values"
+echo "============================================================================================"
+orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:entities:E1?attrs=prop&prettyPrint=yes&options=keyValues' --noPayloadCheck
+echo
+echo
+
+
+echo "10. GET E2 with attr 'rel' and options=keyValues - see 'rel' as an array with three values"
+echo "=========================================================================================="
+orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:entities:E2?attrs=rel&prettyPrint=yes&options=keyValues' --noPayloadCheck
 echo
 echo
 
@@ -288,6 +302,46 @@ Date: REGEX(.*)
 
 08. GET E2 with attr 'rel3' - see 1 instance of 'rel3'
 ======================================================
+
+
+09. GET E1 with attr 'prop' and options=keyValues - see 'prop' as an array with three values
+============================================================================================
+HTTP/1.1 200 OK
+Content-Length: 164
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+{
+  "id": "urn:ngsi-ld:entities:E1",
+  "type": "T",
+  "prop": [
+    "no dataset id",
+    "dataset urn:ngsi-ld/dataset:1",
+    "dataset urn:ngsi-ld/dataset:2"
+  ]
+}
+
+
+
+10. GET E2 with attr 'rel' and options=keyValues - see 'rel' as an array with three values
+==========================================================================================
+HTTP/1.1 200 OK
+Content-Length: 151
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+{
+  "id": "urn:ngsi-ld:entities:E2",
+  "type": "T",
+  "rel": [
+    "urn:no_dataset_id",
+    "urn:ngsi-ld/dataset:1",
+    "urn:ngsi-ld/dataset:2"
+  ]
+}
+
 
 
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation.test
@@ -318,13 +318,13 @@ Date: REGEX(.*)
 08. POST /ngsi-ld/v1/entities, with an attribute without a type - see error
 ===========================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 134
+Content-Length: 110
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "detail": "name",
-    "title": "Attribute found, but the type field is missing",
+    "title": "Attribute without type",
     "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
 }
 
@@ -332,13 +332,13 @@ Date: REGEX(.*)
 09. POST /ngsi-ld/v1/entities, with an attribute with type that is not a string - see error
 ===========================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 115
+Content-Length: 124
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "detail": "attribute type",
-    "title": "Not a JSON String",
+    "detail": "name",
+    "title": "Attribute type must be a JSON string",
     "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_property_property.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_property_property.test
@@ -136,11 +136,11 @@ Date: REGEX(.*)
   "P1": {
     "type": "Property",
     "value": 12,
+    "observedAt": "2018-12-04T12:00:00Z",
     "P1_P1": {
       "type": "Property",
       "value": 0.89
-    },
-    "observedAt": "2018-12-04T12:00:00Z"
+    }
   }
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_property_relationship.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_creation_one_property_relationship.test
@@ -136,11 +136,11 @@ Date: REGEX(.*)
   "P1": {
     "type": "Property",
     "value": 12,
+    "observedAt": "2018-12-04T12:00:00Z",
     "P1_R1": {
       "type": "Relationship",
       "object": "urn:ngsi-ld:T2:6789"
-    },
-    "observedAt": "2018-12-04T12:00:00Z"
+    }
   }
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_forward_patch_entity-attr.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_forward_patch_entity-attr.test
@@ -157,7 +157,7 @@ Date: REGEX(.*)
 05. GET the entity E1 from CP1 - see A1 changed
 ===============================================
 HTTP/1.1 200 OK
-Content-Length: 248
+Content-Length: 299
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0028.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0028.test
@@ -177,15 +177,15 @@ Date: REGEX(.*)
   "P1": {
     "type": "Property",
     "value": 12,
-    "P1_P1": {
-      "type": "Property",
-      "value": 0.79
-    },
+    "observedAt": "2018-12-04T12:00:00Z",
     "P1_R1": {
       "type": "Relationship",
       "object": "urn:ngsi-ld:T2:6789"
     },
-    "observedAt": "2018-12-04T12:00:00Z"
+    "P1_P1": {
+      "type": "Property",
+      "value": 0.79
+    }
   }
 }
 
@@ -241,8 +241,8 @@ Date: REGEX(.*)
   "id": "urn:ngsi-ld:T:00.00.00",
   "type": "T",
   "P1": {
-    "type": "Property",
-    "value": "Hola"
+    "value": "Hola",
+    "type": "Property"
   }
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0043.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0043.test
@@ -35,8 +35,6 @@ brokerStart CB 212-254
 # 02. Getting the entity to see that the forced timestamps 'createdAt' and 'modifiedAt' have been ignored
 #
 
-
-
 echo "01. POST /ngsi-ld/v1/entities with forced values of 'createdAt' and 'modifiedAt'"
 echo "================================================================================"
 payload='{
@@ -130,7 +128,7 @@ echo
 
 echo "02. Getting the entity to see that the forced timestamps 'createdAt' and 'modifiedAt' have been ignored"
 echo "======================================================================================================="
-orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:AgriCrop:df72dc57-1eb9-42a3-88a9-8647ecc954b4?options=sysAttrs&prettyPrint=yes' --noPayloadCheck -H 'Link: <https://raw.githubusercontent.com/GSMADeveloper/NGSI-LD-Entities/master/examples/Agri-Crop-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:AgriCrop:df72dc57-1eb9-42a3-88a9-8647ecc954b4?options=sysAttrs' -H 'Link: <https://raw.githubusercontent.com/GSMADeveloper/NGSI-LD-Entities/master/examples/Agri-Crop-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -148,116 +146,113 @@ Date: REGEX(.*)
 02. Getting the entity to see that the forced timestamps 'createdAt' and 'modifiedAt' have been ignored
 =======================================================================================================
 HTTP/1.1 200 OK
-Content-Length: 2777
+Content-Length: 2196
 Content-Type: application/json
 Link: <https://raw.githubusercontent.com/GSMADeveloper/NGSI-LD-Entities/master/examples/Agri-Crop-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
-#SORT_START
-  "id": "urn:ngsi-ld:AgriCrop:df72dc57-1eb9-42a3-88a9-8647ecc954b4",
-  "type": "AgriCrop",
-  "createdAt": "REGEX(20[1|2]\d-\d\d-\d\dT\d\d:\d\d:\d\dZ)",
-  "modifiedAt": "REGEX(20[1|2]\d-\d\d-\d\dT\d\d:\d\d:\d\dZ)"
-  "alternateName": {
-    "type": "Property",
-    "value": "Triticum aestivum",
-    "createdAt": "REGEX(.*)",
-    "modifiedAt": "REGEX(.*)"
-  },
-  "description": {
-    "type": "Property",
-    "value": "Spring wheat",
-    "createdAt": "REGEX(.*)",
-    "modifiedAt": "REGEX(.*)"
-  },
-  "name": {
-    "type": "Property",
-    "value": "Wheat",
-    "createdAt": "REGEX(.*)",
-    "modifiedAt": "REGEX(.*)"
-  },
-  "agroVocConcept": {
-    "type": "Property",
-    "value": "http://aims.fao.org/aos/agrovoc/c_7951",
-    "createdAt": "REGEX(.*)",
-    "modifiedAt": "REGEX(.*)"
-  },
-  "seeAlso": {
-    "type": "Property",
-    "value": [
-      "https://example.org/concept/wheat",
-      "https://datamodel.org/example/wheat"
-    ],
-    "createdAt": "REGEX(.*)",
-    "modifiedAt": "REGEX(.*)"
-  },
-  "agriFertiliser": {
-    "type": "Relationship",
-    "object": [
-      "urn:ngsi-ld:AgriFertiliser:1b0d6cf7-320c-4a2b-b2f1-4575ea850c73",
-      "urn:ngsi-ld:AgriFertiliser:380973c8-4d3b-4723-a899-0c0c5cc63e7e"
-    ],
-    "createdAt": "REGEX(.*)",
-    "modifiedAt": "REGEX(.*)"
-  },
-  "agriPest": {
-    "type": "Relationship",
-    "object": [
-      "urn:ngsi-ld:AgriPest:1b0d6cf7-320c-4a2b-b2f1-4575ea850c73",
-      "urn:ngsi-ld:AgriPest:380973c8-4d3b-4723-a899-0c0c5cc63e7e"
-    ],
-    "createdAt": "REGEX(.*)",
-    "modifiedAt": "REGEX(.*)"
-  },
-  "agriSoil": {
-    "type": "Relationship",
-    "object": [
-      "urn:ngsi-ld:AgriSoil:00411b56-bd1b-4551-96e0-a6e7fde9c840",
-      "urn:ngsi-ld:AgriSoil:e8a8389a-edf5-4345-8d2c-b98ac1ce8e2a"
-    ],
-    "createdAt": "REGEX(.*)",
-    "modifiedAt": "REGEX(.*)"
-  },
-  "harvestingInterval": {
-    "type": "Property",
-    "value": [
-      {
-        "dateRange": "-03-21/-04-01",
-        "description": "Best Season"
-      },
-      {
-        "dateRange": "-04-02/-04-15",
-        "description": "Season OK"
-      }
-    ],
-    "createdAt": "REGEX(.*)",
-    "modifiedAt": "REGEX(.*)"
-  },
-  "plantingFrom": {
-    "type": "Property",
-    "value": [
-      {
-        "dateRange": "-09-28/-10-12",
-        "description": "Best Season"
-      },
-      {
-        "dateRange": "-10-11/-10-18",
-        "description": "Season OK"
-      }
-    ],
-    "createdAt": "REGEX(.*)",
-    "modifiedAt": "REGEX(.*)"
-  },
-  "wateringFrequency": {
-    "type": "Property",
-    "value": "daily",
-    "createdAt": "REGEX(.*)",
-    "modifiedAt": "REGEX(.*)"
-  }
-#SORT_END
+    "agriFertiliser": {
+        "createdAt": "REGEX(.*)",
+        "modifiedAt": "REGEX(.*)",
+        "object": [
+            "urn:ngsi-ld:AgriFertiliser:1b0d6cf7-320c-4a2b-b2f1-4575ea850c73",
+            "urn:ngsi-ld:AgriFertiliser:380973c8-4d3b-4723-a899-0c0c5cc63e7e"
+        ],
+        "type": "Relationship"
+    },
+    "agriPest": {
+        "createdAt": "REGEX(.*)",
+        "modifiedAt": "REGEX(.*)",
+        "object": [
+            "urn:ngsi-ld:AgriPest:1b0d6cf7-320c-4a2b-b2f1-4575ea850c73",
+            "urn:ngsi-ld:AgriPest:380973c8-4d3b-4723-a899-0c0c5cc63e7e"
+        ],
+        "type": "Relationship"
+    },
+    "agriSoil": {
+        "createdAt": "REGEX(.*)",
+        "modifiedAt": "REGEX(.*)",
+        "object": [
+            "urn:ngsi-ld:AgriSoil:00411b56-bd1b-4551-96e0-a6e7fde9c840",
+            "urn:ngsi-ld:AgriSoil:e8a8389a-edf5-4345-8d2c-b98ac1ce8e2a"
+        ],
+        "type": "Relationship"
+    },
+    "agroVocConcept": {
+        "createdAt": "REGEX(.*)",
+        "modifiedAt": "REGEX(.*)",
+        "type": "Property",
+        "value": "http://aims.fao.org/aos/agrovoc/c_7951"
+    },
+    "alternateName": {
+        "createdAt": "REGEX(.*)",
+        "modifiedAt": "REGEX(.*)",
+        "type": "Property",
+        "value": "Triticum aestivum"
+    },
+    "createdAt": "REGEX(20[1|2]\d-\d\d-\d\dT\d\d:\d\d:\d\dZ)",
+    "description": {
+        "createdAt": "REGEX(.*)",
+        "modifiedAt": "REGEX(.*)",
+        "type": "Property",
+        "value": "Spring wheat"
+    },
+    "harvestingInterval": {
+        "createdAt": "REGEX(.*)",
+        "modifiedAt": "REGEX(.*)",
+        "type": "Property",
+        "value": [
+            {
+                "dateRange": "-03-21/-04-01",
+                "description": "Best Season"
+            },
+            {
+                "dateRange": "-04-02/-04-15",
+                "description": "Season OK"
+            }
+        ]
+    },
+    "id": "urn:ngsi-ld:AgriCrop:df72dc57-1eb9-42a3-88a9-8647ecc954b4",
+    "modifiedAt": "REGEX(20[1|2]\d-\d\d-\d\dT\d\d:\d\d:\d\dZ)"
+    "name": {
+        "createdAt": "REGEX(.*)",
+        "modifiedAt": "REGEX(.*)",
+        "type": "Property",
+        "value": "Wheat"
+    },
+    "plantingFrom": {
+        "createdAt": "REGEX(.*)",
+        "modifiedAt": "REGEX(.*)",
+        "type": "Property",
+        "value": [
+            {
+                "dateRange": "-09-28/-10-12",
+                "description": "Best Season"
+            },
+            {
+                "dateRange": "-10-11/-10-18",
+                "description": "Season OK"
+            }
+        ]
+    },
+    "seeAlso": {
+        "createdAt": "REGEX(.*)",
+        "modifiedAt": "REGEX(.*)",
+        "type": "Property",
+        "value": [
+            "https://example.org/concept/wheat",
+            "https://datamodel.org/example/wheat"
+        ]
+    },
+    "type": "AgriCrop",
+    "wateringFrequency": {
+        "createdAt": "REGEX(.*)",
+        "modifiedAt": "REGEX(.*)",
+        "type": "Property",
+        "value": "daily"
+    }
 }
-
 
 
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0131.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0131.test
@@ -164,6 +164,10 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:Building:store00221",
   "type": "https://uri.fiware.org/ns/data-models#Building",
+  "https://uri.fiware.org/ns/data-models#category": {
+    "type": "Property",
+    "value": "https://uri.fiware.org/ns/data-models#commercial"
+  },
   "https://schema.org/address": {
     "type": "Property",
     "value": {
@@ -172,14 +176,6 @@ Date: REGEX(.*)
       "addressLocality": "Prenzlauer Berg",
       "postalCode": "10439"
     }
-  },
-  "name": {
-    "type": "Property",
-    "value": "Bösebrücke Einkauf"
-  },
-  "https://uri.fiware.org/ns/data-models#category": {
-    "type": "Property",
-    "value": "https://uri.fiware.org/ns/data-models#commercial"
   },
   "location": {
     "type": "GeoProperty",
@@ -190,6 +186,10 @@ Date: REGEX(.*)
         52.5547
       ]
     }
+  },
+  "name": {
+    "type": "Property",
+    "value": "Bösebrücke Einkauf"
   }
 }
 
@@ -206,6 +206,10 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:Building:store00221",
   "type": "Building",
+  "category": {
+    "type": "Property",
+    "value": "commercial"
+  },
   "address": {
     "type": "Property",
     "value": {
@@ -214,14 +218,6 @@ Date: REGEX(.*)
       "addressLocality": "Prenzlauer Berg",
       "postalCode": "10439"
     }
-  },
-  "name": {
-    "type": "Property",
-    "value": "Bösebrücke Einkauf"
-  },
-  "category": {
-    "type": "Property",
-    "value": "commercial"
   },
   "location": {
     "type": "GeoProperty",
@@ -232,6 +228,10 @@ Date: REGEX(.*)
         52.5547
       ]
     }
+  },
+  "name": {
+    "type": "Property",
+    "value": "Bösebrücke Einkauf"
   }
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0364.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0364.test
@@ -229,11 +229,9 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:Building:E1",
   "type": "Building",
-  "furniture": {
-    "type": "Relationship",
-    "object": [
-      "urn:ngsi-ld:Shelf:unit009"
-    ]
+  "category": {
+    "type": "Property",
+    "value": "commercial"
   },
   "address": {
     "type": "Property",
@@ -248,14 +246,6 @@ Date: REGEX(.*)
       "value": false
     }
   },
-  "name": {
-    "type": "Property",
-    "value": "Tower Trodelmarkt"
-  },
-  "category": {
-    "type": "Property",
-    "value": "commercial"
-  },
   "location": {
     "type": "GeoProperty",
     "value": {
@@ -265,6 +255,16 @@ Date: REGEX(.*)
         52.5208
       ]
     }
+  },
+  "name": {
+    "type": "Property",
+    "value": "Tower Trodelmarkt"
+  },
+  "furniture": {
+    "type": "Relationship",
+    "object": [
+      "urn:ngsi-ld:Shelf:unit009"
+    ]
   }
 }
 
@@ -281,24 +281,24 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:Building:E1",
   "type": "Building",
-  "furniture": [
-    "urn:ngsi-ld:Shelf:unit009"
-  ],
+  "category": "commercial",
   "address": {
     "streetAddress": "Panoramastrasse 1A",
     "addressRegion": "Berlin",
     "addressLocality": "Mitte",
     "postalCode": "10178"
   },
-  "name": "Tower Trodelmarkt",
-  "category": "commercial",
   "location": {
     "type": "Point",
     "coordinates": [
       13.4094,
       52.5208
     ]
-  }
+  },
+  "name": "Tower Trodelmarkt",
+  "furniture": [
+    "urn:ngsi-ld:Shelf:unit009"
+  ]
 }
 
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_modify_attr.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_modify_attr.test
@@ -139,8 +139,8 @@ Date: REGEX(.*)
   "id": "urn:ngsi-ld:T:2018-11-22T10:00:00",
   "type": "T",
   "P1": {
-    "type": "Property",
-    "value": 2
+    "value": 2,
+    "type": "Property"
   }
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_modify_some_attrs_others_stay_intact.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_modify_some_attrs_others_stay_intact.test
@@ -246,10 +246,6 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:T:2018-11-22T10:00:00",
   "type": "T",
-  "P1": {
-    "type": "Property",
-    "value": 2
-  },
   "P2": {
     "type": "Property",
     "value": 2
@@ -267,6 +263,10 @@ Date: REGEX(.*)
     "value": {
       "name": "P5"
     }
+  },
+  "P1": {
+    "value": 2,
+    "type": "Property"
   }
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_patch_entity_attr.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_patch_entity_attr.test
@@ -166,8 +166,8 @@ Date: REGEX(.*)
   "id": "urn:ngsi-ld:entity:E1",
   "type": "http://example.org/T",
   "http://a.b.c/A1": {
-    "type": "Property",
-    "value": "30"
+    "value": "30",
+    "type": "Property"
   },
   "http://a.b.c/A2": {
     "type": "Property",
@@ -206,8 +206,8 @@ Date: REGEX(.*)
   "id": "urn:ngsi-ld:entity:E2",
   "type": "http://example.org/T",
   "http://a.b.c/A3": {
-    "type": "Relationship",
-    "object": "urn:ngsi-ld:entity:E3"
+    "object": "urn:ngsi-ld:entity:E3",
+    "type": "Relationship"
   }
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_test-suite--RE-should-retrieve-entity-LD-requested.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_test-suite--RE-should-retrieve-entity-LD-requested.test
@@ -103,26 +103,26 @@ Date: REGEX(.*)
   "P1": {
     "type": "Property",
     "value": 12,
-    "P1_P1": {
-      "type": "Property",
-      "value": 0.79
-    },
+    "observedAt": "2018-12-04T12:00:00Z",
     "P1_R1": {
       "type": "Relationship",
       "object": "urn:ngsi-ld:T2:6789"
     },
-    "observedAt": "2018-12-04T12:00:00Z"
+    "P1_P1": {
+      "type": "Property",
+      "value": 0.79
+    }
   },
   "R1": {
     "type": "Relationship",
     "object": "urn:ngsi-ld:T2:6789",
-    "R1_P1": {
-      "type": "Property",
-      "value": false
-    },
     "R1_R1": {
       "type": "Relationship",
       "object": "urn:ngsi-ld:T3:A2345"
+    },
+    "R1_P1": {
+      "type": "Property",
+      "value": false
     }
   }
 }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_tests_01.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_tests_01.test
@@ -149,15 +149,15 @@ Date: REGEX(.*)
   "P1": {
     "type": "Property",
     "value": 12,
-    "P1_P1": {
-      "type": "Property",
-      "value": 0.79
-    },
+    "observedAt": "2018-12-04T12:00:00Z",
     "P1_R1": {
       "type": "Relationship",
       "object": "urn:ngsi-ld:T2:6789"
     },
-    "observedAt": "2018-12-04T12:00:00Z"
+    "P1_P1": {
+      "type": "Property",
+      "value": 0.79
+    }
   }
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_updated_relationship_with_metadata.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_updated_relationship_with_metadata.test
@@ -186,18 +186,6 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:Shelf:unit001",
   "type": "https://fiware.github.io/tutorials.Step-by-Step/schema/Shelf",
-  "https://fiware.github.io/tutorials.Step-by-Step/schema/maxCapacity": {
-    "type": "Property",
-    "value": 50
-  },
-  "https://fiware.github.io/tutorials.Step-by-Step/schema/stocks": {
-    "type": "Relationship",
-    "object": "urn:ngsi-ld:Product:001"
-  },
-  "name": {
-    "type": "Property",
-    "value": "Corner Unit"
-  },
   "location": {
     "type": "GeoProperty",
     "value": {
@@ -207,6 +195,18 @@ Date: REGEX(.*)
         52.554699
       ]
     }
+  },
+  "https://fiware.github.io/tutorials.Step-by-Step/schema/maxCapacity": {
+    "type": "Property",
+    "value": 50
+  },
+  "name": {
+    "type": "Property",
+    "value": "Corner Unit"
+  },
+  "https://fiware.github.io/tutorials.Step-by-Step/schema/stocks": {
+    "type": "Relationship",
+    "object": "urn:ngsi-ld:Product:001"
   }
 }
 
@@ -231,30 +231,6 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:Shelf:unit001",
   "type": "https://fiware.github.io/tutorials.Step-by-Step/schema/Shelf",
-  "https://fiware.github.io/tutorials.Step-by-Step/schema/locatedIn": {
-    "type": "Relationship",
-    "object": "urn:ngsi-ld:Building:store001",
-    "https://fiware.github.io/tutorials.Step-by-Step/schema/installedBy": {
-      "type": "Relationship",
-      "object": "urn:ngsi-ld:Person:employee001"
-    },
-    "https://fiware.github.io/tutorials.Step-by-Step/schema/statusOfWork": {
-      "type": "Property",
-      "value": "https://fiware.github.io/tutorials.Step-by-Step/schema/completed"
-    }
-  },
-  "https://fiware.github.io/tutorials.Step-by-Step/schema/maxCapacity": {
-    "type": "Property",
-    "value": 50
-  },
-  "https://fiware.github.io/tutorials.Step-by-Step/schema/stocks": {
-    "type": "Relationship",
-    "object": "urn:ngsi-ld:Product:001"
-  },
-  "name": {
-    "type": "Property",
-    "value": "Corner Unit"
-  },
   "location": {
     "type": "GeoProperty",
     "value": {
@@ -263,6 +239,30 @@ Date: REGEX(.*)
         13.398611,
         52.554699
       ]
+    }
+  },
+  "https://fiware.github.io/tutorials.Step-by-Step/schema/maxCapacity": {
+    "type": "Property",
+    "value": 50
+  },
+  "name": {
+    "type": "Property",
+    "value": "Corner Unit"
+  },
+  "https://fiware.github.io/tutorials.Step-by-Step/schema/stocks": {
+    "type": "Relationship",
+    "object": "urn:ngsi-ld:Product:001"
+  },
+  "https://fiware.github.io/tutorials.Step-by-Step/schema/locatedIn": {
+    "object": "urn:ngsi-ld:Building:store001",
+    "type": "Relationship",
+    "https://fiware.github.io/tutorials.Step-by-Step/schema/installedBy": {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:Person:employee001"
+    },
+    "https://fiware.github.io/tutorials.Step-by-Step/schema/statusOfWork": {
+      "type": "Property",
+      "value": "https://fiware.github.io/tutorials.Step-by-Step/schema/completed"
     }
   }
 }
@@ -288,22 +288,6 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:Shelf:unit001",
   "type": "https://fiware.github.io/tutorials.Step-by-Step/schema/Shelf",
-  "https://fiware.github.io/tutorials.Step-by-Step/schema/locatedIn": {
-    "type": "Relationship",
-    "object": "urn:ngsi-ld:Building:store002"
-  },
-  "https://fiware.github.io/tutorials.Step-by-Step/schema/maxCapacity": {
-    "type": "Property",
-    "value": 50
-  },
-  "https://fiware.github.io/tutorials.Step-by-Step/schema/stocks": {
-    "type": "Relationship",
-    "object": "urn:ngsi-ld:Product:001"
-  },
-  "name": {
-    "type": "Property",
-    "value": "Corner Unit"
-  },
   "location": {
     "type": "GeoProperty",
     "value": {
@@ -313,6 +297,22 @@ Date: REGEX(.*)
         52.554699
       ]
     }
+  },
+  "https://fiware.github.io/tutorials.Step-by-Step/schema/maxCapacity": {
+    "type": "Property",
+    "value": 50
+  },
+  "name": {
+    "type": "Property",
+    "value": "Corner Unit"
+  },
+  "https://fiware.github.io/tutorials.Step-by-Step/schema/stocks": {
+    "type": "Relationship",
+    "object": "urn:ngsi-ld:Product:001"
+  },
+  "https://fiware.github.io/tutorials.Step-by-Step/schema/locatedIn": {
+    "object": "urn:ngsi-ld:Building:store002",
+    "type": "Relationship"
   }
 }
 
@@ -337,26 +337,6 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:Shelf:unit001",
   "type": "https://fiware.github.io/tutorials.Step-by-Step/schema/Shelf",
-  "https://fiware.github.io/tutorials.Step-by-Step/schema/locatedIn": {
-    "type": "Relationship",
-    "object": "urn:ngsi-ld:Building:store002",
-    "xtraMdata": {
-      "type": "Property",
-      "value": "urn:ngsi-ld:Building:store005"
-    }
-  },
-  "https://fiware.github.io/tutorials.Step-by-Step/schema/maxCapacity": {
-    "type": "Property",
-    "value": 50
-  },
-  "https://fiware.github.io/tutorials.Step-by-Step/schema/stocks": {
-    "type": "Relationship",
-    "object": "urn:ngsi-ld:Product:001"
-  },
-  "name": {
-    "type": "Property",
-    "value": "Corner Unit"
-  },
   "location": {
     "type": "GeoProperty",
     "value": {
@@ -365,6 +345,26 @@ Date: REGEX(.*)
         13.398611,
         52.554699
       ]
+    }
+  },
+  "https://fiware.github.io/tutorials.Step-by-Step/schema/maxCapacity": {
+    "type": "Property",
+    "value": 50
+  },
+  "name": {
+    "type": "Property",
+    "value": "Corner Unit"
+  },
+  "https://fiware.github.io/tutorials.Step-by-Step/schema/stocks": {
+    "type": "Relationship",
+    "object": "urn:ngsi-ld:Product:001"
+  },
+  "https://fiware.github.io/tutorials.Step-by-Step/schema/locatedIn": {
+    "object": "urn:ngsi-ld:Building:store002",
+    "type": "Relationship",
+    "xtraMdata": {
+      "type": "Property",
+      "value": "urn:ngsi-ld:Building:store005"
     }
   }
 }
@@ -382,26 +382,6 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:Shelf:unit001",
   "type": "Shelf",
-  "locatedIn": {
-    "type": "Relationship",
-    "object": "urn:ngsi-ld:Building:store002",
-    "xtraMdata": {
-      "type": "Property",
-      "value": "urn:ngsi-ld:Building:store005"
-    }
-  },
-  "maxCapacity": {
-    "type": "Property",
-    "value": 50
-  },
-  "stocks": {
-    "type": "Relationship",
-    "object": "urn:ngsi-ld:Product:001"
-  },
-  "name": {
-    "type": "Property",
-    "value": "Corner Unit"
-  },
   "location": {
     "type": "GeoProperty",
     "value": {
@@ -410,6 +390,26 @@ Date: REGEX(.*)
         13.398611,
         52.554699
       ]
+    }
+  },
+  "maxCapacity": {
+    "type": "Property",
+    "value": 50
+  },
+  "name": {
+    "type": "Property",
+    "value": "Corner Unit"
+  },
+  "stocks": {
+    "type": "Relationship",
+    "object": "urn:ngsi-ld:Product:001"
+  },
+  "locatedIn": {
+    "object": "urn:ngsi-ld:Building:store002",
+    "type": "Relationship",
+    "xtraMdata": {
+      "type": "Property",
+      "value": "urn:ngsi-ld:Building:store005"
     }
   }
 }

--- a/test/valgrind/valgrindTestSuite.sh
+++ b/test/valgrind/valgrindTestSuite.sh
@@ -198,6 +198,7 @@ do
   elif [ "$1" == "-v" ];        then verbose=on;
   elif [ "$1" == "-leakTest" ]; then leakTest=on;
   elif [ "$1" == "-filter" ];   then TEST_FILTER=$2; shift;
+  elif [ "$1" == "-ld" ];       then TEST_FILTER="ngsild*.test";
   elif [ "$1" == "-dryrun" ];   then dryrun=on;
   elif [ "$1" == "-dryLeaks" ]; then dryLeaks=on;
   elif [ "$1" == "-fromIx" ];   then  shift; fromIx=$1;


### PR DESCRIPTION
* No longer using WARN for LM_TMP messages
* Fixed all memory leaks
* Fixed all errors reported by valgrind
* Support for datasetId in creation of entities
* Support for datasetId in retrieval of entities
* New DB implementation for Entity Retrieval (no longer depends on mongoBackend)
