### PR TITLE
Task/forwarding optional

### DIFF
--- a/src/app/orionld/orionld.cpp
+++ b/src/app/orionld/orionld.cpp
@@ -206,7 +206,7 @@ char            troePwd[64];
 int             troePoolSize;
 bool            socketService;
 unsigned short  socketServicePort;
-bool            mhdTurbo;
+bool            forwarding;
 
 
 
@@ -278,7 +278,7 @@ bool            mhdTurbo;
 #define TROE_POOL_DESC         "size of the connection pool for TRoE Postgres database connections"
 #define SOCKET_SERVICE_DESC    "enable the socket service - accept connections via a normal TCP socket"
 #define SOCKET_SERVICE_PORT_DESC  "port to receive new socket service connections"
-#define MHDTURBO_DESC          "turn on MHD TURBO"
+#define FORWARDING_DESC        "turn on forwarding"
 
 
 
@@ -350,7 +350,7 @@ PaArgument paArgs[] =
   { "-troePwd",               troePwd,                  "TROE_PWD",                  PaString,  PaOpt,  _i "password",   PaNL,   PaNL,             TROE_HOST_PWD            },
   { "-troePoolSize",          &troePoolSize,            "TROE_POOL_SIZE",            PaInt,     PaOpt,  10,              0,      1000,             TROE_POOL_DESC           },
   { "-ssPort",                &socketServicePort,       "SOCKET_SERVICE_PORT",       PaUShort,  PaHid,  1027,            PaNL,   PaNL,             SOCKET_SERVICE_PORT_DESC },
-  { "-mhdTurbo",              &mhdTurbo,                "MHD_TURBO",                 PaBool,    PaHid,  false,           false,  true,             MHDTURBO_DESC            },
+  { "-forwarding",            &forwarding,              "FORWARDING",                PaBool,    PaOpt,  false,           false,  true,             FORWARDING_DESC          },
 
   PA_END_OF_ARGS
 };

--- a/src/lib/orionld/common/orionldState.cpp
+++ b/src/lib/orionld/common/orionldState.cpp
@@ -57,6 +57,10 @@ const char* orionldVersion = ORIONLD_VERSION;
 //
 __thread OrionldConnectionState orionldState;
 
+#ifdef REQUEST_PERFORMANCE
+__thread Timestamps timestamps;
+#endif
+
 
 
 // -----------------------------------------------------------------------------

--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -283,6 +283,18 @@ typedef struct OrionldConnectionState
   unsigned int            troeIgnoreIx;
 } OrionldConnectionState;
 
+#ifdef REQUEST_PERFORMANCE
+typedef struct Timestamps
+{
+  struct timespec reqStart;
+  struct timespec serviceRoutineStart;
+  struct timespec serviceRoutineEnd;
+  struct timespec reqEnd;
+} Timestamps;
+
+extern __thread Timestamps timestamps;
+#endif
+
 
 
 // -----------------------------------------------------------------------------

--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -331,7 +331,7 @@ extern unsigned short    troePort;                 // From orionld.cpp
 extern char              troeUser[64];             // From orionld.cpp
 extern char              troePwd[64];              // From orionld.cpp
 extern int               troePoolSize;             // From orionld.cpp
-extern bool              mhdTurbo;                 // From orionld.cpp
+extern bool              forwarding;               // From orionld.cpp
 extern const char*       orionldVersion;
 extern char*             tenantV[100];
 extern unsigned int      tenants;

--- a/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
@@ -493,6 +493,7 @@ bool orionldGetEntity(ConnectionInfo* ciP)
     else
       orionldErrorResponseCreate(OrionldResourceNotFound, "Entity Not Found", orionldState.wildcard[0]);
     orionldState.httpStatusCode = SccContextElementNotFound;  // 404
+
     return false;
   }
 

--- a/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
@@ -296,7 +296,7 @@ static KjNode* orionldForwardGetEntityPart(KjNode* registrationP, char* entityId
 static KjNode* orionldForwardGetEntity(ConnectionInfo* ciP, char* entityId, KjNode* regArrayP, KjNode* responseP, bool needEntityType)
 {
   //
-  // If URI param 'attrs' was used, split the attr-names into an array and expanmd according to @context
+  // If URI param 'attrs' was used, split the attr-names into an array and expand according to @context
   //
   char* uriParamAttrsV[100];
   int   uriParamAttrs = 0;
@@ -415,7 +415,7 @@ static char** attrsListToArray(char* attrList, char* attrV[], int attrVecLen)
 bool orionldGetEntity(ConnectionInfo* ciP)
 {
   char*    detail;
-  KjNode*  regArray;
+  KjNode*  regArray = NULL;
 
   //
   // Make sure the ID (orionldState.wildcard[0]) is a valid URI
@@ -427,7 +427,8 @@ bool orionldGetEntity(ConnectionInfo* ciP)
     return false;
   }
 
-  regArray = dbRegistrationLookup(orionldState.wildcard[0], NULL, NULL);
+  if (forwarding)
+    regArray = dbRegistrationLookup(orionldState.wildcard[0], NULL, NULL);
 
   LM_T(LmtServiceRoutine, ("In orionldGetEntity: %s", orionldState.wildcard[0]));
 

--- a/src/lib/orionld/serviceRoutines/orionldPatchAttribute.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchAttribute.cpp
@@ -387,17 +387,20 @@ bool orionldPatchAttribute(ConnectionInfo* ciP)
     attrName = orionldContextItemExpand(orionldState.contextP, attrName, true, NULL);
   }
 
-  //
-  // If a matching registration is found, no local treatment will be done.
-  // The request is simply forwarded to the matching Context Provider
-  //
-  regArray = dbRegistrationLookup(entityId, attrName, &matchingRegs);
-  if (regArray != NULL)
+  if (forwarding)
   {
-    if (matchingRegs > 1)
-      dbRegistrationsOnlyOneAllowed(regArray, matchingRegs, entityId, attrName);
+    //
+    // If a matching registration is found, no local treatment will be done.
+    // The request is simply forwarded to the matching Context Provider
+    //
+    regArray = dbRegistrationLookup(entityId, attrName, &matchingRegs);
+    if (regArray != NULL)
+    {
+      if (matchingRegs > 1)
+        dbRegistrationsOnlyOneAllowed(regArray, matchingRegs, entityId, attrName);
 
-    return orionldForwardPatchAttribute(ciP, regArray->value.firstChildP, entityId, attrName, orionldState.requestTree);
+      return orionldForwardPatchAttribute(ciP, regArray->value.firstChildP, entityId, attrName, orionldState.requestTree);
+    }
   }
 
   // ----------------------------------------------------------------

--- a/src/lib/orionld/socketService/socketServiceRun.cpp
+++ b/src/lib/orionld/socketService/socketServiceRun.cpp
@@ -88,7 +88,12 @@ static int ssRead(int fd, char* dataP, int dataLen, bool* connectionClosedP)
 //
 static void ssWrite(int fd, const char* data, int dataLen)
 {
-  write(fd, data, dataLen);
+  int nb = write(fd, data, dataLen);
+
+  if (nb == -1)
+    LM_E(("Internal Error (unable to write to socket service client: %s)", strerror(errno)));
+  else if (nb != dataLen)
+    LM_E(("Internal Error (written only %d bytes out of %d to socket service client)", nb, dataLen));
 }
 
 

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -1915,9 +1915,6 @@ static int restStart(IpVersion ipVersion, const char* httpsKey = NULL, const cha
 #endif
   }
 
-  if (mhdTurbo == true)
-    serverMode |= MHD_USE_TURBO;
-
   if ((ipVersion == IPV4) || (ipVersion == IPDUAL))
   {
     memset(&sad, 0, sizeof(sad));

--- a/test/functionalTest/cases/0000_cli/bool_option_with_value.test
+++ b/test/functionalTest/cases/0000_cli/bool_option_with_value.test
@@ -99,5 +99,6 @@ Usage: orionld  [option '-U' (extended usage)]
                 [option '-troeUser' <username for troe database db server>]
                 [option '-troePwd' <password for troe database db server>]
                 [option '-troePoolSize' <size of the connection pool for TRoE Postgres database connections>]
+                [option '-forwarding' (turn on forwarding)]
 
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_cli/command_line_options.test
+++ b/test/functionalTest/cases/0000_cli/command_line_options.test
@@ -88,5 +88,6 @@ Usage: orionld  [option '-U' (extended usage)]
                 [option '-troeUser' <username for troe database db server>]
                 [option '-troePwd' <password for troe database db server>]
                 [option '-troePoolSize' <size of the connection pool for TRoE Postgres database connections>]
+                [option '-forwarding' (turn on forwarding)]
 
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_ngsild/ngsild_forward_get_entity-attrs-all-four-combinations.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_forward_get_entity-attrs-all-four-combinations.test
@@ -27,7 +27,7 @@ NGSI-LD Forward of GET /entities/{entityId}
 export BROKER=orionld
 dbInit CB
 dbInit CP1
-brokerStart CB
+brokerStart CB 0 IPv4 -forwarding
 brokerStart CP1
 
 --SHELL--

--- a/test/functionalTest/cases/0000_ngsild/ngsild_forward_get_entity-attrs-both-regAttrs-and-uriAttrs-no-local-entity.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_forward_get_entity-attrs-both-regAttrs-and-uriAttrs-no-local-entity.test
@@ -27,7 +27,7 @@ NGSI-LD Forward of GET /entities/{entityId}?attrs=<merge between Registered Attr
 export BROKER=orionld
 dbInit CB
 dbInit CP1
-brokerStart CB
+brokerStart CB 0 IPv4 -forwarding
 brokerStart CP1
 
 --SHELL--

--- a/test/functionalTest/cases/0000_ngsild/ngsild_forward_get_entity-attrs-both-regAttrs-and-uriAttrs-two-cps.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_forward_get_entity-attrs-both-regAttrs-and-uriAttrs-two-cps.test
@@ -28,7 +28,7 @@ export BROKER=orionld
 dbInit CB
 dbInit CP1
 dbInit CP2
-brokerStart CB
+brokerStart CB 0 IPv4 -forwarding
 brokerStart CP1
 brokerStart CP2
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_forward_get_entity-attrs-both-regAttrs-and-uriAttrs.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_forward_get_entity-attrs-both-regAttrs-and-uriAttrs.test
@@ -27,7 +27,7 @@ NGSI-LD Forward of GET /entities/{entityId}?attrs=<merge between Registered Attr
 export BROKER=orionld
 dbInit CB
 dbInit CP1
-brokerStart CB
+brokerStart CB 0 IPv4 -forwarding
 brokerStart CP1
 
 --SHELL--

--- a/test/functionalTest/cases/0000_ngsild/ngsild_forward_get_entity-attrs-no-regAttrs-no-uriAttrs.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_forward_get_entity-attrs-no-regAttrs-no-uriAttrs.test
@@ -27,7 +27,7 @@ NGSI-LD Forward of GET /entities/{entityId} without registered attributes and wi
 export BROKER=orionld
 dbInit CB
 dbInit CP1
-brokerStart CB
+brokerStart CB 0 IPv4 -forwarding
 brokerStart CP1
 
 --SHELL--

--- a/test/functionalTest/cases/0000_ngsild/ngsild_forward_get_entity-attrs-only-regAttrs.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_forward_get_entity-attrs-only-regAttrs.test
@@ -27,7 +27,7 @@ NGSI-LD Forward of GET /entities/{entityId}?attrs=<Only Registered Attributes>
 export BROKER=orionld
 dbInit CB
 dbInit CP1
-brokerStart CB
+brokerStart CB 0 IPv4 -forwarding
 brokerStart CP1
 
 --SHELL--

--- a/test/functionalTest/cases/0000_ngsild/ngsild_forward_get_entity-attrs-only-uriAttrs.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_forward_get_entity-attrs-only-uriAttrs.test
@@ -27,7 +27,7 @@ NGSI-LD Forward of GET /entities/{entityId}?attrs=<Only URI Parameter Attributes
 export BROKER=orionld
 dbInit CB
 dbInit CP1
-brokerStart CB
+brokerStart CB 0 IPv4 -forwarding
 brokerStart CP1
 
 --SHELL--

--- a/test/functionalTest/cases/0000_ngsild/ngsild_forward_get_entity-with-xauthtoken-header.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_forward_get_entity-with-xauthtoken-header.test
@@ -26,7 +26,7 @@ NGSI-LD Forward of GET /entities/{entityId}?attrs=<Only URI Parameter Attributes
 --SHELL-INIT--
 export BROKER=orionld
 dbInit CB
-brokerStart CB
+brokerStart CB 0 IPv4 -forwarding
 accumulatorStart --url "/ngsi-ld/v1/entities/urn:ngsi-ld:entities:E1"
 
 --SHELL--

--- a/test/functionalTest/cases/0000_ngsild/ngsild_forward_patch_entity-attr-with-contexts.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_forward_patch_entity-attr-with-contexts.test
@@ -27,7 +27,7 @@ Forwarding of PATCH Entity-Attribute requests with contexts
 export BROKER=orionld
 dbInit CB
 dbInit C1
-brokerStart CB 0-255
+brokerStart CB 0 IPv4 -forwarding
 brokerStart CP1
 
 --SHELL--

--- a/test/functionalTest/cases/0000_ngsild/ngsild_forward_patch_entity-attr.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_forward_patch_entity-attr.test
@@ -27,7 +27,7 @@ Forwarding of PATCH Entity-Attribute requests
 export BROKER=orionld
 dbInit CB
 dbInit C1
-brokerStart CB 0-255
+brokerStart CB 0 IPv4 -forwarding
 brokerStart CP1
 
 --SHELL--

--- a/test/unittests/main_UnitTest.cpp
+++ b/test/unittests/main_UnitTest.cpp
@@ -94,7 +94,7 @@ char            troeHost[64];
 unsigned short  troePort;
 char            troeUser[64];
 char            troePwd[64];
-bool            mhdTurbo                = false;
+bool            forwarding              = true;
 
 
 


### PR DESCRIPTION
* Removed the temporary CLI option `-mhdTurbo` - it was just a test
* Made Forwarding optional - for performance reasons - not all users use registrations
  * Use the CLI `-forwarding` to turn forwarding on
* Fixed a possible compiler warning that may cause compilation errors 