### PR TITLE
Subscriptions stop working after restarting broker when id param. is not specified.

### DIFF
--- a/src/lib/mongoBackend/mongoSubCache.cpp
+++ b/src/lib/mongoBackend/mongoSubCache.cpp
@@ -251,15 +251,11 @@ int mongoSubCacheItemInsert(const char* tenant, const BSONObj& sub)
     }
 
     std::string id            = getStringFieldF(entity, ENT_ENTITY_ID);
-    std::string isPattern;
-    if (entity.hasField(CSUB_ENTITY_ISPATTERN))
+    std::string isPattern     = entity.hasField(CSUB_ENTITY_ISPATTERN)? getStringFieldF(entity, CSUB_ENTITY_ISPATTERN) : "false";
+    if (isPattern.empty() && id.empty()) 
     {
-      isPattern = getStringFieldF(entity, CSUB_ENTITY_ISPATTERN);
-      if(isPattern.empty() && id.empty()) isPattern = "true";
-    }
-    else
-    {
-      isPattern = "false";
+      id = ".*";
+      isPattern = "true";
     }
 
     std::string type          = entity.hasField(CSUB_ENTITY_TYPE)?      getStringFieldF(entity, CSUB_ENTITY_TYPE)      : "";
@@ -381,15 +377,11 @@ int mongoSubCacheItemInsert
     }
 
     std::string id            = getStringFieldF(entity, ENT_ENTITY_ID);
-    std::string isPattern;
-    if (entity.hasField(CSUB_ENTITY_ISPATTERN))
+    std::string isPattern     = entity.hasField(CSUB_ENTITY_ISPATTERN)? getStringFieldF(entity, CSUB_ENTITY_ISPATTERN) : "false";
+    if (isPattern.empty() && id.empty()) 
     {
-      isPattern = getStringFieldF(entity, CSUB_ENTITY_ISPATTERN);
-      if(isPattern.empty() && id.empty()) isPattern = "true";
-    }
-    else
-    {
-      isPattern = "false";
+      id = ".*";
+      isPattern = "true";
     }
 
     std::string type          = entity.hasField(CSUB_ENTITY_TYPE)?      getStringFieldF(entity, CSUB_ENTITY_TYPE)      : "";

--- a/src/lib/mongoBackend/mongoSubCache.cpp
+++ b/src/lib/mongoBackend/mongoSubCache.cpp
@@ -251,7 +251,17 @@ int mongoSubCacheItemInsert(const char* tenant, const BSONObj& sub)
     }
 
     std::string id            = getStringFieldF(entity, ENT_ENTITY_ID);
-    std::string isPattern     = entity.hasField(CSUB_ENTITY_ISPATTERN)? getStringFieldF(entity, CSUB_ENTITY_ISPATTERN) : "false";
+    std::string isPattern;
+    if (entity.hasField(CSUB_ENTITY_ISPATTERN))
+    {
+      isPattern = getStringFieldF(entity, CSUB_ENTITY_ISPATTERN);
+      if(isPattern.empty() && id.empty()) isPattern = "true";
+    }
+    else
+    {
+      isPattern = "false";
+    }
+
     std::string type          = entity.hasField(CSUB_ENTITY_TYPE)?      getStringFieldF(entity, CSUB_ENTITY_TYPE)      : "";
     bool        isTypePattern = entity.hasField(CSUB_ENTITY_ISTYPEPATTERN)? getBoolFieldF(entity, CSUB_ENTITY_ISTYPEPATTERN) : false;
     EntityInfo* eiP           = new EntityInfo(id, type, isPattern, isTypePattern);
@@ -371,7 +381,17 @@ int mongoSubCacheItemInsert
     }
 
     std::string id            = getStringFieldF(entity, ENT_ENTITY_ID);
-    std::string isPattern     = entity.hasField(CSUB_ENTITY_ISPATTERN)? getStringFieldF(entity, CSUB_ENTITY_ISPATTERN) : "false";
+    std::string isPattern;
+    if (entity.hasField(CSUB_ENTITY_ISPATTERN))
+    {
+      isPattern = getStringFieldF(entity, CSUB_ENTITY_ISPATTERN);
+      if(isPattern.empty() && id.empty()) isPattern = "true";
+    }
+    else
+    {
+      isPattern = "false";
+    }
+
     std::string type          = entity.hasField(CSUB_ENTITY_TYPE)?      getStringFieldF(entity, CSUB_ENTITY_TYPE)      : "";
     bool        isTypePattern = entity.hasField(CSUB_ENTITY_ISTYPEPATTERN)? getBoolFieldF(entity, CSUB_ENTITY_ISTYPEPATTERN) : false;
     EntityInfo* eiP           = new EntityInfo(id, type, isPattern, isTypePattern);

--- a/test/functionalTest/cases/0000_ngsild/ngsild_retrieve_notifications_after_kill_broker_only_type_designation.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_retrieve_notifications_after_kill_broker_only_type_designation.test
@@ -67,7 +67,7 @@ payload='{
   "id": "http://a.b.c/subs/sub01",
   "type": "Subscription",
   "name": "Sub 01",
-  "description": "receiving notifications for ALL attributes of urn:ngsi-ld:E01",
+  "description": "receiving notifications for ALL attributes of type T",
   "entities": [
     {
       "type": "T"
@@ -179,7 +179,7 @@ MongoDB server version: REGEX(.*)
 	"mimeType" : "application/json",
 	"throttling" : 0,
 	"servicePath" : "/",
-	"description" : "receiving notifications for ALL attributes of urn:ngsi-ld:E01",
+	"description" : "receiving notifications for ALL attributes of type T",
 	"status" : "active",
 	"entities" : [
 		{

--- a/test/functionalTest/cases/0000_ngsild/ngsild_retrieve_notifications_after_kill_broker_only_type_designation.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_retrieve_notifications_after_kill_broker_only_type_designation.test
@@ -1,0 +1,318 @@
+# Copyright 2019 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Subscription Creation and a simple notification
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+brokerStart CB 0-255
+accumulatorStart --pretty-print 127.0.0.1 ${LISTENER_PORT} -v
+
+--SHELL--
+
+#
+# 01. Create an Entity E01 with attr P1 and P2
+# 02. Create a subscription with accumulator receiving notifications for ALL attributes of E01
+# 03. See notification in DB
+# 04. Add P3 to E01
+# 05. Dump accumulator to see one notification - NGSI-LD has no initial notifications
+# 06. Kill and restart Broker
+# 07. Add P4 to E01
+# 08. Dump accumulator to see one notification
+#
+
+echo "01. Create an Entity E01 with attr P1 and P2"
+echo "============================================"
+payload='{
+  "id": "urn:ngsi-ld:E01",
+  "type": "T",
+  "P1": {
+    "type": "Property",
+    "value": 1
+  },
+  "P2": {
+    "type": "Property",
+    "value": "ok"
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities -X POST --payload "$payload" -H "Content-Type: application/json"
+echo
+echo
+
+
+echo "02. Create a subscription with accumulator receiving notifications for ALL attributes of E01"
+echo "============================================================================================"
+payload='{
+  "id": "http://a.b.c/subs/sub01",
+  "type": "Subscription",
+  "name": "Sub 01",
+  "description": "receiving notifications for ALL attributes of urn:ngsi-ld:E01",
+  "entities": [
+    {
+      "type": "T"
+    }
+  ],
+  "notification": {
+    "attributes": [ ],
+    "format": "normalized",
+    "endpoint": {
+      "uri": "http://127.0.0.1:'${LISTENER_PORT}'/notify",
+      "accept": "application/json"
+    }
+  },
+  "expires": "2028-12-31T10:00:00"
+}'
+orionCurl --url /ngsi-ld/v1/subscriptions --payload "$payload" -H "Content-Type: application/json"
+echo
+echo
+
+
+echo "03. See notification in DB"
+echo "=========================="
+mongoCmd2 ftest "db.csubs.findOne()"
+echo
+echo
+
+
+echo "04. Add P3 to E01"
+echo "================="
+payload='{
+  "P3": {
+    "type": "Property",
+    "value": 3
+  }
+}'
+orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:E01/attrs?options=noOverwrite' --payload "$payload" -H "Content-Type: application/json"
+echo
+echo
+
+
+echo "05. Dump accumulator to see one notification - NGSI-LD has no initial notifications"
+echo "==================================================================================="
+accumulatorDump
+accumulatorReset
+echo
+echo
+
+
+echo "06. Kill and restart Broker"
+echo "==========================="
+brokerStop CB
+export BROKER=orionld
+brokerStart CB 0-255
+sleep 2  # give the poor broker some time to start (not really necessary)
+echo
+echo
+
+
+echo "07. Add P4 to E01"
+echo "================="
+payload='{
+  "P4": {
+    "type": "Property",
+    "value": 4
+  }
+}'
+orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:E01/attrs?options=noOverwrite' --payload "$payload" -H "Content-Type: application/json"
+echo
+echo
+
+
+echo "08. Dump accumulator to see one notification"
+echo "============================================"
+sleep .2
+accumulatorDump
+echo
+echo
+
+
+--REGEXPECT--
+01. Create an Entity E01 with attr P1 and P2
+============================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:E01
+Date: REGEX(.*)
+
+
+
+02. Create a subscription with accumulator receiving notifications for ALL attributes of E01
+============================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/http://a.b.c/subs/sub01
+Date: REGEX(.*)
+
+
+
+03. See notification in DB
+==========================
+MongoDB shell version REGEX(.*)
+connecting to: mongodb:REGEX(.*)
+MongoDB server version: REGEX(.*)
+{
+	"_id" : "http://a.b.c/subs/sub01",
+	"expiration" : REGEX(.*),
+	"reference" : "http://127.0.0.1:9997/notify",
+	"custom" : false,
+	"mimeType" : "application/json",
+	"throttling" : 0,
+	"servicePath" : "/",
+	"description" : "receiving notifications for ALL attributes of urn:ngsi-ld:E01",
+	"status" : "active",
+	"entities" : [
+		{
+			"id" : "",
+			"isPattern" : "",
+			"type" : "https://uri.etsi.org/ngsi-ld/default-context/T",
+			"isTypePattern" : false
+		}
+	],
+	"attrs" : [ ],
+	"metadata" : [ ],
+	"blacklist" : false,
+	"name" : "Sub 01",
+	"ldContext" : "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+	"createdAt" : REGEX(.*),
+	"modifiedAt" : REGEX(.*),
+	"conditions" : [ ],
+	"expression" : {
+		"q" : "",
+		"mq" : "",
+		"geometry" : "",
+		"coords" : "",
+		"georel" : "",
+		"geoproperty" : ""
+	},
+	"format" : "normalized"
+}
+bye
+
+
+04. Add P3 to E01
+=================
+HTTP/1.1 204 No Content
+Content-Length: 0
+Date: REGEX(.*)
+
+
+
+05. Dump accumulator to see one notification - NGSI-LD has no initial notifications
+===================================================================================
+POST http://REGEX(.*):9997/notify
+Fiware-Servicepath: /
+Content-Length: 316
+User-Agent: orion/REGEX(.*)
+Ngsiv2-Attrsformat: normalized
+Host: REGEX(.*)
+Accept: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Content-Type: application/json; charset=utf-8
+
+{
+    "data": [
+        {
+            "P1": {
+                "type": "Property", 
+                "value": 1
+            }, 
+            "P2": {
+                "type": "Property", 
+                "value": "ok"
+            }, 
+            "P3": {
+                "type": "Property", 
+                "value": 3
+            }, 
+            "id": "urn:ngsi-ld:E01", 
+            "type": "T"
+        }
+    ], 
+    "id": "urn:ngsi-ld:Notification:REGEX([0-9a-f\-]{24})", 
+    "notifiedAt": "REGEX(.*)", 
+    "subscriptionId": "http://a.b.c/subs/sub01", 
+    "type": "Notification"
+}
+=======================================
+
+
+06. Kill and restart Broker
+===========================
+
+
+07. Add P4 to E01
+=================
+HTTP/1.1 204 No Content
+Content-Length: 0
+Date: REGEX(.*)
+
+
+
+08. Dump accumulator to see one notification
+============================================
+POST http://REGEX(.*)/notify
+Fiware-Servicepath: /
+Content-Length: 351
+User-Agent: orion/REGEX(.*)
+Ngsiv2-Attrsformat: normalized
+Host: REGEX(.*)
+Accept: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Content-Type: application/json; charset=utf-8
+
+{
+    "data": [
+        {
+            "P1": {
+                "type": "Property", 
+                "value": 1
+            }, 
+            "P2": {
+                "type": "Property", 
+                "value": "ok"
+            }, 
+            "P3": {
+                "type": "Property", 
+                "value": 3
+            }, 
+            "P4": {
+                "type": "Property", 
+                "value": 4
+            }, 
+            "id": "urn:ngsi-ld:E01", 
+            "type": "T"
+        }
+    ], 
+    "id": "urn:ngsi-ld:Notification:REGEX([0-9a-f\-]{24})", 
+    "notifiedAt": "REGEX(.*)", 
+    "subscriptionId": "http://a.b.c/subs/sub01", 
+    "type": "Notification"
+}
+=======================================
+
+
+--TEARDOWN--
+brokerStop CB
+accumulatorStop
+dbDrop CB

--- a/test/functionalTest/cases/0000_ngsild/ngsild_retrieve_notifications_after_kill_broker_only_type_designation.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_retrieve_notifications_after_kill_broker_only_type_designation.test
@@ -33,7 +33,7 @@ accumulatorStart --pretty-print 127.0.0.1 ${LISTENER_PORT} -v
 
 #
 # 01. Create an Entity E01 with attr P1 and P2
-# 02. Create a subscription with accumulator receiving notifications for ALL attributes of E01
+# 02. Create a subscription with accumulator receiving notifications for ALL attributes of type T
 # 03. See notification in DB
 # 04. Add P3 to E01
 # 05. Dump accumulator to see one notification - NGSI-LD has no initial notifications


### PR DESCRIPTION
If a subscription represented as below is created, the subscription will stop working after restarting the Orion-LD broker.
This is because `isPattern` flag is set as false in `mongoSubCacheItemInsert` function.

```
{
  "id": "http://a.b.c/subs/sub01",
  "type": "Subscription",
  "name": "Sub 01",
  "description": "receiving notifications for ALL attributes of type T",
  "entities": [
    {
      "type": "T"
    }
  ],
  "notification": {
    "attributes": [ ],
    "format": "normalized",
    "endpoint": {
      "uri": "http://127.0.0.1:'${LISTENER_PORT}'/notify",
      "accept": "application/json"
    }
  },
  "expires": "2028-12-31T10:00:00"
}
```