### PR TITLE
Task/pg attribute push

### DIFF
--- a/src/lib/orionld/temporal/pgAttributePush.h
+++ b/src/lib/orionld/temporal/pgAttributePush.h
@@ -31,8 +31,23 @@
 
 // -----------------------------------------------------------------------------
 //
-// pgAttributePush - push an attribute to its DB table
+// pgAttributePush - add an attribute to the DB
 //
-extern bool pgAttributePush(PGconn* connectionP, char* id, char* instanceId);
+extern bool pgAttributePush
+(
+  PGconn*      connectionP,
+  KjNode*      valueNodeP,
+  const char*  attributeType,
+  const char*  entityRef,
+  const char*  entityId,
+  const char*  id,
+  const char*  instanceId,
+  const char*  datasetId,
+  const char*  observedAt,
+  const char*  createdAt,
+  const char*  modifiedAt,
+  bool         subAttrs,
+  const char*  unitCode
+);
 
 #endif  // SRC_LIB_ORIONLD_TEMPORAL_PGATTRIBUTEPUSH_H_

--- a/src/lib/orionld/temporal/pgAttributeTreat.cpp
+++ b/src/lib/orionld/temporal/pgAttributeTreat.cpp
@@ -127,7 +127,7 @@ bool pgAttributeTreat
   }
   else if (valueNodeP->type == KjString)
   {
-    if (pgStringPropertyPush(connectionP, "String", valueNodeP->value.s, entityRef, entityId, id, instanceId, datasetId, observedAt, createdAt, modifiedAt, subAttrs) == false)
+    if (pgStringPropertyPush(connectionP, valueNodeP->value.s, entityRef, entityId, id, instanceId, datasetId, observedAt, createdAt, modifiedAt, subAttrs) == false)
       LM_RE(false, ("pgStringPropertyPush failed"));
   }
   else if (valueNodeP->type == KjInt)

--- a/src/lib/orionld/temporal/pgEntityTreat.cpp
+++ b/src/lib/orionld/temporal/pgEntityTreat.cpp
@@ -88,9 +88,16 @@ bool pgEntityTreat(PGconn* connectionP, KjNode* entityP, char* id, char* type, c
 
   for (KjNode* attrP = entityP->value.firstChildP; attrP != NULL; attrP = attrP->next)
   {
-    // FIXME: createdAt ... I need to know that the Attribute did not exist for this to be OK ...
-    if (pgAttributeTreat(connectionP, attrP, instanceId, id, createdAt, modifiedAt) == false)
-      LM_RE(false, ("pgAttributeTreat failed for attribute '%s'", attrP->name));
+    if (attrP->type == KjObject)
+    {
+      // FIXME: createdAt ... I need to know that the Attribute did not exist for this to be OK ...
+      if (pgAttributeTreat(connectionP, attrP, instanceId, id, createdAt, modifiedAt) == false)
+        LM_RE(false, ("pgAttributeTreat failed for attribute '%s'", attrP->name));
+    }
+    else if (attrP->type == KjArray)
+    {
+      LM_W(("The attribute '%s' is an array ... datasetId is not supported for TRoE", attrP->name));
+    }
   }
 
   return true;

--- a/src/lib/orionld/temporal/pgStringPropertyPush.cpp
+++ b/src/lib/orionld/temporal/pgStringPropertyPush.cpp
@@ -39,7 +39,6 @@
 bool pgStringPropertyPush
 (
   PGconn*      connectionP,
-  const char*  valueType,
   const char*  value,
   const char*  entityRef,
   const char*  entityId,
@@ -64,29 +63,29 @@ bool pgStringPropertyPush
   {
     snprintf(sql, sizeof(sql), "INSERT INTO attributes("
              "instanceId, id, entityRef, entityId, createdAt, modifiedAt, observedAt, valueType, subProperty, datasetId, text) "
-             "VALUES ('%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', %s, '%s', '%s')",
-             attributeInstance, attributeName, entityRef, entityId, createdAt, modifiedAt, observedAt, valueType, subPropertiesString, datasetId, value);
+             "VALUES ('%s', '%s', '%s', '%s', '%s', '%s', '%s', 'String', %s, '%s', '%s')",
+             attributeInstance, attributeName, entityRef, entityId, createdAt, modifiedAt, observedAt, subPropertiesString, datasetId, value);
   }
   else if ((datasetId == NULL) && (observedAt == NULL))
   {
     snprintf(sql, sizeof(sql), "INSERT INTO attributes("
              "instanceId, id, entityRef, entityId, createdAt, modifiedAt, valueType, subProperty, text) "
-             "VALUES ('%s', '%s', '%s', '%s', '%s', '%s', '%s', %s, '%s')",
-             attributeInstance, attributeName, entityRef, entityId, createdAt, modifiedAt, valueType, subPropertiesString, value);
+             "VALUES ('%s', '%s', '%s', '%s', '%s', '%s', 'String', %s, '%s')",
+             attributeInstance, attributeName, entityRef, entityId, createdAt, modifiedAt, subPropertiesString, value);
   }
   else if (datasetId != NULL)  // observedAt == NULL
   {
     snprintf(sql, sizeof(sql), "INSERT INTO attributes("
              "instanceId, id, entityRef, entityId, createdAt, modifiedAt, valueType, subProperty, datasetId, text) "
-             "VALUES ('%s', '%s', '%s', '%s', '%s', '%s', '%s', %s, '%s', '%s')",
-             attributeInstance, attributeName, entityRef, entityId, createdAt, modifiedAt, valueType, subPropertiesString, datasetId, value);
+             "VALUES ('%s', '%s', '%s', '%s', '%s', '%s', 'String', %s, '%s', '%s')",
+             attributeInstance, attributeName, entityRef, entityId, createdAt, modifiedAt, subPropertiesString, datasetId, value);
   }
   else  // observedAt != NULL, datasetId == NULL
   {
     snprintf(sql, sizeof(sql), "INSERT INTO attributes("
              "instanceId, id, entityRef, entityId, createdAt, modifiedAt, observedAt, valueType, subProperty, text) "
-             "VALUES ('%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', %s, '%s')",
-             attributeInstance, attributeName, entityRef, entityId, createdAt, modifiedAt, observedAt, valueType, subPropertiesString, value);
+             "VALUES ('%s', '%s', '%s', '%s', '%s', '%s', '%s', 'String', %s, '%s')",
+             attributeInstance, attributeName, entityRef, entityId, createdAt, modifiedAt, observedAt, subPropertiesString, value);
   }
 
 

--- a/src/lib/orionld/temporal/pgStringPropertyPush.h
+++ b/src/lib/orionld/temporal/pgStringPropertyPush.h
@@ -36,7 +36,6 @@
 extern bool pgStringPropertyPush
 (
   PGconn*      connectionP,
-  const char*  valueType,    // "Relationship", "String", "Array", "Object", "DateTime"
   const char*  value,
   const char*  entityRef,
   const char*  entityId,


### PR DESCRIPTION
Refactoring:
* pgAttributePush taking care of pushing attrs to DB
* pgStringPropertyPush no longer takes the "value type" as parameter - it's always just "String"
* Prepared pgEntityTreat for datasetId