### PR TITLE
fix issue-559

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -10,5 +10,6 @@
 * Issue  #280   Implemented Batch Update with options=noOverwrite
 * Issue  #280   Default mongo request mutex policy changed from 'all' to 'none'
 * Issue  #586   Stopped using gtime(), that is not reentrant - gtime_r() is used instead
-* Issue   XXX   A Korean contributor "@manaty226" fixed an important bug about subscriptions after broker restart - Thanks!
+* Issue   XXX   External contributor "@manaty226" fixed an important bug about subscriptions after broker restart - Thanks!
+* Issue  #605   ORIONLD_MONGO_HOST env var is not parsed correctly - made the buffer for the CLI '-dbHost' bigger (64 -> 1024)
 * Issue  #559   External contributor "@manaty226" ixed notification on PATCH Entity, updating attributes

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -11,3 +11,4 @@
 * Issue  #280   Default mongo request mutex policy changed from 'all' to 'none'
 * Issue  #586   Stopped using gtime(), that is not reentrant - gtime_r() is used instead
 * Issue   XXX   A Korean contributor "@manaty226" fixed an important bug about subscriptions after broker restart - Thanks!
+* Issue  #559   External contributor "@manaty226" ixed notification on PATCH Entity, updating attributes

--- a/test/functionalTest/cases/0000_ngsild/ngsild_patch_entity_attr_with_subscription.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_patch_entity_attr_with_subscription.test
@@ -30,11 +30,6 @@ brokerStart CB 0-255
 accumulatorStart --pretty-print
 
 --SHELL--
-#
-# FIXME: There is a bug in the notifications triggered by PATCH /ngsi-ld/v1/entities/{EID}/attrs
-#        and the step 06 compensates for this bug.
-#        Once the issue #559 is fixed, this functest will start failing and must be modified
-#
 # 01. Create an entity E1 with properties A1 and A2
 # 02. Create a subscription matching E1
 # 03. Update the E1 property A1
@@ -254,7 +249,7 @@ Date: REGEX(.*)
 ============================================================================
 POST http://REGEX(.*)/notify
 Fiware-Servicepath: /
-Content-Length: 360
+Content-Length: 309
 User-Agent: REGEX(.*)
 Ngsiv2-Attrsformat: normalized
 Host: REGEX(.*)
@@ -266,10 +261,6 @@ Content-Type: application/json; charset=utf-8
     "data": [
         {
             "A1": {
-                "PP1": {
-                    "type": "Property", 
-                    "value": "A1::PP1 Step 1"
-                }, 
                 "type": "Property", 
                 "value": "A1 Step 3"
             }, 

--- a/test/functionalTest/cases/1156_mq_as_uri_param_for_metadata/q_and_mq_as_uri_param_for_metadata.test
+++ b/test/functionalTest/cases/1156_mq_as_uri_param_for_metadata/q_and_mq_as_uri_param_for_metadata.test
@@ -513,7 +513,7 @@ Date: REGEX(.*)
 ============================
 POST http://localhost:REGEX(\d+)/notify
 Fiware-Servicepath: /
-Content-Length: 194
+Content-Length: 161
 User-Agent: orion/REGEX(\d+\.\d+\.\d+.*)
 Ngsiv2-Attrsformat: normalized
 Host: localhost:REGEX(\d+)
@@ -527,10 +527,6 @@ Fiware-Correlator: REGEX([0-9a-f\-]{36})
             "A1": {
                 "metadata": {
                     "M1": {
-                        "type": "Number", 
-                        "value": 3
-                    }, 
-                    "M2": {
                         "type": "Number", 
                         "value": 3
                     }


### PR DESCRIPTION
Metadata should be replaced if `actionType` is `NGSI_MD_ACTIONTYPE_UPDATE`.
The conventional updating way is applied for `NGSI_MD_ACTIONTYPE_APPEND`.

Reason:
In the conventional way, if `targetAttr` has no metadata, an entity's metadata was not changed because of 
`for (unsigned int jx = 0; jx < targetAttr->metadataVector.size(); jx++) {...}`.
Thus, I add another update processing if `NGSI_MD_ACTIONTYPE_UPDATE`.