### PR TITLE
task/no-context-needed-for-some-operations

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -4,3 +4,4 @@
 * Issue  #280   Much faster response rendering function, giving a performance bump
 * Issue  #280   GeoJSON formated response for GET /entities and GET /entities/{EID}, if Accept header set to "application/geo+json"
 * Issue  #280   GeoJSON formated notifications, if notification:endpoint:accept is set to "application/geo+json"
+* Issue  #280   Some requests don't use the @context - e.g. DELETE /etntities/{entityId} - those requests now ignore the context

--- a/src/lib/orionld/rest/OrionLdRestService.h
+++ b/src/lib/orionld/rest/OrionLdRestService.h
@@ -103,6 +103,7 @@ typedef struct OrionLdRestServiceSimplifiedVector
 #define ORIONLD_SERVICE_OPTION_MAKE_SURE_TENANT_EXISTS               (1 << 3)
 #define ORIONLD_SERVICE_OPTION_CLONE_PAYLOAD                         (1 << 4)
 #define ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS                      (1 << 5)
+#define ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED                     (1 << 6)
 
 
 

--- a/src/lib/orionld/rest/orionldServiceInit.cpp
+++ b/src/lib/orionld/rest/orionldServiceInit.cpp
@@ -274,6 +274,7 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
   else if (serviceP->serviceRoutine == orionldDeleteEntity)
   {
     serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
+    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED;
   }
   else if (serviceP->serviceRoutine == orionldPostEntity)
   {
@@ -329,6 +330,7 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
   else if (serviceP->serviceRoutine == orionldDeleteRegistration)
   {
     serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
+    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED;
   }
   else if (serviceP->serviceRoutine == orionldPostSubscriptions)
   {
@@ -359,6 +361,7 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
   else if (serviceP->serviceRoutine == orionldDeleteSubscription)
   {
     serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
+    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED;
   }
   else if (serviceP->serviceRoutine == orionldPostBatchCreate)
   {
@@ -376,7 +379,8 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
   }
   else if (serviceP->serviceRoutine == orionldPostBatchDelete)
   {
-    serviceP->options  |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
+    serviceP->options   |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
+    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED;
   }
   else if (serviceP->serviceRoutine == orionldPostQuery)
   {
@@ -397,6 +401,7 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
 
     serviceP->options  = ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
     serviceP->options |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
+    serviceP->options |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED;
   }
   else if (serviceP->serviceRoutine == orionldGetTenants)
   {
@@ -404,12 +409,14 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
 
     serviceP->options |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
     serviceP->options |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
+    serviceP->options |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED;
   }
   else if (serviceP->serviceRoutine == orionldGetDbIndexes)
   {
     serviceP->options  = 0;  // Tenant is Ignored
     serviceP->options |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
     serviceP->options |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
+    serviceP->options |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED;
   }
 
   if (troe)  // CLI Option to turn on Temporal Representation of Entities

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_delete_with_non-existing-context.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_delete_with_non-existing-context.test
@@ -1,0 +1,81 @@
+# Copyright 2021 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Entity Deletion with a context that doesn't exist
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+brokerStart CB 212-249
+
+--SHELL--
+
+#
+# 01. Create Entity E1
+# 02. Attempt to delete E1 using a context that doesn't exist
+#
+
+
+echo "01. Create Entity E1"
+echo "===================="
+payload='{
+  "id": "urn:ngsi-ld:entities:E1",
+  "type": "A",
+  "name": {
+    "type": "Property",
+    "value": "1"
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+
+echo "02. Attempt to delete E1 using a context that doesn't exist"
+echo "==========================================================="
+orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:entities:E1' -X DELETE -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/error/noContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+echo
+echo
+
+
+--REGEXPECT--
+01. Create Entity E1
+====================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:entities:E1
+Date: REGEX(.*)
+
+
+
+02. Attempt to delete E1 using a context that doesn't exist
+===========================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
Some requests don't use the @context - e.g. `DELETE /entities/{entityId}` - those requests now ignore the context