### PR TITLE
Task/uri params get only if mongo backend

### DIFF
--- a/src/lib/orionld/mongoCppLegacy/mongoCppLegacyEntityRetrieve.cpp
+++ b/src/lib/orionld/mongoCppLegacy/mongoCppLegacyEntityRetrieve.cpp
@@ -403,11 +403,9 @@ KjNode* mongoCppLegacyEntityRetrieve(const char* entityId, char** attrs, bool at
   releaseMongoConnection(connectionP);
   // semGive()
 
-  if (dbTree == NULL)
-  {
-    // Entity not found
+  if (dbTree == NULL)  // Entity not found
     return NULL;
-  }
+
 
   KjNode*  dbAttrsP           = kjLookup(dbTree, "attrs");      // Must be there
   KjNode*  dbDataSetsP        = kjLookup(dbTree, "@datasets");  // May not be there
@@ -427,7 +425,7 @@ KjNode* mongoCppLegacyEntityRetrieve(const char* entityId, char** attrs, bool at
   // Else (no 'attrs' given):
   //
   //
-  if (attrs == NULL)     // Include all attributes in the response
+  if ((attrs == NULL) || (attrs[0] == NULL))     // Include all attributes in the response
   {
     if (keyValues == false)
     {

--- a/src/lib/orionld/rest/OrionLdRestService.h
+++ b/src/lib/orionld/rest/OrionLdRestService.h
@@ -101,6 +101,7 @@ typedef struct OrionLdRestServiceSimplifiedVector
 #define ORIONLD_SERVICE_OPTION_CREATE_CONTEXT                        (1 << 1)
 #define ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD  (1 << 2)
 #define ORIONLD_SERVICE_OPTION_MAKE_SURE_TENANT_EXISTS               (1 << 3)
+#define ORIONLD_SERVICE_OPTION_CLONE_PAYLOAD                         (1 << 4)
 
 
 

--- a/src/lib/orionld/rest/OrionLdRestService.h
+++ b/src/lib/orionld/rest/OrionLdRestService.h
@@ -102,6 +102,7 @@ typedef struct OrionLdRestServiceSimplifiedVector
 #define ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD  (1 << 2)
 #define ORIONLD_SERVICE_OPTION_MAKE_SURE_TENANT_EXISTS               (1 << 3)
 #define ORIONLD_SERVICE_OPTION_CLONE_PAYLOAD                         (1 << 4)
+#define ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS                      (1 << 5)
 
 
 

--- a/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
@@ -560,17 +560,19 @@ MHD_Result orionldMhdConnectionInit
   }
 
   // 4. GET Service Pointer from VERB and URL-PATH
-  LM_TMP(("URI: Verb: %s", method));
-  LM_TMP(("URI: URL:  %s", url));
   orionldState.serviceP = serviceLookup(ciP);
 
   if (orionldState.serviceP == NULL)  // 405 or 404 - no need to continue - prettyPrint not possible here
     return MHD_YES;
 
-  LM_TMP(("URI: serviceP at %p", orionldState.serviceP));
-
+  //
   // 5. GET URI params
-  MHD_get_connection_values(connection, MHD_GET_ARGUMENT_KIND, uriArgumentGet, ciP);           // FIXME: To Be Removed!
+  //    Those Service Routines that DON'T USE mongoBackend don't need to call uriArgumentGet
+  //    [ mongoBackend needs stuff in ciP->uriParams ]
+  //
+  if ((orionldState.serviceP->options & ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS) == 0)
+    MHD_get_connection_values(connection, MHD_GET_ARGUMENT_KIND, uriArgumentGet, ciP);
+
   MHD_get_connection_values(connection, MHD_GET_ARGUMENT_KIND, orionldUriArgumentGet, NULL);
 
   //

--- a/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
@@ -38,7 +38,10 @@ extern "C"
 #include "orionld/common/orionldErrorResponse.h"                 // OrionldBadRequestData, ...
 #include "orionld/common/orionldState.h"                         // orionldState, orionldStateInit
 #include "orionld/common/SCOMPARE.h"                             // SCOMPARE
+#include "orionld/serviceRoutines/orionldBadVerb.h"              // orionldBadVerb
 #include "orionld/payloadCheck/pcheckUri.h"                      // pcheckUri
+#include "orionld/rest/orionldServiceInit.h"                     // orionldRestServiceV
+#include "orionld/rest/orionldServiceLookup.h"                   // orionldServiceLookup
 #include "orionld/rest/temporaryErrorPayloads.h"                 // Temporary Error Payloads
 #include "orionld/rest/OrionLdRestService.h"                     // ORIONLD_URIPARAM_LIMIT, ...
 #include "orionld/rest/orionldMhdConnectionInit.h"               // Own interface
@@ -146,31 +149,26 @@ static Verb verbGet(const char* method)
 //
 static void ipAddressAndPort(ConnectionInfo* ciP)
 {
-  char      ip[IP_LENGTH_MAX];
-  uint16_t  port = 0;
-
   const union MHD_ConnectionInfo* mciP = MHD_get_connection_info(ciP->connection, MHD_CONNECTION_INFO_CLIENT_ADDRESS);
 
   if (mciP != NULL)
   {
     struct sockaddr* addr = (struct sockaddr*) mciP->client_addr;
 
-    port = (addr->sa_data[0] << 8) + addr->sa_data[1];
-    snprintf(ip, sizeof(ip), "%d.%d.%d.%d",
+    ciP->port = (addr->sa_data[0] << 8) + addr->sa_data[1];
+    snprintf(clientIp, sizeof(clientIp), "%d.%d.%d.%d",
              addr->sa_data[2] & 0xFF,
              addr->sa_data[3] & 0xFF,
              addr->sa_data[4] & 0xFF,
              addr->sa_data[5] & 0xFF);
-    snprintf(clientIp, sizeof(clientIp), "%s", ip);
   }
   else
   {
-    port = 0;
-    snprintf(ip, sizeof(ip), "IP unknown");
+    ciP->port = 0;
+    strncpy(clientIp, "IP unknown", sizeof(clientIp));
   }
-
-  ciP->port = port;
 }
+
 
 
 // -----------------------------------------------------------------------------
@@ -440,15 +438,28 @@ static MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const
 
 // -----------------------------------------------------------------------------
 //
-// uriArgumentsPresent - necessary for functest "ngsild_uri_params_in_orionldState.test"
+// serviceLookup - lookup the Service
 //
-static void uriArgumentsPresent(void)
+// orionldMhdConnectionInit guarantees that a valid verb is used. I.e. POST, GET, DELETE or PATCH
+// orionldServiceLookup makes sure the URL supprts the verb
+//
+static OrionLdRestService* serviceLookup(ConnectionInfo* ciP)
 {
-  LM_T(LmtUriParams, ("orionldUriArguments: id:        '%s'", orionldState.uriParams.id));
-  LM_T(LmtUriParams, ("orionldUriArguments: type:      '%s'", orionldState.uriParams.type));
-  LM_T(LmtUriParams, ("orionldUriArguments: idPattern: '%s'", orionldState.uriParams.idPattern));
-  LM_T(LmtUriParams, ("orionldUriArguments: attrs:     '%s'", orionldState.uriParams.attrs));
-  LM_T(LmtUriParams, ("orionldUriArguments: options:   '%s'", orionldState.uriParams.options));
+  OrionLdRestService* serviceP;
+
+  serviceP = orionldServiceLookup(&orionldRestServiceV[orionldState.verb]);
+  if (serviceP == NULL)
+  {
+    if (orionldBadVerb(ciP) == true)
+      orionldState.httpStatusCode = 405;  // SccBadVerb
+    else
+    {
+      orionldErrorResponseCreate(OrionldInvalidRequest, "Service Not Found", orionldState.urlPath);
+      orionldState.httpStatusCode = 404;
+    }
+  }
+
+  return serviceP;
 }
 
 
@@ -474,6 +485,7 @@ MHD_Result orionldMhdConnectionInit
   //
   LM_K(("------------------------- Servicing NGSI-LD request %03d: %s %s --------------------------", requestNo, method, url));
 
+
   //
   // 1. Prepare connectionInfo
   //
@@ -485,22 +497,27 @@ MHD_Result orionldMhdConnectionInit
   // Remember ciP for consequent connection callbacks from MHD
   *con_cls = ciP;
 
+  // The 'connection', as given by MHD is very important. No responses can be sent without it
+  ciP->connection = connection;
+
+  // IP Address and port of caller
+  ipAddressAndPort(ciP);
+
+
   //
-  // 1. Prepare orionldState
+  // 2. Prepare orionldState
   //
   orionldStateInit();
   orionldState.ciP = ciP;
 
-
-  // The 'connection', as given by MHD is very important. No responses can be sent without it
-  ciP->connection = connection;
+  // By default, no whitespace in output
+  orionldState.kjsonP->spacesPerIndent   = 0;
+  orionldState.kjsonP->nlString          = (char*) "";
+  orionldState.kjsonP->stringBeforeColon = (char*) "";
+  orionldState.kjsonP->stringAfterColon  = (char*) "";
 
   // Flagging all as OK - errors will be flagged when occurring
   orionldState.httpStatusCode = 200;
-
-
-  // IP Address and port of caller
-  ipAddressAndPort(ciP);
 
   // Keep a pointer to the method/verb
   orionldState.verbString = (char*) method;
@@ -525,7 +542,7 @@ MHD_Result orionldMhdConnectionInit
     if (orionldState.urlPath[urlLen - 1] == '/')
     {
       LM_T(LmtUriPath, ("URI PATH ends in DOUBLE SLASH - flagging error"));
-      orionldState.responsePayload = (char*) doubleSlashPayload;
+      orionldState.responsePayload = (char*) doubleSlashPayload;  // FIXME: use orionldErrorResponseCreate - after setting prettyPrint
       orionldState.httpStatusCode  = 400;
       return MHD_YES;
     }
@@ -537,57 +554,22 @@ MHD_Result orionldMhdConnectionInit
   if (orionldState.verb == NOVERB)
   {
     LM_T(LmtVerb, ("NOVERB for (%s)", method));
-    orionldErrorResponseCreate(OrionldBadRequestData, "not a valid verb", method);
+    orionldErrorResponseCreate(OrionldBadRequestData, "not a valid verb", method);  // FIXME: do this after setting prettyPrint
     orionldState.httpStatusCode   = 400;
     return MHD_YES;
   }
 
-  // 4. Get HTTP Headers
-  MHD_get_connection_values(connection, MHD_HEADER_KIND, httpHeaderGet, ciP);  // FIXME: implement orionldHttpHeaderGet in C !!!
+  // 4. GET Service Pointer from VERB and URL-PATH
+  LM_TMP(("URI: Verb: %s", method));
+  LM_TMP(("URI: URL:  %s", url));
+  orionldState.serviceP = serviceLookup(ciP);
 
-  if ((orionldState.ngsildContent == true) && (orionldState.linkHttpHeaderPresent == true))
-  {
-    orionldErrorResponseCreate(OrionldBadRequestData, "invalid combination of HTTP headers Content-Type and Link", "Content-Type is 'application/ld+json' AND Link header is present - not allowed");
-    orionldState.httpStatusCode  = 400;
+  if (orionldState.serviceP == NULL)  // 405 or 404 - no need to continue - prettyPrint not possible here
     return MHD_YES;
-  }
 
-  // 5. Check payload too big
-  if (ciP->httpHeaders.contentLength > 2000000)
-  {
-    orionldState.responsePayload = (char*) payloadTooLargePayload;
-    orionldState.httpStatusCode  = 400;
-    return MHD_YES;
-  }
+  LM_TMP(("URI: serviceP at %p", orionldState.serviceP));
 
-  // 6. Set servicePath: "/#" for GET requests, "/" for all others (ehmmm ... creation of subscriptions ...)
-  ciP->servicePathV.push_back((orionldState.verb == GET)? "/#" : "/");
-
-
-  // 7.  Check that GET/DELETE has no payload
-  // 8.  Check that POST/PUT/PATCH has payload
-  // 9.  Check validity of tenant
-  // 10. Check Accept header
-  // 11. Check URL path is OK
-
-  // 12. Check Content-Type is accepted
-  if ((orionldState.verb == POST) || (orionldState.verb == PATCH))
-  {
-    //
-    // FIXME: Instead of multiple strcmps, save an enum constant in ciP about content-type
-    //
-    if ((strcmp(ciP->httpHeaders.contentType.c_str(), "application/json") != 0) && (strcmp(ciP->httpHeaders.contentType.c_str(), "application/ld+json") != 0))
-    {
-      LM_W(("Bad Input (invalid Content-Type: '%s'", ciP->httpHeaders.contentType.c_str()));
-      orionldErrorResponseCreate(OrionldBadRequestData,
-                                 "unsupported format of payload",
-                                 "only application/json and application/ld+json are supported");
-      orionldState.httpStatusCode = 415;  // Unsupported Media Type
-      return MHD_YES;
-    }
-  }
-
-  // 13. Get URI parameters
+  // 5. GET URI params
   MHD_get_connection_values(connection, MHD_GET_ARGUMENT_KIND, uriArgumentGet, ciP);           // FIXME: To Be Removed!
   MHD_get_connection_values(connection, MHD_GET_ARGUMENT_KIND, orionldUriArgumentGet, NULL);
 
@@ -602,18 +584,16 @@ MHD_Result orionldMhdConnectionInit
     orionldState.kjsonP->stringBeforeColon = (char*) "";
     orionldState.kjsonP->stringAfterColon  = (char*) " ";
   }
-  else
-  {
-    // By default, no whitespace in output
-    orionldState.kjsonP->spacesPerIndent   = 0;
-    orionldState.kjsonP->nlString          = (char*) "";
-    orionldState.kjsonP->stringBeforeColon = (char*) "";
-    orionldState.kjsonP->stringAfterColon  = (char*) "";
-  }
 
-  if (orionldState.httpStatusCode != 200)
+
+  //
+  // NGSI-LD only accepts the verbs POST, GET, DELETE and PATCH
+  // If any other verb is used, even if a valid REST Verb, a generic error will be returned
+  //
+  if ((orionldState.verb != POST) && (orionldState.verb != GET) && (orionldState.verb != DELETE) && (orionldState.verb != PATCH))
   {
-    LM_W(("Bad Input (invalid URI parameter)"));
+    LM_T(LmtVerb, ("The verb '%s' is not supported by NGSI-LD", method));
+    orionldErrorResponseCreate(OrionldBadRequestData, "Verb not supported by NGSI-LD", method);
     orionldState.httpStatusCode = 400;
   }
 
@@ -634,26 +614,50 @@ MHD_Result orionldMhdConnectionInit
     orionldState.httpStatusCode = 400;
   }
 
-  if (lmTraceIsSet(LmtUriParams))
-    uriArgumentsPresent();
+  // Get HTTP Headers
+  MHD_get_connection_values(connection, MHD_HEADER_KIND, httpHeaderGet, ciP);  // FIXME: implement orionldHttpHeaderGet in C !!!
 
-  // 14. Check ...
-
-  // 20. Lookup the Service Routine
-  // 21. Not found?  Look it up in the badVerb vector
-  // 22. Not found still? Return error
-
-  //
-  // NGSI-LD only accepts the verbs POST, GET, DELETE and PATCH
-  // If any other verb is used, even if a valid REST Verb, a generic error will be returned
-  //
-  if ((orionldState.verb != POST) && (orionldState.verb != GET) && (orionldState.verb != DELETE) && (orionldState.verb != PATCH))
+  if ((orionldState.ngsildContent == true) && (orionldState.linkHttpHeaderPresent == true))
   {
-    LM_T(LmtVerb, ("The verb '%s' is not supported by NGSI-LD", method));
-    orionldErrorResponseCreate(OrionldBadRequestData, "Verb not supported by NGSI-LD", method);
-    orionldState.httpStatusCode = 400;
+    orionldErrorResponseCreate(OrionldBadRequestData, "invalid combination of HTTP headers Content-Type and Link", "Content-Type is 'application/ld+json' AND Link header is present - not allowed");
+    orionldState.httpStatusCode  = 400;
+    return MHD_YES;
   }
 
-  LM_T(LmtMhd, ("Connection Init DONE"));
+  // Check payload too big
+  if (ciP->httpHeaders.contentLength > 2000000)
+  {
+    orionldState.responsePayload = (char*) payloadTooLargePayload;
+    orionldState.httpStatusCode  = 400;
+    return MHD_YES;
+  }
+
+  // Set servicePath: "/#" for GET requests, "/" for all others (ehmmm ... creation of subscriptions ...)
+  ciP->servicePathV.push_back((orionldState.verb == GET)? "/#" : "/");
+
+
+  // Check that GET/DELETE has no payload
+  // Check that POST/PUT/PATCH has payload
+  // Check validity of tenant
+  // Check Accept header
+  // Check URL path is OK
+
+  // Check Content-Type is accepted
+  if ((orionldState.verb == POST) || (orionldState.verb == PATCH))
+  {
+    //
+    // FIXME: Instead of multiple strcmps, save an enum constant in ciP about content-type
+    //
+    if ((strcmp(ciP->httpHeaders.contentType.c_str(), "application/json") != 0) && (strcmp(ciP->httpHeaders.contentType.c_str(), "application/ld+json") != 0))
+    {
+      LM_W(("Bad Input (invalid Content-Type: '%s'", ciP->httpHeaders.contentType.c_str()));
+      orionldErrorResponseCreate(OrionldBadRequestData,
+                                 "unsupported format of payload",
+                                 "only application/json and application/ld+json are supported");
+      orionldState.httpStatusCode = 415;  // Unsupported Media Type
+      return MHD_YES;
+    }
+  }
+
   return MHD_YES;
 }

--- a/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
@@ -767,7 +767,7 @@ MHD_Result orionldMhdConnectionTreat(ConnectionInfo* ciP)
   //
   if (ciP->payload != NULL)
   {
-    if ((orionldState.serviceP->uriParams & ORIONLD_SERVICE_OPTION_CLONE_PAYLOAD) == 0)
+    if ((orionldState.serviceP->options & ORIONLD_SERVICE_OPTION_CLONE_PAYLOAD) == 0)
       orionldState.requestPayload = ciP->payload;
     else
       orionldState.requestPayload = kaStrdup(&orionldState.kalloc, ciP->payload);

--- a/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
@@ -767,7 +767,7 @@ MHD_Result orionldMhdConnectionTreat(ConnectionInfo* ciP)
   //
   if (ciP->payload != NULL)
   {
-    if ((orionldState.serviceP->uriParams & ORIONLD_SERVICE_OPTION_CLONE_PAYLOAD) == ORIONLD_SERVICE_OPTION_CLONE_PAYLOAD)
+    if ((orionldState.serviceP->uriParams & ORIONLD_SERVICE_OPTION_CLONE_PAYLOAD) == 0)
       orionldState.requestPayload = ciP->payload;
     else
       orionldState.requestPayload = kaStrdup(&orionldState.kalloc, ciP->payload);

--- a/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
@@ -765,11 +765,9 @@ MHD_Result orionldMhdConnectionTreat(ConnectionInfo* ciP)
   // Save a copy of the incoming payload before it is destroyed during kjParse AND
   // parse the payload, and check for empty payload, also, find @context in payload and check it's OK
   //
-  // FIXME - Only use kaStrdup for "some" requests - right now only for "PATCH /ngsi-ld/v1/entities/*/attrs/*"
-  //
   if (ciP->payload != NULL)
   {
-    if (orionldState.serviceP->serviceRoutine != orionldPatchAttribute)  // FIXME: use ORIONLD_SERVICE_OPTION_CLONE_PAYLOAD instead
+    if ((orionldState.serviceP->uriParams & ORIONLD_SERVICE_OPTION_CLONE_PAYLOAD) == ORIONLD_SERVICE_OPTION_CLONE_PAYLOAD)
       orionldState.requestPayload = ciP->payload;
     else
       orionldState.requestPayload = kaStrdup(&orionldState.kalloc, ciP->payload);

--- a/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
@@ -66,10 +66,9 @@ extern "C"
 #include "orionld/context/orionldContextFromUrl.h"               // orionldContextFromUrl
 #include "orionld/context/orionldContextFromTree.h"              // orionldContextFromTree
 #include "orionld/context/orionldContextUrlGenerate.h"           // orionldContextUrlGenerate
-#include "orionld/serviceRoutines/orionldBadVerb.h"              // orionldBadVerb
+#include "orionld/serviceRoutines/orionldPatchAttribute.h"       // orionldPatchAttribute
+#include "orionld/rest/OrionLdRestService.h"                     // ORIONLD_URIPARAM_LIMIT, ...
 #include "orionld/rest/uriParamName.h"                           // uriParamName
-#include "orionld/rest/orionldServiceInit.h"                     // orionldRestServiceV
-#include "orionld/rest/orionldServiceLookup.h"                   // orionldServiceLookup
 #include "orionld/rest/temporaryErrorPayloads.h"                 // Temporary Error Payloads
 #include "orionld/rest/orionldMhdConnectionTreat.h"              // Own Interface
 
@@ -238,34 +237,6 @@ static bool acceptHeaderExtractAndCheck(ConnectionInfo* ciP)
     ciP->outMimeType = JSONLD;
 
   return true;
-}
-
-
-
-// -----------------------------------------------------------------------------
-//
-// serviceLookup - lookup the Service
-//
-// orionldMhdConnectionInit guarantees that a valid verb is used. I.e. POST, GET, DELETE or PATCH
-// orionldServiceLookup makes sure the URL supprts the verb
-//
-static OrionLdRestService* serviceLookup(ConnectionInfo* ciP)
-{
-  OrionLdRestService* serviceP;
-
-  serviceP = orionldServiceLookup(&orionldRestServiceV[ciP->verb]);
-  if (serviceP == NULL)
-  {
-    if (orionldBadVerb(ciP) == true)
-      orionldState.httpStatusCode = SccBadVerb;
-    else
-    {
-      orionldErrorResponseCreate(OrionldInvalidRequest, "Service Not Found", orionldState.urlPath);
-      orionldState.httpStatusCode = 404;
-    }
-  }
-
-  return serviceP;
 }
 
 
@@ -744,17 +715,9 @@ MHD_Result orionldMhdConnectionTreat(ConnectionInfo* ciP)
   LM_T(LmtMhd, ("Read all the payload - treating the request!"));
 
   //
-  // 01. Predetected Error?
+  // Predetected Error from orionldMhdConnectionInit?
   //
-  if (orionldState.httpStatusCode != SccOk)
-    goto respond;
-
-  //
-  // 02. Lookup the Service
-  //
-  // Invalid Verb is checked for in orionldMhdConnectionInit()
-  //
-  if ((orionldState.serviceP = serviceLookup(ciP)) == NULL)
+  if (orionldState.httpStatusCode != 200)
     goto respond;
 
   //
@@ -799,19 +762,21 @@ MHD_Result orionldMhdConnectionTreat(ConnectionInfo* ciP)
 
 
   //
-  // Save a copy of the incoming payload before it is destroyed during kjParse
+  // Save a copy of the incoming payload before it is destroyed during kjParse AND
+  // parse the payload, and check for empty payload, also, find @context in payload and check it's OK
   //
-  // FIXME - Only for "some" requests - right now only for "PATCH /ngsi-ld/v1/entities/*/attrs/*"
+  // FIXME - Only use kaStrdup for "some" requests - right now only for "PATCH /ngsi-ld/v1/entities/*/attrs/*"
   //
   if (ciP->payload != NULL)
-    orionldState.requestPayload = kaStrdup(&orionldState.kalloc, ciP->payload);
+  {
+    if (orionldState.serviceP->serviceRoutine != orionldPatchAttribute)  // FIXME: use ORIONLD_SERVICE_OPTION_CLONE_PAYLOAD instead
+      orionldState.requestPayload = ciP->payload;
+    else
+      orionldState.requestPayload = kaStrdup(&orionldState.kalloc, ciP->payload);
 
-  //
-  // 04. Parse the payload, and check for empty payload, also, find @context in payload and check it's OK
-  //
-  if ((ciP->payload != NULL) && (payloadParseAndExtractSpecialFields(ciP, &contextToBeCashed) == false))
-    goto respond;
-
+    if (payloadParseAndExtractSpecialFields(ciP, &contextToBeCashed) == false)
+      goto respond;
+  }
 
   //
   // 05. Check the Content-Type

--- a/src/lib/orionld/rest/orionldServiceInit.cpp
+++ b/src/lib/orionld/rest/orionldServiceInit.cpp
@@ -278,6 +278,7 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
   }
   else if (serviceP->serviceRoutine == orionldPatchAttribute)
   {
+    serviceP->uriParams |= ORIONLD_SERVICE_OPTION_CLONE_PAYLOAD;
   }
   else if (serviceP->serviceRoutine == orionldDeleteAttribute)
   {

--- a/src/lib/orionld/rest/orionldServiceInit.cpp
+++ b/src/lib/orionld/rest/orionldServiceInit.cpp
@@ -278,7 +278,7 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
   }
   else if (serviceP->serviceRoutine == orionldPatchAttribute)
   {
-    serviceP->uriParams |= ORIONLD_SERVICE_OPTION_CLONE_PAYLOAD;
+    serviceP->options |= ORIONLD_SERVICE_OPTION_CLONE_PAYLOAD;
   }
   else if (serviceP->serviceRoutine == orionldDeleteAttribute)
   {

--- a/src/lib/orionld/rest/orionldServiceInit.cpp
+++ b/src/lib/orionld/rest/orionldServiceInit.cpp
@@ -268,9 +268,12 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
     serviceP->uriParams |= ORIONLD_URIPARAM_OPTIONS;
     serviceP->uriParams |= ORIONLD_URIPARAM_ATTRS;
     serviceP->uriParams |= ORIONLD_URIPARAM_GEOMETRYPROPERTY;
+
+    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
   }
   else if (serviceP->serviceRoutine == orionldDeleteEntity)
   {
+    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
   }
   else if (serviceP->serviceRoutine == orionldPostEntity)
   {
@@ -284,6 +287,8 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
   {
     serviceP->uriParams |= ORIONLD_URIPARAM_DATASETID;
     serviceP->uriParams |= ORIONLD_URIPARAM_DELETEALL;
+
+    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
   }
   else if (serviceP->serviceRoutine == orionldPostRegistrations)
   {
@@ -319,9 +324,11 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
   }
   else if (serviceP->serviceRoutine == orionldPatchRegistration)
   {
+    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
   }
   else if (serviceP->serviceRoutine == orionldDeleteRegistration)
   {
+    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
   }
   else if (serviceP->serviceRoutine == orionldPostSubscriptions)
   {
@@ -347,9 +354,11 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
   }
   else if (serviceP->serviceRoutine == orionldPatchSubscription)
   {
+    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
   }
   else if (serviceP->serviceRoutine == orionldDeleteSubscription)
   {
+    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
   }
   else if (serviceP->serviceRoutine == orionldPostBatchCreate)
   {
@@ -379,23 +388,28 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
   else if (serviceP->serviceRoutine == orionldGetEntityTypes)
   {
     serviceP->uriParams |= ORIONLD_URIPARAM_DETAILS;
+
+    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
   }
   else if (serviceP->serviceRoutine == orionldGetVersion)
   {
     serviceP->options  = 0;  // Tenant is Ignored
 
     serviceP->options  = ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
+    serviceP->options |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
   }
   else if (serviceP->serviceRoutine == orionldGetTenants)
   {
-    serviceP->options  = 0;  // Tenant is Ignored
+    serviceP->options = 0;  // Tenant is Ignored
 
-    serviceP->options  |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
+    serviceP->options |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
+    serviceP->options |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
   }
   else if (serviceP->serviceRoutine == orionldGetDbIndexes)
   {
     serviceP->options  = 0;  // Tenant is Ignored
-    serviceP->options  |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
+    serviceP->options |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
+    serviceP->options |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
   }
 
   if (troe)  // CLI Option to turn on Temporal Representation of Entities

--- a/src/lib/orionld/serviceRoutines/orionldPatchAttribute.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchAttribute.cpp
@@ -38,9 +38,7 @@ extern "C"
 #include "rest/ConnectionInfo.h"                                 // ConnectionInfo
 #include "rest/HttpStatusCode.h"                                 // SccNotFound
 #include "ngsi/ContextElement.h"                                 // ContextElement
-
 #include "mongoBackend/mongoUpdateContext.h"                     // mongoUpdateContext
-#include "mongoBackend/mongoQueryContext.h"                      // mongoQueryContext
 
 #include "orionld/common/orionldErrorResponse.h"                 // orionldErrorResponseCreate
 #include "orionld/common/orionldState.h"                         // orionldState

--- a/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert-context_in_payload_data.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert-context_in_payload_data.test
@@ -208,7 +208,7 @@ Date: REGEX(.*)
 04. Batch Upsert, Content-Type is LD+JSON, @context in payload data but ALSO in HTTP link header
 ================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 233
+Content-Length: 219
 Content-Type: application/json
 Date: REGEX(.*)
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_content-type_jsonld_and_link_header_must_give_error.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_content-type_jsonld_and_link_header_must_give_error.test
@@ -70,7 +70,7 @@ echo
 01. Attempt to create an entity E1 with a context in HTTP header 'Link' AND Content-Type ==	application/ld+json + @content in payload
 =====================================================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 233
+Content-Length: 219
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -84,7 +84,7 @@ Date: REGEX(.*)
 02. Attempt to create two entities, using batch upsert, with a context in HTTP header 'Link' AND Content-Type == application/ld+json + @content in payload
 ==========================================================================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 233
+Content-Length: 219
 Content-Type: application/json
 Date: REGEX(.*)
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_content_type_and_context.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_content_type_and_context.test
@@ -217,7 +217,7 @@ Date: REGEX(.*)
 06. Content-Type: application/ld+json + context in HTTP Header - see error
 ==========================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 233
+Content-Length: 219
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -231,7 +231,7 @@ Date: REGEX(.*)
 07. Content-Type: application/ld+json + context in HTTP Header + context in payload - see error
 ===============================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 233
+Content-Length: 219
 Content-Type: application/json
 Date: REGEX(.*)
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_error_reject_entity_if_jsonld_link_header_is_provided_with_jsonld_payload.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_error_reject_entity_if_jsonld_link_header_is_provided_with_jsonld_payload.test
@@ -49,7 +49,7 @@ echo
 01. Attempt to create an entity with application/ld+json and with context in HTTP Link Header - see error
 =========================================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 233
+Content-Length: 219
 Content-Type: application/json
 Date: REGEX(.*)
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_http_status_code_406_for_mime_type_not_accepted.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_http_status_code_406_for_mime_type_not_accepted.test
@@ -54,7 +54,7 @@ echo
 01. Attempt to Create an NGSI-LD Entity with a Content-Type HTTP header of text/plain
 =====================================================================================
 HTTP/1.1 415 Unsupported Media Type
-Content-Length: 186
+Content-Length: 172
 Content-Type: application/json
 Date: REGEX(.*)
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_unsupported_content_type.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_unsupported_content_type.test
@@ -50,7 +50,7 @@ echo
 01. Attempt to send a payload with Content-Type image/gif - see error
 =====================================================================
 HTTP/1.1 415 Unsupported Media Type
-Content-Length: 186
+Content-Length: 172
 Content-Type: application/json
 Date: REGEX(.*)
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_uri_params_in_orionldState.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_uri_params_in_orionldState.test
@@ -31,13 +31,11 @@ brokerStart CB 31
 --SHELL--
 
 #
-# NOTE: never mind that the requests 01 and 03 fail - the URI Arg parsing is done lone before the
+# NOTE: never mind that the requests 01 and 03 fail - the URI Arg parsing is done long before the
 #       error is discovered by the broker and does not alter the test results.
 #
 # 01. GET Entity with four URI Params: id, type, idPattern, and attrs, all four with valid values
-# 02. Grep from log-file - see all four with their corresponding values
-# 03. GET Entity with 'id=' - no value for id
-# 04. Grep from log-file - see that ID is given but that its value is empty - the other three: null values
+# 02. GET Entity with 'id=' - no value for id
 #
 
 echo "01. GET Entity with four URI Params: id, type, idPattern, and attrs, all four with valid values"
@@ -48,23 +46,9 @@ echo
 
 
 
-echo "02. Grep from log-file - see all four with their corresponding values"
-echo "====================================================================="
-grep "orionldUriArguments" /tmp/orionld.log | awk -Fmsg= '{ print $2 }'
-echo
-echo
-
-
-echo "03. GET Entity with 'id=' - no value for id"
+echo "02. GET Entity with 'id=' - no value for id"
 echo "==========================================="
 orionCurl --url "/ngsi-ld/v1/entities?id="
-echo
-echo
-
-
-echo "04. Grep from log-file - see that ID is given but that its value is empty - the other three: null values"
-echo "========================================================================================================"
-grep "orionldUriArguments" /tmp/orionld.log | awk -Fmsg= '{ print $2 }'
 echo
 echo
 
@@ -84,16 +68,7 @@ Date: REGEX(.*)
 }
 
 
-02. Grep from log-file - see all four with their corresponding values
-=====================================================================
-orionldUriArguments: id:        'E1,E2,E3'
-orionldUriArguments: type:      'T1,T2,T3'
-orionldUriArguments: idPattern: 'E.*'
-orionldUriArguments: attrs:     'A1,A2,A3'
-orionldUriArguments: options:   '(null)'
-
-
-03. GET Entity with 'id=' - no value for id
+02. GET Entity with 'id=' - no value for id
 ===========================================
 HTTP/1.1 400 Bad Request
 Content-Length: 183
@@ -105,20 +80,6 @@ Date: REGEX(.*)
     "title": "Too broad query",
     "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
 }
-
-
-04. Grep from log-file - see that ID is given but that its value is empty - the other three: null values
-========================================================================================================
-orionldUriArguments: id:        'E1,E2,E3'
-orionldUriArguments: type:      'T1,T2,T3'
-orionldUriArguments: idPattern: 'E.*'
-orionldUriArguments: attrs:     'A1,A2,A3'
-orionldUriArguments: options:   '(null)'
-orionldUriArguments: id:        ''
-orionldUriArguments: type:      '(null)'
-orionldUriArguments: idPattern: '(null)'
-orionldUriArguments: attrs:     '(null)'
-orionldUriArguments: options:   '(null)'
 
 
 --TEARDOWN--


### PR DESCRIPTION
Made LD Entity Retrieval a little faster by:
* avoiding a call to 'APIv2 URI param extraction'
* stopping to depend on ConnectionInfo

Also all other LD requests that don't use mongoBackend now avoid the  'APIv2 URI param extraction'