### PR TITLE
task/batch-creupsert-entity-duplication

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
 * Issue #XXX  Better error handling for geo location
 * Issue #XXX  Version Info printed to stdout (and log-file) at startup
 * Issue #XXX  Fixed the "1001 bug" - a delayed free problem solved by making kjClone() not use always malloc, with an option to use KAlloc
+* Issue #280  Avoiding duplicates of entities in Batch Upsert

--- a/src/lib/orionld/kjTree/CMakeLists.txt
+++ b/src/lib/orionld/kjTree/CMakeLists.txt
@@ -37,6 +37,7 @@ SET (SOURCES
     kjTreeToTimeInterval.cpp
     kjTreeToGeoLocation.cpp
     kjStringValueLookupInArray.cpp
+    kjEntityIdLookupInEntityArray.cpp
     kjTreeToUpdateContextRequest.cpp
     kjTreeToEntity.cpp
     kjTreeToMetadata.cpp

--- a/src/lib/orionld/kjTree/kjEntityIdLookupInEntityArray.cpp
+++ b/src/lib/orionld/kjTree/kjEntityIdLookupInEntityArray.cpp
@@ -1,6 +1,3 @@
-#ifndef SRC_LIB_ORIONLD_KJTREE_KJSTRINGVALUELOOKUPINARRAY_H_
-#define SRC_LIB_ORIONLD_KJTREE_KJSTRINGVALUELOOKUPINARRAY_H_
-
 /*
 *
 * Copyright 2019 FIWARE Foundation e.V.
@@ -25,21 +22,44 @@
 *
 * Author: Ken Zangelin
 */
+#include <string.h>                                                        // strcmp
+
 extern "C"
 {
 #include "kjson/KjNode.h"                                                  // KjNode
+#include "kjson/kjLookup.h"                                                // kjLookup
 }
+
+#include "orionld/kjTree/kjEntityIdLookupInEntityArray.h"                  // Own interface
 
 
 
 // ----------------------------------------------------------------------------
 //
-// kjStringValueLookupInArray -
+// kjEntityIdLookupInEntityArray -
 //
 // NOTE
-//   This lookup function works on string items in an array.
-//   The caller needs to be sure that the 'stringArrayNodeP' is really an array and that ALL its items are Strings
+//   This lookup function works for Entity Arrays (batch operations)
+//   For each item in the array, a field called "id" is looked up and compared to 'value'
 //
-extern KjNode* kjStringValueLookupInArray(KjNode* stringArrayNodeP, const char* value);
+KjNode* kjEntityIdLookupInEntityArray(KjNode* entityArrayP, const char* value)
+{
+  if (entityArrayP == NULL)
+    return NULL;
 
-#endif  // SRC_LIB_ORIONLD_KJTREE_KJSTRINGVALUELOOKUPINARRAY_H_
+  if (entityArrayP->type != KjArray)
+    return NULL;
+
+  for (KjNode* entityP = entityArrayP->value.firstChildP; entityP != NULL; entityP = entityP->next)
+  {
+    if (entityP->type != KjObject)
+      continue;
+
+    KjNode* idP = kjLookup(entityP, "id");
+
+    if ((idP != NULL) && (strcmp(value, idP->value.s) == 0))
+      return entityP;
+  }
+
+  return NULL;
+}

--- a/src/lib/orionld/kjTree/kjEntityIdLookupInEntityArray.h
+++ b/src/lib/orionld/kjTree/kjEntityIdLookupInEntityArray.h
@@ -1,5 +1,5 @@
-#ifndef SRC_LIB_ORIONLD_KJTREE_KJSTRINGVALUELOOKUPINARRAY_H_
-#define SRC_LIB_ORIONLD_KJTREE_KJSTRINGVALUELOOKUPINARRAY_H_
+#ifndef SRC_LIB_ORIONLD_KJTREE_KJENTITYIDLOOKUPINENTITYARRAY_H_
+#define SRC_LIB_ORIONLD_KJTREE_KJENTITYIDLOOKUPINENTITYARRAY_H_
 
 /*
 *
@@ -34,12 +34,12 @@ extern "C"
 
 // ----------------------------------------------------------------------------
 //
-// kjStringValueLookupInArray -
+// kjEntityIdLookupInEntityArray -
 //
 // NOTE
-//   This lookup function works on string items in an array.
-//   The caller needs to be sure that the 'stringArrayNodeP' is really an array and that ALL its items are Strings
+//   This lookup function works for Entity Arrays (batch operations)
+//   For each item in the array, a field called "id" is looked up and compared to 'value'
 //
-extern KjNode* kjStringValueLookupInArray(KjNode* stringArrayNodeP, const char* value);
+extern KjNode* kjEntityIdLookupInEntityArray(KjNode* entityArrayP, const char* value);
 
-#endif  // SRC_LIB_ORIONLD_KJTREE_KJSTRINGVALUELOOKUPINARRAY_H_
+#endif  // SRC_LIB_ORIONLD_KJTREE_KJENTITYIDLOOKUPINENTITYARRAY_H_

--- a/test/functionalTest/cases/0000_ngsild/ngsild_batch_update-attempt_to_change_entity_type.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_batch_update-attempt_to_change_entity_type.test
@@ -134,7 +134,6 @@ Date: REGEX(.*)
 HTTP/1.1 207 Multi Status
 Content-Length: 179
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert-context_in_payload_data.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert-context_in_payload_data.test
@@ -157,7 +157,6 @@ echo
 HTTP/1.1 207 Multi Status
 Content-Length: 261
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -181,7 +180,6 @@ Date: REGEX(.*)
 HTTP/1.1 207 Multi Status
 Content-Length: 249
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert-duplicate-entities-in-array.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert-duplicate-entities-in-array.test
@@ -1,0 +1,172 @@
+# Copyright 2019 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Batch Upsert with duplicated entities in the array of entities
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Create entities E1-E5 using Batch Upsert, but two copies of E4
+# 02. GET the entities
+#
+
+
+echo "01. Create entities E1-E5 using Batch Upsert, but two copies of E4"
+echo "=================================================================="
+payload='[
+  {
+    "id": "urn:ngsi-ld:entity:E1",
+    "type": "Vehicle",
+    "P1": {
+      "type": "Property",
+      "value": "Step 1"
+    }
+  },
+  {
+    "id": "urn:ngsi-ld:entity:E2",
+    "type": "Vehicle",
+    "P1": {
+      "type": "Property",
+      "value": "Step 1"
+    }
+  },
+  {
+    "id": "urn:ngsi-ld:entity:E3",
+    "type": "Vehicle",
+    "P1": {
+      "type": "Property",
+      "value": "Step 1"
+    }
+  },
+  {
+    "id": "urn:ngsi-ld:entity:E4",
+    "type": "Vehicle",
+    "P1": {
+      "type": "Property",
+      "value": "Step 1 - first copy"
+    }
+  },
+  {
+    "id": "urn:ngsi-ld:entity:E5",
+    "type": "Vehicle",
+    "P1": {
+      "type": "Property",
+      "value": "Step 1"
+    }
+  },
+  {
+    "id": "urn:ngsi-ld:entity:E4",
+    "type": "Vehicle",
+    "P1": {
+      "type": "Property",
+      "value": "Step 1 - second copy"
+    }
+  }
+]'
+orionCurl --url "/ngsi-ld/v1/entityOperations/upsert?options=update" -X POST --payload "$payload"
+echo
+echo
+
+
+echo "02. GET the entities"
+echo "===================="
+orionCurl --url '/ngsi-ld/v1/entities?type=Vehicle&options=keyValues'
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entities E1-E5 using Batch Upsert, but two copies of E4
+==================================================================
+HTTP/1.1 207 Multi Status
+Content-Length: 329
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "errors": [
+        {
+            "entityId": "urn:ngsi-ld:entity:E4",
+            "error": {
+                "detail": "previous instance removed",
+                "status": 400,
+                "title": "Duplicated Entity",
+                "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+            }
+        }
+    ],
+    "success": [
+        "urn:ngsi-ld:entity:E1",
+        "urn:ngsi-ld:entity:E2",
+        "urn:ngsi-ld:entity:E3",
+        "urn:ngsi-ld:entity:E5",
+        "urn:ngsi-ld:entity:E4"
+    ]
+}
+
+
+02. GET the entities
+====================
+HTTP/1.1 200 OK
+Content-Length: 325
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+[
+    {
+        "P1": "Step 1",
+        "id": "urn:ngsi-ld:entity:E1",
+        "type": "Vehicle"
+    },
+    {
+        "P1": "Step 1",
+        "id": "urn:ngsi-ld:entity:E2",
+        "type": "Vehicle"
+    },
+    {
+        "P1": "Step 1",
+        "id": "urn:ngsi-ld:entity:E3",
+        "type": "Vehicle"
+    },
+    {
+        "P1": "Step 1",
+        "id": "urn:ngsi-ld:entity:E5",
+        "type": "Vehicle"
+    },
+    {
+        "P1": "Step 1 - second copy",
+        "id": "urn:ngsi-ld:entity:E4",
+        "type": "Vehicle"
+    }
+]
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert-options=replace_payload_error_type_field.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert-options=replace_payload_error_type_field.test
@@ -204,7 +204,6 @@ Date: REGEX(.*)
 HTTP/1.1 207 Multi Status
 Content-Length: 289
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert-options=replace_payload_error_validation.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert-options=replace_payload_error_validation.test
@@ -303,7 +303,6 @@ echo
 HTTP/1.1 207 Multi Status
 Content-Length: 223
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -329,7 +328,6 @@ Date: REGEX(.*)
 HTTP/1.1 207 Multi Status
 Content-Length: 218
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -355,7 +353,6 @@ Date: REGEX(.*)
 HTTP/1.1 207 Multi Status
 Content-Length: 201
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -381,7 +378,6 @@ Date: REGEX(.*)
 HTTP/1.1 207 Multi Status
 Content-Length: 230
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -407,7 +403,6 @@ Date: REGEX(.*)
 HTTP/1.1 207 Multi Status
 Content-Length: 230
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -433,7 +428,6 @@ Date: REGEX(.*)
 HTTP/1.1 207 Multi Status
 Content-Length: 223
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -459,7 +453,6 @@ Date: REGEX(.*)
 HTTP/1.1 207 Multi Status
 Content-Length: 223
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert-options=update_error_handling.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert-options=update_error_handling.test
@@ -450,7 +450,6 @@ echo
 HTTP/1.1 207 Multi Status
 Content-Length: 223
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -476,7 +475,6 @@ Date: REGEX(.*)
 HTTP/1.1 207 Multi Status
 Content-Length: 218
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -502,7 +500,6 @@ Date: REGEX(.*)
 HTTP/1.1 207 Multi Status
 Content-Length: 201
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -528,7 +525,6 @@ Date: REGEX(.*)
 HTTP/1.1 207 Multi Status
 Content-Length: 230
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -554,7 +550,6 @@ Date: REGEX(.*)
 HTTP/1.1 207 Multi Status
 Content-Length: 403
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -587,7 +582,6 @@ Date: REGEX(.*)
 HTTP/1.1 207 Multi Status
 Content-Length: 223
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {
@@ -613,7 +607,6 @@ Date: REGEX(.*)
 HTTP/1.1 207 Multi Status
 Content-Length: 223
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {


### PR DESCRIPTION
Avoiding duplicates of entities in Batch Upsert.

If duplicated entities (same entity-id) are found in the array of the incoming payload data for BATCH Upsert, only the last entry is kept.
The preceding ones are discarded.

In the future, we need to add those discarded entities to the temporal database.