### PR TITLE
Task/duplicate notifs

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -4,3 +4,4 @@
 * Issue #280  Avoiding duplicates of entities in Batch Upsert
 * Issue #280  All env vars are now prefixed ORIONLD_
 * Issue #XXX  Crash when patching observedAt as sub-attribute
+* Issue #XXX  Subscriptions when deleted were not removed from the subscription cache - now they are

--- a/docker/build-debian.sh
+++ b/docker/build-debian.sh
@@ -199,11 +199,11 @@ fi
 
 if [[ ${STAGE} == 'release' ]]; then
 
-    echo "Debian Builder: installing orion"
+    echo "Debian Builder: compiling and installing orion as a DEBUGGABLE executable"
     git clone ${REPOSITORY} ${PATH_TO_SRC}
     cd ${PATH_TO_SRC}
     git checkout ${REV}
-    make install
+    make debug install
     strip /usr/bin/${BROKER}
 
     BOOST_VER=$(apt-cache policy libboost-all-dev | grep Installed | awk '{ print $2 }' | cut -c -6)

--- a/src/lib/cache/subCache.cpp
+++ b/src/lib/cache/subCache.cpp
@@ -947,6 +947,7 @@ void subCacheStatisticsReset(const char* by)
 }
 
 
+
 /* ****************************************************************************
 *
 * subCacheItemRemove -

--- a/src/lib/orionld/serviceRoutines/orionldDeleteSubscription.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldDeleteSubscription.cpp
@@ -26,6 +26,8 @@
 #include "logMsg/traceLevels.h"                                  // Lmt*
 
 #include "rest/ConnectionInfo.h"                                 // ConnectionInfo
+#include "common/globals.h"                                      // noCache
+#include "cache/subCache.h"                                      // CachedSubscription, subCacheItemLookup, ...
 #include "orionld/common/orionldState.h"                         // orionldState
 #include "orionld/common/urlCheck.h"                             // urlCheck
 #include "orionld/common/urnCheck.h"                             // urnCheck
@@ -65,6 +67,15 @@ bool orionldDeleteSubscription(ConnectionInfo* ciP)
     orionldState.httpStatusCode = SccNotFound;
     orionldErrorResponseCreate(OrionldBadRequestData, "The requested subscription has not been found - check its id", orionldState.wildcard[0]);
     return false;
+  }
+
+  if (noCache == false)
+  {
+    CachedSubscription* cSubP = subCacheItemLookup(orionldState.tenant, orionldState.wildcard[0]);
+    if (cSubP != NULL)
+      subCacheItemRemove(cSubP);
+    else
+      LM_W(("The subscription '%s' was successfully removed from DB but does not exist in sub-cache ... (sub-cache is enabled)"));
   }
 
   orionldState.httpStatusCode = SccNoContent;

--- a/src/lib/orionld/serviceRoutines/orionldGetVersion.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetVersion.cpp
@@ -47,6 +47,7 @@ extern "C"
 
 #include "rest/ConnectionInfo.h"                               // ConnectionInfo
 #include "serviceRoutines/versionTreat.h"                      // versionGet
+#include "cache/subCache.h"                                    // subCacheItems
 #include "orionld/common/orionldState.h"                       // orionldState, orionldVersion
 #include "orionld/common/branchName.h"                         // ORIONLD_BRANCH
 #include "orionld/serviceRoutines/orionldGetVersion.h"         // Own Interface
@@ -134,6 +135,10 @@ bool orionldGetVersion(ConnectionInfo* ciP)
 
   // Branch
   nodeP = kjString(orionldState.kjsonP, "branch", ORIONLD_BRANCH);
+  kjChildAdd(orionldState.responseTree, nodeP);
+
+  // Number of item in the subscription cache
+  nodeP = kjInteger(orionldState.kjsonP, "cached subscriptions", subCacheItems());
   kjChildAdd(orionldState.responseTree, nodeP);
 
   //

--- a/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert_crash_with_and_without_link_header.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert_crash_with_and_without_link_header.test
@@ -180,6 +180,7 @@ Date: REGEX(.*)
     "based on orion": "REGEX(.*)",
     "boost version": "REGEX(.*)",
     "branch": "REGEX(.*)",
+    "cached subscriptions": 0,
     "kalloc version": "REGEX(.*)",
     "kbase version": "REGEX(.*)",
     "khash version": "REGEX(.*)",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0065.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0065.test
@@ -81,6 +81,7 @@ Date: REGEX(.*)
     "based on orion": "REGEX(.*)",
     "boost version": "REGEX(.*)",
     "branch": "REGEX(.*)",
+    "cached subscriptions": 0,
     "kalloc version": "REGEX(.*)",
     "kbase version": "REGEX(.*)",
     "khash version": "REGEX(.*)",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_delete.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_delete.test
@@ -37,8 +37,8 @@ brokerStart CB 0-255
 # 04. Delete subscription 'http://a.b.c/subs/sub01'
 # 05. GET subscription 'http://a.b.c/subs/sub01' and see that it is gone
 # 06. See no subscription in mongo
+# 07. GET version to see that there is ZERO subs in the subscription cache
 #
-
 
 echo "01. Create subscription 'http://a.b.c/subs/sub01'"
 echo "================================================="
@@ -127,6 +127,13 @@ echo
 echo "06. See no subscription in mongo"
 echo "================================"
 mongoCmd2 ftest "db.csubs.findOne()"
+echo
+echo
+
+
+echo "07. GET version to see that there is ZERO subs in the subscription cache"
+echo "========================================================================"
+orionCurl --url '/ngsi-ld/ex/v1/version?prettyPrint=yes' --noPayloadCheck
 echo
 echo
 
@@ -291,6 +298,34 @@ connecting to: mongodb:REGEX(.*)
 MongoDB server version: REGEX(.*)
 null
 bye
+
+
+07. GET version to see that there is ZERO subs in the subscription cache
+========================================================================
+HTTP/1.1 200 OK
+Content-Length: REGEX(.*)
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+  "Orion-LD version": REGEX(.*),
+  "based on orion": REGEX(.*),
+  "kbase version": REGEX(.*),
+  "kalloc version": REGEX(.*),
+  "khash version": REGEX(.*),
+  "kjson version": REGEX(.*),
+  "boost version": REGEX(.*),
+  "microhttpd version": REGEX(.*),
+  "openssl version": REGEX(.*),
+  "mongo version": REGEX(.*),
+  "rapidjson version": REGEX(.*),
+  "libcurl version": REGEX(.*),
+  "libuuid version": REGEX(.*),
+  "branch": REGEX(.*),
+  "cached subscriptions": 0,
+  "Next File Descriptor": REGEX(.*)
+}
+
 
 
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_ngsild/ngsild_version.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_version.test
@@ -81,6 +81,7 @@ Date: REGEX(.*)
   "libcurl version": "REGEX(.*)",
   "libuuid version": "UNKNOWN",
   "branch": "REGEX(.*)",
+  "cached subscriptions": 0,
   "Next File Descriptor": REGEX(\d+)
 }
 


### PR DESCRIPTION
Bug Fix:
Subscriptions stayed in the Subscription Cache after a DELETE Subscription request.
The Subscription was successfully removed from the database but the cache was forgotten ...

This bug caused (of course) Notifications after removal of Subscriptions.