### PR TITLE
Tmp/traces for context download

### DIFF
--- a/src/lib/orionld/context/orionldContextDownload.cpp
+++ b/src/lib/orionld/context/orionldContextDownload.cpp
@@ -51,6 +51,8 @@ char* orionldContextDownload(const char* url, bool* downloadFailedP, OrionldProb
 
   *downloadFailedP = true;
 
+  LM_TMP(("Downloading the context '%s'", url));
+
   char                 protocol[16];
   char                 ip[256];
   uint16_t             port    = 0;

--- a/src/lib/orionld/context/orionldContextInit.cpp
+++ b/src/lib/orionld/context/orionldContextInit.cpp
@@ -255,6 +255,7 @@ bool orionldContextInit(OrionldProblemDetails* pdP)
     if (gotCoreContext == false)
       LM_E(("Unable to cache pre-loaded contexts from '%s'", cacheContextDir));
   }
+  LM_TMP(("ORIONLD_CACHED_CONTEXT_DIRECTORY == '%s'", cacheContextDir));
 #endif
 
   if (gotCoreContext == false)


### PR DESCRIPTION
* Added a trace line each time a context is downloaded:   Downloading the context '$URL'
* Added a single trace line about the "File-Cache" for contexts:  ORIONLD_CACHED_CONTEXT_DIRECTORY == '$PATH'
