### PR TITLE
task/postgresDataAsCliParams

### DIFF
--- a/src/app/orionld/orionld.cpp
+++ b/src/app/orionld/orionld.cpp
@@ -196,6 +196,10 @@ int             contextDownloadTimeout;
 bool            temporal;
 bool            disableFileLog;
 bool            lmtmp;
+char            troeHost[64];
+unsigned short  troePort;
+char            troeUser[64];
+char            troePwd[64];
 
 
 
@@ -260,6 +264,10 @@ bool            lmtmp;
 #define TEMPORAL_DESC          "enable temporal evolution of entities"
 #define DISABLE_FILE_LOG       "disable logging into file"
 #define TMPTRACES_DESC         "disable LM_TMP traces"
+#define TROE_HOST_DESC         "host for temporal database db server"
+#define TROE_PORT_DESC         "port for temporal database db server"
+#define TROE_HOST_USER         "username for temporal database db server"
+#define TROE_HOST_PWD          "password for temporal database db server"
 
 
 
@@ -324,6 +332,10 @@ PaArgument paArgs[] =
   { "-ctxAttempts",           &contextDownloadAttempts, "CONTEXT_DOWNLOAD_ATTEMPTS", PaInt,     PaOpt,  3,               0,      100,              CTX_ATT_DESC           },
   { "-temporal",              &temporal,                "TEMPORAL",                  PaBool,    PaOpt,  false,           false,  true,             TEMPORAL_DESC          },
   { "-lmtmp",                 &lmtmp,                   "TMP_TRACES",                PaBool,    PaHid,  true,            false,  true,             TMPTRACES_DESC         },
+  { "-troeHost",              troeHost,                 "TROE_HOST",                 PaString,  PaOpt,  _i "localhost",  PaNL,   PaNL,             TROE_HOST_DESC         },
+  { "-troePort",              &troePort,                "TROE_PORT",                 PaInt,     PaOpt,  5432,            PaNL,   PaNL,             TROE_PORT_DESC         },
+  { "-troeUser",              troeUser,                 "TROE_USER",                 PaString,  PaOpt,  _i "postgres",   PaNL,   PaNL,             TROE_HOST_USER         },
+  { "-troePwd",               troePwd,                  "TROE_PWD",                  PaString,  PaOpt,  _i "password",   PaNL,   PaNL,             TROE_HOST_PWD          },
 
   PA_END_OF_ARGS
 };

--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -305,6 +305,10 @@ extern char*             tenant;                   // From orionld.cpp
 extern int               contextDownloadAttempts;  // From orionld.cpp
 extern int               contextDownloadTimeout;   // From orionld.cpp
 extern bool              temporal;                 // From orionld.cpp
+extern char              troeHost[64];             // From orionld.cpp
+extern unsigned short    troePort;                 // From orionld.cpp
+extern char              troeUser[64];             // From orionld.cpp
+extern char              troePwd[64];              // From orionld.cpp
 extern const char*       orionldVersion;
 extern char*             tenantV[100];
 extern unsigned int      tenants;

--- a/src/lib/orionld/temporal/pgConnectionGet.cpp
+++ b/src/lib/orionld/temporal/pgConnectionGet.cpp
@@ -27,7 +27,7 @@
 #include "logMsg/logMsg.h"                                     // LM_*
 #include "logMsg/traceLevels.h"                                // Lmt*
 
-#include "orionld/temporal/temporal.h"                         // TEMPORAL_DB, TEMPORAL_DB_USER, TEMPORAL_DB_PASSWORD
+#include "orionld/common/orionldState.h"                       // troeHost, troePort, troeUser, troePwd
 #include "orionld/temporal/pgConnectionGet.h"                  // Own interface
 
 
@@ -58,13 +58,16 @@
 PGconn* pgConnectionGet(const char* dbName)
 {
   // FIXME: connection pool: lookup a free connection to 'dbName' ...
+  char port[16];
 
-  const char*  keywords[]   = { "host",      "port", "user",            "password",           "dbname", NULL };
-  const char*  values[]     = { "localhost", "5432",  TEMPORAL_DB_USER, TEMPORAL_DB_PASSWORD, dbName, NULL   };
-  PGconn*      connectionP  = PQconnectdbParams(keywords, values, 0);  // 0: no expansion of dbname: https://www.postgresql.org/docs/12/libpq-connect.html
+  snprintf(port, sizeof(port), "%d", troePort);
+
+  const char*  keywords[]   = { "host",   "port",   "user",   "password",  "dbname", NULL };
+  const char*  values[]     = { troeHost, port,     troeUser, troePwd,     dbName,   NULL };
+  PGconn*      connectionP  = PQconnectdbParams(keywords, values, 0);  // 0: no expansion of dbname - see https://www.postgresql.org/docs/12/libpq-connect.html
 
   if (connectionP == NULL)
-    LM_RE(NULL, ("Database Error (unable  to connect to postgres('%s', %d, '%s', '%s', '%s')", "localhost", 5432, TEMPORAL_DB_USER, TEMPORAL_DB_PASSWORD, dbName));
+    LM_RE(NULL, ("Database Error (unable  to connect to postgres('%s', %d, '%s', '%s', '%s')", troeHost, troePort, troeUser, troePwd, dbName));
 
   return connectionP;
 }


### PR DESCRIPTION
All postgres temporal db info:
* host,
* port,
* user,
* password

now supported as CLI params