### PR TITLE
hardening/avoid-apiv2-regs-for-ngsild-ops

### DIFF
--- a/test/functionalTest/cases/0000_ngsild/ngsild_adding_attributes.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_adding_attributes.test
@@ -235,7 +235,7 @@ MongoDB server version: REGEX(.*)
 				},
 				"https://fiware=github=io/tutorials=Step-by-Step/schema/statusOfWork" : {
 					"type" : "Property",
-					"value" : "https://fiware.github.io/tutorials.Step-by-Step/schema/completed"
+					"value" : "completed"
 				}
 			},
 			"mdNames" : [
@@ -263,7 +263,7 @@ bye
 05. Get the entity and see the five attributes
 ==============================================
 HTTP/1.1 200 OK
-Content-Length: 1108
+Content-Length: 1053
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -298,7 +298,7 @@ Date: REGEX(.*)
     },
     "https://fiware.github.io/tutorials.Step-by-Step/schema/statusOfWork": {
       "type": "Property",
-      "value": "https://fiware.github.io/tutorials.Step-by-Step/schema/completed"
+      "value": "completed"
     }
   },
   "https://fiware.github.io/tutorials.Step-by-Step/schema/stocks": {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0364.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0364.test
@@ -158,7 +158,7 @@ MongoDB server REGEX(.*)
 			"type" : "Property",
 			"creDate" : REGEX(.*),
 			"modDate" : REGEX(.*),
-			"value" : "https://uri.fiware.org/ns/data-models#commercial",
+			"value" : "commercial",
 			"mdNames" : [ ]
 		},
 		"https://schema=org/address" : {
@@ -332,10 +332,10 @@ MongoDB server version: REGEX(.*)
 			"creDate" : REGEX(.*),
 			"modDate" : REGEX(.*),
 			"value" : [
-				"https://uri.fiware.org/ns/data-models#commercial",
-				"https://uri.fiware.org/ns/data-models#office",
-				"https://uri.fiware.org/ns/data-models#industrial",
-				"https://uri.fiware.org/ns/data-models#retail"
+				"commercial",
+				"office",
+				"industrial",
+				"retail"
 			],
 			"mdNames" : [ ]
 		}

--- a/test/functionalTest/cases/0000_ngsild/ngsild_updated_relationship_with_metadata.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_updated_relationship_with_metadata.test
@@ -223,7 +223,7 @@ Date: REGEX(.*)
 04. GET the entity, make sure all metadata of 'locatedIn' are present
 =====================================================================
 HTTP/1.1 200 OK
-Content-Length: 1108
+Content-Length: 1053
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -262,7 +262,7 @@ Date: REGEX(.*)
     },
     "https://fiware.github.io/tutorials.Step-by-Step/schema/statusOfWork": {
       "type": "Property",
-      "value": "https://fiware.github.io/tutorials.Step-by-Step/schema/completed"
+      "value": "completed"
     }
   }
 }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_value_expansion-and-q-filter.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_value_expansion-and-q-filter.test
@@ -104,7 +104,7 @@ MongoDB server version: REGEX(.*)
 			"type" : "Property",
 			"creDate" : REGEX(.*),
 			"modDate" : REGEX(.*),
-			"value" : "https://uri.fiware.org/ns/data-models#commercial",
+			"value" : "commercial",
 			"mdNames" : [ ]
 		}
 	},

--- a/test/functionalTest/cases/0000_ngsild/ngsild_value_expansion-context-as-array.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_value_expansion-context-as-array.test
@@ -116,7 +116,7 @@ MongoDB server version: REGEX(.*)
 			"type" : "Property",
 			"creDate" : REGEX(.*),
 			"modDate" : REGEX(.*),
-			"value" : "https://uri.fiware.org/ns/data-models#commercial",
+			"value" : "commercial",
 			"mdNames" : [ ]
 		},
 		"https://schema=org/address" : {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_value_expansion-for-strings.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_value_expansion-for-strings.test
@@ -103,7 +103,7 @@ MongoDB server version: REGEX(.*)
 			"type" : "Property",
 			"creDate" : REGEX(.*),
 			"modDate" : REGEX(.*),
-			"value" : "https://uri.fiware.org/ns/data-models#industrial",
+			"value" : "industrial",
 			"mdNames" : [ ]
 		}
 	},
@@ -135,7 +135,7 @@ Date: REGEX(.*)
 04. GET E2 and see the long value of 'category', as the data-model context is NOT used
 ======================================================================================
 HTTP/1.1 200 OK
-Content-Length: 183
+Content-Length: 145
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -143,7 +143,7 @@ Date: REGEX(.*)
 {
     "https://uri.fiware.org/ns/data-models#category": {
         "type": "Property",
-        "value": "https://uri.fiware.org/ns/data-models#industrial"
+        "value": "industrial"
     },
     "id": "urn:ngsi-ld:test:value-expansion:E2",
     "type": "T"

--- a/test/functionalTest/cases/0000_ngsild/ngsild_value_expansion.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_value_expansion.test
@@ -296,7 +296,7 @@ Date: REGEX(.*)
 08. GET E2 and see the expanded value of 'category'
 ===================================================
 HTTP/1.1 200 OK
-Content-Length: 183
+Content-Length: 145
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -304,7 +304,7 @@ Date: REGEX(.*)
 {
     "https://uri.fiware.org/ns/data-models#category": {
         "type": "Property",
-        "value": "https://uri.fiware.org/ns/data-models#industrial"
+        "value": "industrial"
     },
     "id": "urn:ngsi-ld:test:value-expansion:E2",
     "type": "T"


### PR DESCRIPTION
Avoiding to query registration inside mongoBackend for NGSI-LD requests - performance