### PR TITLE
bug/patch-and-subscription-update-and-crash

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,4 +2,5 @@
 * Issue #XXX  Version Info printed to stdout (and log-file) at startup
 * Issue #XXX  Fixed the "1001 bug" - a delayed free problem solved by making kjClone() not use always malloc, with an option to use KAlloc
 * Issue #280  Avoiding duplicates of entities in Batch Upsert
-* Issue #280 All env vars are now prefixed ORIONLD_
+* Issue #280  All env vars are now prefixed ORIONLD_
+* Issue #XXX  Crash when patching observedAt as sub-attribute

--- a/src/lib/orionld/payloadCheck/pcheckEntity.cpp
+++ b/src/lib/orionld/payloadCheck/pcheckEntity.cpp
@@ -172,7 +172,7 @@ bool pcheckEntity
       {
         if (pcheckName(kNodeP->name, &detailsP) == false)
         {
-          orionldErrorResponseCreate(OrionldBadRequestData, "Invalid Property/Relationship name", detailsP);
+          orionldErrorResponseCreate(OrionldBadRequestData, "Invalid Property/Relationship name", kNodeP->name);
           return false;
         }
       }

--- a/test/functionalTest/harnessFunctions.sh
+++ b/test/functionalTest/harnessFunctions.sh
@@ -393,8 +393,18 @@ function localBrokerStart()
   # 
   # [ A *number* of old leaks were discovered when this modification was made. ]
   #
-  if [ "$VALGRIND" == "" ] || [ "$port" != "$CB_PORT" ]; then
+  if [ "$VALGRIND" == "" ] || [ "$port" != "$CB_PORT" ]
+  then
+    if [ "$verbose" == "on" ]
+    then
+      echo Starting broker: $CB_START_CMD
+    fi
     $CB_START_CMD
+    brokerPid=$!
+    if [ "$verbose" == "on" ]
+    then
+      echo Broker PID: $brokerPid
+    fi
   else
     #
     # Important: the -v flag must be present so that the text "X errors in context Y of Z" is present in the output
@@ -408,6 +418,11 @@ function localBrokerStart()
   then
     echo "Unable to start $BROKER as $role"
     exit 1
+  else
+    if [ "$verbose" == "on" ]
+    then
+      echo "$BROKER is running as $role"
+    fi
   fi
 
   # Test to see whether we have a broker running on $port. If not raise an error


### PR DESCRIPTION
Fixed a crash about obtaining an entity that has been patched with `observedAt` as sub-attribute