### PR TITLE
Improvements for TRoE

### DIFF
--- a/src/lib/orionld/common/CMakeLists.txt
+++ b/src/lib/orionld/common/CMakeLists.txt
@@ -51,6 +51,7 @@ SET (SOURCES
     typeCheckForNonExistingEntities.cpp
     entityIdAndTypeGet.cpp
     qAliasCompact.cpp
+    orionldTenantInit.cpp
     orionldTenantLookup.cpp
     orionldTenantCreate.cpp
     attributeUpdated.cpp

--- a/src/lib/orionld/common/orionldState.cpp
+++ b/src/lib/orionld/common/orionldState.cpp
@@ -23,6 +23,7 @@
 * Author: Ken Zangelin
 */
 #include <string.h>                                              // strlen
+#include <semaphore.h>                                           // sem_t
 
 extern "C"
 {
@@ -94,6 +95,7 @@ unsigned int      tenants                  = 0;
 OrionldGeoIndex*  geoIndexList             = NULL;
 OrionldPhase      orionldPhase             = OrionldPhaseStartup;
 bool              orionldStartup           = true;
+sem_t             tenantSem;
 
 
 //

--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -26,6 +26,7 @@
 * Author: Ken Zangelin
 */
 #include <time.h>                                                // struct timespec
+#include <semaphore.h>                                           // sem_t
 
 #include "orionld/db/dbDriver.h"                                 // database driver header
 #include "orionld/db/dbConfiguration.h"                          // DB_DRIVER_MONGOC
@@ -284,6 +285,7 @@ typedef struct OrionldConnectionState
   KjNode*                 duplicateArray;
   KjNode*                 troeIgnoreV[20];
   unsigned int            troeIgnoreIx;
+  KjNode*                 batchEntities;
 
   //
   // GeoJSON
@@ -376,6 +378,7 @@ extern OrionldGeoIndex*  geoIndexList;
 extern OrionldPhase      orionldPhase;
 extern bool              orionldStartup;           // For now, only used inside sub-cache routines
 extern bool              idIndex;                  // From orionld.cpp
+extern sem_t             tenantSem;
 
 
 

--- a/src/lib/orionld/common/orionldTenantCreate.cpp
+++ b/src/lib/orionld/common/orionldTenantCreate.cpp
@@ -44,6 +44,8 @@ extern "C"
 //
 void orionldTenantCreate(char* tenant)
 {
+  LM_TMP(("TROE: New tenant: '%s'", tenant));
+
   if (tenants >= K_VEC_SIZE(tenantV))
     LM_X(1, ("Too many tenants in the system - increase the size of tenantV and recompile!"));
 

--- a/src/lib/orionld/common/orionldTenantInit.cpp
+++ b/src/lib/orionld/common/orionldTenantInit.cpp
@@ -1,6 +1,6 @@
 /*
 *
-* Copyright 2019 FIWARE Foundation e.V.
+* Copyright 2021 FIWARE Foundation e.V.
 *
 * This file is part of Orion-LD Context Broker.
 *
@@ -22,20 +22,21 @@
 *
 * Author: Ken Zangelin
 */
-#include <unistd.h>                                              // NULL
-#include <semaphore.h>                                           // sem_t
+#include <semaphore.h>                                           // sem_init
 
-#include "orionld/context/OrionldContext.h"                      // OrionldContext
-#include "orionld/context/orionldContextCache.h"                 // Own interface
+#include "logMsg/logMsg.h"                                       // LM_*
+#include "logMsg/traceLevels.h"                                  // Lmt*
+
+#include "orionld/common/orionldState.h"                         // tenantSem
 
 
 
 // -----------------------------------------------------------------------------
 //
-// Context Cache Internals
+// orionldTenantInit
 //
-sem_t             orionldContextCacheSem;
-OrionldContext*   orionldContextCacheArray[100];  // When 100 is not enough, a realloc is done (automatically)
-OrionldContext**  orionldContextCache         = orionldContextCacheArray;
-int               orionldContextCacheSlots    = 100;
-int               orionldContextCacheSlotIx   = 0;
+void orionldTenantInit(void)
+{
+  if (sem_init(&tenantSem, 0, 1) == -1)
+    LM_X(1, ("Runtime Error (error initializing semaphore for orionld tenants: %s)", strerror(errno)));
+}

--- a/src/lib/orionld/common/orionldTenantInit.h
+++ b/src/lib/orionld/common/orionldTenantInit.h
@@ -1,6 +1,9 @@
+#ifndef SRC_LIB_ORIONLD_COMMON_ORIONLDTENANTINIT_H_
+#define SRC_LIB_ORIONLD_COMMON_ORIONLDTENANTINIT_H_
+
 /*
 *
-* Copyright 2019 FIWARE Foundation e.V.
+* Copyright 2021 FIWARE Foundation e.V.
 *
 * This file is part of Orion-LD Context Broker.
 *
@@ -22,20 +25,13 @@
 *
 * Author: Ken Zangelin
 */
-#include <unistd.h>                                              // NULL
-#include <semaphore.h>                                           // sem_t
-
-#include "orionld/context/OrionldContext.h"                      // OrionldContext
-#include "orionld/context/orionldContextCache.h"                 // Own interface
 
 
 
 // -----------------------------------------------------------------------------
 //
-// Context Cache Internals
+// orionldTenantInit
 //
-sem_t             orionldContextCacheSem;
-OrionldContext*   orionldContextCacheArray[100];  // When 100 is not enough, a realloc is done (automatically)
-OrionldContext**  orionldContextCache         = orionldContextCacheArray;
-int               orionldContextCacheSlots    = 100;
-int               orionldContextCacheSlotIx   = 0;
+extern void orionldTenantInit(void);
+
+#endif  // SRC_LIB_ORIONLD_COMMON_ORIONLDTENANTINIT_H_

--- a/src/lib/orionld/rest/orionldServiceInit.cpp
+++ b/src/lib/orionld/rest/orionldServiceInit.cpp
@@ -46,6 +46,7 @@ extern "C"
 
 #include "orionld/common/orionldState.h"                             // orionldState
 #include "orionld/common/urlCheck.h"                                 // urlCheck
+#include "orionld/common/orionldTenantInit.h"                        // orionldTenantInit
 #include "orionld/context/orionldCoreContext.h"                      // orionldCoreContext, ORIONLD_CORE_CONTEXT_URL
 #include "orionld/context/orionldContextInit.h"                      // orionldContextInit
 #include "orionld/rest/OrionLdRestService.h"                         // OrionLdRestService, ORION_LD_SERVICE_PREFIX_LEN
@@ -78,16 +79,16 @@ extern "C"
 #include "orionld/serviceRoutines/orionldPatchSubscription.h"        // orionldPatchSubscription
 #include "orionld/serviceRoutines/orionldDeleteSubscription.h"       // orionldDeleteSubscription
 #include "orionld/serviceRoutines/orionldGetEntityTypes.h"           // orionldGetEntityTypes
-#include "orionld/troe/troePostEntities.h"                   // troePostEntities
-#include "orionld/troe/troePostBatchDelete.h"                // troePostBatchDelete
-#include "orionld/troe/troeDeleteAttribute.h"                // troeDeleteAttribute
-#include "orionld/troe/troeDeleteEntity.h"                   // troeDeleteEntity
-#include "orionld/troe/troePatchAttribute.h"                 // troePatchAttribute
-#include "orionld/troe/troePatchEntity.h"                    // troePatchEntity
-#include "orionld/troe/troePostBatchCreate.h"                // troePostBatchCreate
-#include "orionld/troe/troePostBatchUpsert.h"                // troePostBatchUpsert
-#include "orionld/troe/troePostBatchUpdate.h"                // troePostBatchUpdate
-#include "orionld/troe/troePostEntity.h"                     // troePostEntity
+#include "orionld/troe/troePostEntities.h"                           // troePostEntities
+#include "orionld/troe/troePostBatchDelete.h"                        // troePostBatchDelete
+#include "orionld/troe/troeDeleteAttribute.h"                        // troeDeleteAttribute
+#include "orionld/troe/troeDeleteEntity.h"                           // troeDeleteEntity
+#include "orionld/troe/troePatchAttribute.h"                         // troePatchAttribute
+#include "orionld/troe/troePatchEntity.h"                            // troePatchEntity
+#include "orionld/troe/troePostBatchCreate.h"                        // troePostBatchCreate
+#include "orionld/troe/troePostBatchUpsert.h"                        // troePostBatchUpsert
+#include "orionld/troe/troePostBatchUpdate.h"                        // troePostBatchUpdate
+#include "orionld/troe/troePostEntity.h"                             // troePostEntity
 #include "orionld/mqtt/mqttConnectionInit.h"                         // mqttConnectionInit
 #include "orionld/rest/orionldMhdConnection.h"                       // Own Interface
 
@@ -523,4 +524,9 @@ void orionldServiceInit(OrionLdRestServiceSimplifiedVector* restServiceVV, int v
   // Initialize NQTT notifications
   //
   mqttConnectionInit();
+
+  //
+  // Initialize Tenant list
+  //
+  orionldTenantInit();
 }

--- a/src/lib/orionld/serviceRoutines/orionldPostBatchUpsert.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostBatchUpsert.cpp
@@ -179,6 +179,8 @@ bool orionldPostBatchUpsert(ConnectionInfo* ciP)
   //
   KjNode* idTypeAndCreDateFromDb = dbEntityListLookupWithIdTypeCreDate(idArray, false);
 
+  orionldState.batchEntities = idTypeAndCreDateFromDb;  // So that TRoE knows what entities existed prior to the upsert call
+  LM_TMP(("orionldState.batchEntities at %p", orionldState.batchEntities));
   //
   // 03. Creation Date from DB entities, and type-check
   //

--- a/src/lib/orionld/troe/pgConnectionGet.cpp
+++ b/src/lib/orionld/troe/pgConnectionGet.cpp
@@ -56,8 +56,6 @@
 //
 PGconn* pgConnectionGet(const char* db)
 {
-  LM_TMP(("PGPOOL: connect to db '%s'", db));
-
   // Empty tenant => use default db name
   if ((db != NULL) && (*db == 0))
     db = dbName;
@@ -79,23 +77,36 @@ PGconn* pgConnectionGet(const char* db)
   PGconn*  connectionP;
   snprintf(port, sizeof(port), "%d", troePort);
 
-  if (db != NULL)
-  {
-    const char*  keywords[]   = { "host",   "port",   "user",   "password",  "dbname", NULL };
-    const char*  values[]     = { troeHost, port,     troeUser, troePwd,     db,       NULL };
+  int attemptNo   = 0;
+  int maxAttempts = 100;
 
-    connectionP  = PQconnectdbParams(keywords, values, 0);  // 0: no expansion of dbname - see https://www.postgresql.org/docs/12/libpq-connect.html
-  }
-  else
+  while (attemptNo < maxAttempts)
   {
-    const char*  keywords[]   = { "host",   "port",   "user",   "password",  NULL };
-    const char*  values[]     = { troeHost, port,     troeUser, troePwd,     NULL };
+    if (db != NULL)
+    {
+      const char*  keywords[]   = { "host",   "port",   "user",   "password",  "dbname", NULL };
+      const char*  values[]     = { troeHost, port,     troeUser, troePwd,     db,       NULL };
 
-    connectionP  = PQconnectdbParams(keywords, values, 0);  // 0: no expansion of dbname - see https://www.postgresql.org/docs/12/libpq-connect.html
+      connectionP  = PQconnectdbParams(keywords, values, 0);  // 0: no expansion of dbname - see https://www.postgresql.org/docs/12/libpq-connect.html
+    }
+    else
+    {
+      const char*  keywords[]   = { "host",   "port",   "user",   "password",  NULL };
+      const char*  values[]     = { troeHost, port,     troeUser, troePwd,     NULL };
+
+      connectionP  = PQconnectdbParams(keywords, values, 0);  // 0: no expansion of dbname - see https://www.postgresql.org/docs/12/libpq-connect.html
+    }
+
+    ++attemptNo;
+    if (connectionP != NULL)
+      break;
+
+    usleep(100000);  // Sleep 0.1 seconds before we try again
   }
 
   if (connectionP == NULL)
     LM_RE(NULL, ("Database Error (unable  to connect to postgres('%s', %d, '%s', '%s', '%s')", troeHost, troePort, troeUser, troePwd, db));
 
+  LM_TMP(("TROE: connected to db '%s', at 0x%x (on connection attempt %d)", db, connectionP, attemptNo));
   return connectionP;
 }

--- a/src/lib/orionld/troe/pgConnectionRelease.cpp
+++ b/src/lib/orionld/troe/pgConnectionRelease.cpp
@@ -22,7 +22,10 @@
 *
 * Author: Ken Zangelin
 */
-#include <postgresql/libpq-fe.h>                                 // PGconn, PQfinish
+#include <postgresql/libpq-fe.h>                               // PGconn, PQfinish
+
+#include "logMsg/logMsg.h"                                     // LM_*
+#include "logMsg/traceLevels.h"                                // Lmt*
 
 
 
@@ -32,5 +35,6 @@
 //
 void pgConnectionRelease(PGconn* connectionP)
 {
+  LM_TMP(("TROE: disconnecting the connection at 0x%x", connectionP));
   PQfinish(connectionP);
 }

--- a/src/lib/orionld/troe/pgDatabaseCreate.cpp
+++ b/src/lib/orionld/troe/pgDatabaseCreate.cpp
@@ -50,6 +50,7 @@ bool pgDatabaseCreate(PGconn* connectionP, const char* dbName)
   // Create the database (using an already established connection to the "NULL" database)
   //
   snprintf(sql, sizeof(sql), "CREATE DATABASE %s", dbName);
+  LM_TMP(("TROE: SQL to create database: '%s'", sql));
   res = PQexec(connectionP, sql);
   if (res == NULL)
     LM_RE(false, ("Database Error (PQexec(BEGIN): %s)", PQresStatus(PQresultStatus(res))));

--- a/src/lib/orionld/troe/pgDatabasePrepare.cpp
+++ b/src/lib/orionld/troe/pgDatabasePrepare.cpp
@@ -42,7 +42,7 @@
 //
 bool pgDatabasePrepare(const char* dbName)
 {
-  LM_TMP(("PGPOOL: new tenant '%s'", dbName));
+  LM_TMP(("TROE: new tenant '%s'", dbName));
 
   // Connect to the "NULL" database
   PGconn*         connectionP = pgConnectionGet(NULL);
@@ -51,25 +51,25 @@ bool pgDatabasePrepare(const char* dbName)
   if (status != CONNECTION_OK)
     LM_RE(false, ("Database Error (unable to connect to postgres - connection / status: %p / %d)", connectionP, status));
 
-  LM_TMP(("PGPOOL: creating db '%s'", dbName));
+  LM_TMP(("TROE: creating db '%s'", dbName));
 
   //
   // For now, we just create the Postgres database for the default tenant
   // This will fail if the database already exists - that's OK
-  LM_TMP(("PGPOOL: creating db '%s'", dbName));
+  LM_TMP(("TROE: creating db '%s'", dbName));
   if (pgDatabaseCreate(connectionP, dbName) == false)  // FIXME: return the connection to the new DB ?
   {
-    LM_TMP(("PGPOOL: database '%s' seems to exist already", dbName));
+    LM_TMP(("TROE: database '%s' seems to exist already", dbName));
     pgConnectionRelease(connectionP);
     return true;
   }
-  LM_TMP(("PGPOOL: db '%s' has been created", dbName));
+  LM_TMP(("TROE: db '%s' has been created", dbName));
 
   // Disconnect from the "NULL" DB
   pgConnectionRelease(connectionP);
 
   // Connect to the newly created database
-  LM_TMP(("PGPOOL: connecting to db '%s' to create the tables", dbName));
+  LM_TMP(("TROE: connecting to db '%s' to create the tables", dbName));
 
   connectionP = pgConnectionGet(dbName);
   if (connectionP == NULL)
@@ -78,7 +78,7 @@ bool pgDatabasePrepare(const char* dbName)
   bool r;
   if ((r = pgDatabaseTableCreateAll(connectionP)) == false)
     LM_E(("Database Error (error creating postgres database tables)"));
-  LM_TMP(("PGPOOL: created tables for db '%s'", dbName));
+  LM_TMP(("TROE: created tables for db '%s'", dbName));
 
   pgConnectionRelease(connectionP);
 

--- a/src/lib/orionld/troe/pgEntityTreat.cpp
+++ b/src/lib/orionld/troe/pgEntityTreat.cpp
@@ -49,7 +49,7 @@ extern "C"
 //
 // pgEntityTreat -
 //
-bool pgEntityTreat(PGconn* connectionP, KjNode* entityP, char* id, char* type, TroeMode opMode)
+bool pgEntityTreat(PGconn* connectionP, KjNode* entityP, char* id, char* type, TroeMode entityOpMode, TroeMode attributeOpMode)
 {
   if (id == NULL)  // Find the entity id in the entity tree
   {
@@ -74,9 +74,9 @@ bool pgEntityTreat(PGconn* connectionP, KjNode* entityP, char* id, char* type, T
     kjChildRemove(entityP, nodeP);
   }
 
-  if ((opMode == TROE_ENTITY_CREATE) || (opMode == TROE_ENTITY_REPLACE))
+  if ((entityOpMode == TROE_ENTITY_CREATE) || (entityOpMode == TROE_ENTITY_REPLACE))
   {
-    const char* opModeString = (opMode == TROE_ENTITY_CREATE)? "Create" : "Replace";
+    const char* opModeString = (entityOpMode == TROE_ENTITY_CREATE)? "Create" : "Replace";
     char        entityInstance[80];
 
     uuidGenerate(entityInstance, sizeof(entityInstance), true);
@@ -89,8 +89,7 @@ bool pgEntityTreat(PGconn* connectionP, KjNode* entityP, char* id, char* type, T
   {
     if (attrP->type == KjObject)
     {
-      LM_TMP(("APPA: Calling pgAttributeTreat with opMode %s", troeMode(opMode)));
-      if (pgAttributeTreat(connectionP, attrP, id, opMode) == false)
+      if (pgAttributeTreat(connectionP, attrP, id, attributeOpMode) == false)
         LM_RE(false, ("pgAttributeTreat failed for attribute '%s'", attrP->name));
     }
     else if (attrP->type == KjArray)
@@ -99,7 +98,7 @@ bool pgEntityTreat(PGconn* connectionP, KjNode* entityP, char* id, char* type, T
       {
         attrInstanceP->name = attrP->name;  // For array items, the name is NULL - the attr name must be taken from the array itself
 
-        if (pgAttributeTreat(connectionP, attrInstanceP, id, opMode) == false)
+        if (pgAttributeTreat(connectionP, attrInstanceP, id, attributeOpMode) == false)
           LM_RE(false, ("pgAttributeTreat(datasets) failed for attribute '%s'", attrP->name));
       }
     }

--- a/src/lib/orionld/troe/pgEntityTreat.h
+++ b/src/lib/orionld/troe/pgEntityTreat.h
@@ -40,6 +40,6 @@ extern "C"
 //
 // pgEntityTreat -
 //
-extern bool pgEntityTreat(PGconn* connectionP, KjNode* entityP, char* id, char* type, TroeMode mode);
+extern bool pgEntityTreat(PGconn* connectionP, KjNode* entityP, char* id, char* type, TroeMode mode, TroeMode attributeOpMode);
 
 #endif  // SRC_LIB_ORIONLD_TROE_PGENTITYTREAT_H_

--- a/src/lib/orionld/troe/pgInit.cpp
+++ b/src/lib/orionld/troe/pgInit.cpp
@@ -190,7 +190,7 @@ bool pgDbPopulate(const char* dbPrefix)
     if (strncmp(dbNameP, dbPrefix, strlen(dbPrefix)) != 0)
       continue;
 
-    LM_TMP(("PGPOOL: matching DB: '%s'", dbNameP));
+    LM_TMP(("TROE: matching DB: '%s'", dbNameP));
     // FIXME: Check all tables are present and 100% OK
     pgDbAppend(dbNameP);
   }

--- a/src/lib/orionld/troe/troePatchEntity.cpp
+++ b/src/lib/orionld/troe/troePatchEntity.cpp
@@ -63,7 +63,7 @@ bool troePatchEntity(ConnectionInfo* ciP)
   char* entityId   = orionldState.wildcard[0];
   char* entityType = (char*) "REPLACE";
   LM_TMP(("TEMP: Calling pgEntityTreat for entity '%s'", entityId));
-  if (pgEntityTreat(connectionP, orionldState.requestTree, entityId, entityType, TROE_ATTRIBUTE_REPLACE) == false)
+  if (pgEntityTreat(connectionP, orionldState.requestTree, entityId, entityType, TROE_ENTITY_UPDATE, TROE_ATTRIBUTE_REPLACE) == false)
   {
     LM_E(("Database Error (post entities TRoE layer failed)"));
     if (pgTransactionRollback(connectionP) == false)

--- a/src/lib/orionld/troe/troePostBatchCreate.cpp
+++ b/src/lib/orionld/troe/troePostBatchCreate.cpp
@@ -73,7 +73,7 @@ bool troePostBatchCreate(ConnectionInfo* ciP)
   for (KjNode* entityP = orionldState.requestTree->value.firstChildP; entityP != NULL; entityP = entityP->next)
   {
     LM_TMP(("TEMP: Calling pgEntityTreat for entity at %p", entityP));
-    if (pgEntityTreat(connectionP, entityP, NULL, NULL, TROE_ENTITY_CREATE) == false)
+    if (pgEntityTreat(connectionP, entityP, NULL, NULL, TROE_ENTITY_CREATE, TROE_ENTITY_CREATE) == false)
     {
       ok = false;
       break;

--- a/src/lib/orionld/troe/troePostBatchUpdate.cpp
+++ b/src/lib/orionld/troe/troePostBatchUpdate.cpp
@@ -63,15 +63,15 @@ bool troePostBatchUpdate(ConnectionInfo* ciP)
   if (pgTransactionBegin(connectionP) != true)
     LM_RE(false, ("pgTransactionBegin failed"));
 
-  bool      ok       = true;
-  TroeMode  troeMode = (orionldState.uriParamOptions.noOverwrite == true)? TROE_ATTRIBUTE_APPEND : TROE_ATTRIBUTE_REPLACE;
+  bool      ok                = true;
+  TroeMode  attributeTroeMode = (orionldState.uriParamOptions.noOverwrite == true)? TROE_ATTRIBUTE_APPEND : TROE_ATTRIBUTE_REPLACE;
 
   if (orionldState.duplicateArray != NULL)
   {
     troeEntityArrayExpand(orionldState.duplicateArray);  // FIXME: Remove once orionldPostBatchUpdate.cpp has been fixed to do this
     for (KjNode* entityP = orionldState.duplicateArray->value.firstChildP; entityP != NULL; entityP = entityP->next)
     {
-      if (pgEntityTreat(connectionP, entityP, NULL, NULL, troeMode) == false)
+      if (pgEntityTreat(connectionP, entityP, NULL, NULL, TROE_ENTITY_UPDATE, attributeTroeMode) == false)
       {
         LM_E(("Database Error (pgEntityTreat failed)"));
         ok = false;
@@ -89,7 +89,7 @@ bool troePostBatchUpdate(ConnectionInfo* ciP)
       if (troeIgnored(entityP) == true)
         continue;
 
-      if (pgEntityTreat(connectionP, entityP, NULL, NULL, troeMode) == false)
+      if (pgEntityTreat(connectionP, entityP, NULL, NULL, TROE_ENTITY_UPDATE, attributeTroeMode) == false)
       {
         LM_E(("Database Error (pgEntityTreat failed)"));
         ok = false;

--- a/src/lib/orionld/troe/troePostEntities.cpp
+++ b/src/lib/orionld/troe/troePostEntities.cpp
@@ -116,7 +116,7 @@ bool troePostEntities(ConnectionInfo* ciP)
   LM_TMP(("TEMP: Calling pgEntityTreat for entity at %p", entityP));
   char* entityId   = orionldState.payloadIdNode->value.s;
   char* entityType = orionldContextItemExpand(orionldState.contextP, orionldState.payloadTypeNode->value.s, true, NULL);
-  if (pgEntityTreat(connectionP, entityP, entityId, entityType, TROE_ENTITY_CREATE) == false)
+  if (pgEntityTreat(connectionP, entityP, entityId, entityType, TROE_ENTITY_CREATE, TROE_ENTITY_CREATE) == false)
   {
     LM_E(("Database Error (post entities TRoE layer failed)"));
     if (pgTransactionRollback(connectionP) == false)

--- a/src/lib/orionld/troe/troePostEntity.cpp
+++ b/src/lib/orionld/troe/troePostEntity.cpp
@@ -83,7 +83,7 @@ bool troePostEntity(ConnectionInfo* ciP)
   char* entityId   = orionldState.wildcard[0];
   char* entityType = (char*) "REPLACE";
   LM_TMP(("TEMP: Calling pgEntityTreat for entity '%s'", entityId));
-  if (pgEntityTreat(connectionP, orionldState.requestTree, entityId, entityType, TROE_ATTRIBUTE_REPLACE) == false)
+  if (pgEntityTreat(connectionP, orionldState.requestTree, entityId, entityType, TROE_ENTITY_UPDATE, TROE_ATTRIBUTE_REPLACE) == false)
   {
     LM_E(("Database Error (post entities TRoE layer failed)"));
     if (pgTransactionRollback(connectionP) == false)

--- a/src/lib/orionld/troe/troePostEntityNoOverwrite.cpp
+++ b/src/lib/orionld/troe/troePostEntityNoOverwrite.cpp
@@ -62,7 +62,7 @@ bool troePostEntityNoOverwrite(ConnectionInfo* ciP)
   char* entityId   = orionldState.wildcard[0];
   char* entityType = (char*) "APPEND";
 
-  if (pgEntityTreat(connectionP, orionldState.requestTree, entityId, entityType, TROE_ATTRIBUTE_APPEND) == false)
+  if (pgEntityTreat(connectionP, orionldState.requestTree, entityId, entityType, TROE_ENTITY_UPDATE, TROE_ATTRIBUTE_APPEND) == false)
   {
     LM_E(("Database Error (post entities TRoE layer failed)"));
     if (pgTransactionRollback(connectionP) == false)

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -634,6 +634,7 @@ MHD_Result httpHeaderGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, co
     orionldState.tenant = (char*) value;
     if (troe)
       snprintf(orionldState.troeDbName, sizeof(orionldState.troeDbName), "%s_%s", dbName, value);
+    LM_TMP(("TROE: orionldState.troeDbName: '%s'", orionldState.troeDbName));
 #endif
     headerP->tenant = value;
     ciP->tenant     = value;
@@ -649,6 +650,7 @@ MHD_Result httpHeaderGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, co
     orionldState.tenant = (char*) value;
     if (troe)
       snprintf(orionldState.troeDbName, sizeof(orionldState.troeDbName), "%s_%s", dbName, value);
+    LM_TMP(("TROE: orionldState.troeDbName: '%s'", orionldState.troeDbName));
   }
   else if (strcasecmp(ckey, "NGSILD-Path") == 0)
     orionldState.servicePath = (char*) value;

--- a/test/functionalTest/cases/0000_troe/troe_batch_create-with_context_in_body.test
+++ b/test/functionalTest/cases/0000_troe/troe_batch_create-with_context_in_body.test
@@ -157,7 +157,7 @@ Date: REGEX(.*)
 opmode,id,type
 Create,urn:ngsi-ld:entities:E1,http://example.org/T
 Replace,urn:ngsi-ld:entities:E1,http://example.org/T
-Replace,urn:ngsi-ld:entities:E2,http://example.org/T
+Create,urn:ngsi-ld:entities:E2,http://example.org/T
 
 
 06. See the attributes in the temporal database

--- a/test/functionalTest/cases/0000_troe/troe_batch_upsert-options-update_with_contexts.test
+++ b/test/functionalTest/cases/0000_troe/troe_batch_upsert-options-update_with_contexts.test
@@ -1,0 +1,181 @@
+# Copyright 2021 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Entity Batch Upsert with context
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+pgInit $CB_DB_NAME
+brokerStart CB 100 IPv4 -troe
+
+--SHELL--
+
+#
+# 01. Upsert/Create the entity E1, with a user context
+# 02. GET the entity without context (core) and see the longnames of entity-type and attributes
+# 03. See entity in TRoE - make sure the entity type is correctly expanded
+# 04. See the attributes in the temporal database - make sure the attribute names are correctly expanded
+# 05. See the sub-attributes in the temporal database (spoiler - there aren't any)
+#
+
+echo "01. Upsert/Create the entity E1, with a user context"
+echo "===================================================="
+payload='[
+  {
+    "id": "urn:ngsi-ld:entities:E1",
+    "type": "SoilSensor",
+    "humidity": {
+      "value": 32,
+      "type": "Property",
+      "unitCode": "P1",
+      "observedAt": "2021-03-05T12:00:40.228Z"
+    },
+    "description": {
+        "value": "Soil Humdity Sensor",
+        "type": "Property",
+        "observedAt": "2021-03-05T12:00:40.228Z"
+    },
+    "category": {
+      "type": "Property",
+      "value": "sensor",
+      "observedAt": "2021-03-05T12:00:40.228Z"
+    },
+    "controlledProperty": {
+      "value": "humidity",
+      "type": "Property",
+      "observedAt": "2021-03-05T12:00:40.228Z"
+    },
+    "supportedProtocol": {
+      "value": "ul20",
+      "type": "Property",
+      "observedAt": "2021-03-05T12:00:40.228Z"
+    }
+  }
+]'
+orionCurl --url /ngsi-ld/v1/entityOperations/upsert?options=update --payload "$payload" -H 'Link: <https://raw.githubusercontent.com/FIWARE/tutorials.NGSI-LD/master/app/public/data-models/ngsi-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+echo
+echo
+
+
+echo "02. GET the entity without context (core) and see the longnames of entity-type and attributes"
+echo "============================================================================================="
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entities:E1
+echo
+echo
+
+
+echo "03. See entity in TRoE - make sure the entity type is correctly expanded"
+echo "========================================================================"
+postgresCmd -sql "SELECT opMode,id,type,ts FROM entities"
+echo
+echo
+
+
+echo "04. See the attributes in the temporal database - make sure the attribute names are correctly expanded"
+echo "======================================================================================================"
+postgresCmd -sql "SELECT opMode,id,valueType,entityId,subProperties,unitcode,datasetid,text,number,boolean,ts FROM attributes"
+echo
+echo
+
+
+echo "05. See the sub-attributes in the temporal database (spoiler - there aren't any)"
+echo "================================================================================"
+postgresCmd -sql "SELECT id,valueType,entityId,attrInstanceId,unitcode,text,number,boolean,ts FROM subAttributes"
+echo
+echo
+
+
+--REGEXPECT--
+01. Upsert/Create the entity E1, with a user context
+====================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+02. GET the entity without context (core) and see the longnames of entity-type and attributes
+=============================================================================================
+HTTP/1.1 200 OK
+Content-Length: 741
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+{
+    "description": {
+        "observedAt": "2021-03-05T12:00:40.228Z",
+        "type": "Property",
+        "value": "Soil Humdity Sensor"
+    },
+    "https://uri.fiware.org/ns/data-models#category": {
+        "observedAt": "2021-03-05T12:00:40.228Z",
+        "type": "Property",
+        "value": "sensor"
+    },
+    "https://uri.fiware.org/ns/data-models#controlledProperty": {
+        "observedAt": "2021-03-05T12:00:40.228Z",
+        "type": "Property",
+        "value": "humidity"
+    },
+    "https://uri.fiware.org/ns/data-models#supportedProtocol": {
+        "observedAt": "2021-03-05T12:00:40.228Z",
+        "type": "Property",
+        "value": "ul20"
+    },
+    "https://w3id.org/saref#humidity": {
+        "observedAt": "2021-03-05T12:00:40.228Z",
+        "type": "Property",
+        "unitCode": "P1",
+        "value": 32
+    },
+    "id": "urn:ngsi-ld:entities:E1",
+    "type": "https://ngsi-ld-tutorials.readthedocs.io/en/latest/datamodels.html#SoilSensor"
+}
+
+
+03. See entity in TRoE - make sure the entity type is correctly expanded
+========================================================================
+opmode,id,type,ts
+Create,urn:ngsi-ld:entities:E1,https://ngsi-ld-tutorials.readthedocs.io/en/latest/datamodels.html#SoilSensor,REGEX(202.*)
+
+
+04. See the attributes in the temporal database - make sure the attribute names are correctly expanded
+======================================================================================================
+opmode,id,valuetype,entityid,subproperties,unitcode,datasetid,text,number,boolean,ts
+Replace,https://w3id.org/saref#humidity,Number,urn:ngsi-ld:entities:E1,f,P1,,,32,,202REGEX(.*)
+Replace,https://uri.etsi.org/ngsi-ld/description,String,urn:ngsi-ld:entities:E1,f,,,Soil Humdity Sensor,,,202REGEX(.*)
+Replace,https://uri.fiware.org/ns/data-models#category,String,urn:ngsi-ld:entities:E1,f,,,sensor,,,202REGEX(.*)
+Replace,https://uri.fiware.org/ns/data-models#controlledProperty,String,urn:ngsi-ld:entities:E1,f,,,humidity,,,202REGEX(.*)
+Replace,https://uri.fiware.org/ns/data-models#supportedProtocol,String,urn:ngsi-ld:entities:E1,f,,,ul20,,,202REGEX(.*)
+
+
+05. See the sub-attributes in the temporal database (spoiler - there aren't any)
+================================================================================
+id,valuetype,entityid,attrinstanceid,unitcode,text,number,boolean,ts
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB
+pgDrop $CB_DB_NAME

--- a/test/functionalTest/cases/0000_troe/troe_batch_upsert-with-some-entities-already-existing.test
+++ b/test/functionalTest/cases/0000_troe/troe_batch_upsert-with-some-entities-already-existing.test
@@ -1,0 +1,232 @@
+# Copyright 2021 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Entity Batch Upsert with some entities already existing
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+pgInit $CB_DB_NAME
+brokerStart CB 100 IPv4 -troe
+
+--SHELL--
+
+#
+# 01. Create entities E1 and E2
+# 02. Batch Upsert entities E1-E4
+# 03. See entities in TRoE - make sure E3 and E4 have opMode Create, while E1 and E2 have Create + Replace
+# 04. Batch Upsert entities E3-E6, with options=update
+# 05. See entities in TRoE - make sure E5 and E6 have opMode Create, while E3 and E4 have Create only (updates aren't recorded)
+#
+
+echo "01. Create entities E1 and E2"
+echo "============================="
+payload='[
+  {
+    "id": "urn:ngsi-ld:entities:E1",
+    "type": "T",
+    "category": {
+      "type": "Property",
+      "value": "sensor",
+      "observedAt": "2021-01-05T12:00:40.228Z"
+    },
+    "controlledProperty": {
+      "value": "humidity",
+      "type": "Property",
+      "observedAt": "2021-02-05T12:00:40.228Z"
+    }
+  },
+  {
+    "id": "urn:ngsi-ld:entities:E2",
+    "type": "T",
+    "category": {
+      "type": "Property",
+      "value": "sensor",
+      "observedAt": "2021-03-05T12:00:40.228Z"
+    },
+    "controlledProperty": {
+      "value": "humidity",
+      "type": "Property",
+      "observedAt": "2021-04-05T12:00:40.228Z"
+    }
+  }
+]'
+orionCurl --url /ngsi-ld/v1/entityOperations/upsert --payload "$payload"
+echo
+echo
+
+
+echo "02. Batch Upsert entities E1-E4"
+echo "==============================="
+payload='[
+  {
+    "id": "urn:ngsi-ld:entities:E1",
+    "type": "T",
+    "controlledProperty": {
+      "value": "humidity",
+      "type": "Property",
+      "observedAt": "2020-01-05T12:00:40.228Z"
+    }
+  },
+  {
+    "id": "urn:ngsi-ld:entities:E2",
+    "type": "T",
+    "category": {
+      "type": "Property",
+      "value": "sensor",
+      "observedAt": "2020-02-05T12:00:40.228Z"
+    }
+  },
+  {
+    "id": "urn:ngsi-ld:entities:E3",
+    "type": "T",
+    "controlledProperty": {
+      "value": "humidity",
+      "type": "Property",
+      "observedAt": "2020-03-05T12:00:40.228Z"
+    }
+  },
+  {
+    "id": "urn:ngsi-ld:entities:E4",
+    "type": "T",
+    "category": {
+      "type": "Property",
+      "value": "sensor",
+      "observedAt": "2020-04-05T12:00:40.228Z"
+    }
+  }
+]'
+orionCurl --url /ngsi-ld/v1/entityOperations/upsert --payload "$payload"
+echo
+echo
+
+
+echo "03. See entities in TRoE - make sure E3 and E4 have opMode Create, while E1 and E2 have Create + Replace"
+echo "========================================================================================================"
+postgresCmd -sql "SELECT opMode,id,type,ts FROM entities"
+echo
+echo
+
+
+echo "04. Batch Upsert entities E3-E6, with options=update"
+echo "===================================================="
+payload='[
+  {
+    "id": "urn:ngsi-ld:entities:E3",
+    "type": "T",
+    "controlledProperty": {
+      "value": "humidity",
+      "type": "Property",
+      "observedAt": "2019-01-05T12:00:40.228Z"
+    }
+  },
+  {
+    "id": "urn:ngsi-ld:entities:E4",
+    "type": "T",
+    "category": {
+      "type": "Property",
+      "value": "sensor",
+      "observedAt": "2019-02-05T12:00:40.228Z"
+    }
+  },
+  {
+    "id": "urn:ngsi-ld:entities:E5",
+    "type": "T",
+    "controlledProperty": {
+      "value": "humidity",
+      "type": "Property",
+      "observedAt": "2019-03-05T12:00:40.228Z"
+    }
+  },
+  {
+    "id": "urn:ngsi-ld:entities:E6",
+    "type": "T",
+    "category": {
+      "type": "Property",
+      "value": "sensor",
+      "observedAt": "2019-04-05T12:00:40.228Z"
+    }
+  }
+]'
+orionCurl --url /ngsi-ld/v1/entityOperations/upsert?options=update --payload "$payload"
+echo
+echo
+
+
+echo "05. See entities in TRoE - make sure E5 and E6 have opMode Create, while E3 and E4 have Create only (updates aren't recorded)"
+echo "============================================================================================================================="
+postgresCmd -sql "SELECT opMode,id,type,ts FROM entities"
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entities E1 and E2
+=============================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+02. Batch Upsert entities E1-E4
+===============================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+03. See entities in TRoE - make sure E3 and E4 have opMode Create, while E1 and E2 have Create + Replace
+========================================================================================================
+opmode,id,type,ts
+Create,urn:ngsi-ld:entities:E1,https://uri.etsi.org/ngsi-ld/default-context/T,202REGEX(.*)
+Create,urn:ngsi-ld:entities:E2,https://uri.etsi.org/ngsi-ld/default-context/T,202REGEX(.*)
+Replace,urn:ngsi-ld:entities:E1,https://uri.etsi.org/ngsi-ld/default-context/T,202REGEX(.*)
+Replace,urn:ngsi-ld:entities:E2,https://uri.etsi.org/ngsi-ld/default-context/T,202REGEX(.*)
+Create,urn:ngsi-ld:entities:E3,https://uri.etsi.org/ngsi-ld/default-context/T,202REGEX(.*)
+Create,urn:ngsi-ld:entities:E4,https://uri.etsi.org/ngsi-ld/default-context/T,202REGEX(.*)
+
+
+04. Batch Upsert entities E3-E6, with options=update
+====================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+05. See entities in TRoE - make sure E5 and E6 have opMode Create, while E3 and E4 have Create only (updates aren't recorded)
+=============================================================================================================================
+opmode,id,type,ts
+Create,urn:ngsi-ld:entities:E1,https://uri.etsi.org/ngsi-ld/default-context/T,202REGEX(.*)
+Create,urn:ngsi-ld:entities:E2,https://uri.etsi.org/ngsi-ld/default-context/T,202REGEX(.*)
+Replace,urn:ngsi-ld:entities:E1,https://uri.etsi.org/ngsi-ld/default-context/T,202REGEX(.*)
+Replace,urn:ngsi-ld:entities:E2,https://uri.etsi.org/ngsi-ld/default-context/T,202REGEX(.*)
+Create,urn:ngsi-ld:entities:E3,https://uri.etsi.org/ngsi-ld/default-context/T,202REGEX(.*)
+Create,urn:ngsi-ld:entities:E4,https://uri.etsi.org/ngsi-ld/default-context/T,202REGEX(.*)
+Create,urn:ngsi-ld:entities:E5,https://uri.etsi.org/ngsi-ld/default-context/T,202REGEX(.*)
+Create,urn:ngsi-ld:entities:E6,https://uri.etsi.org/ngsi-ld/default-context/T,202REGEX(.*)
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB
+pgDrop $CB_DB_NAME

--- a/test/functionalTest/cases/0000_troe/troe_batch_upsert_with_contexts.test
+++ b/test/functionalTest/cases/0000_troe/troe_batch_upsert_with_contexts.test
@@ -1,0 +1,181 @@
+# Copyright 2021 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Entity Batch Upsert with context
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+pgInit $CB_DB_NAME
+brokerStart CB 100 IPv4 -troe
+
+--SHELL--
+
+#
+# 01. Upsert/Create the entity E1, with a user context
+# 02. GET the entity without context (core) and see the longnames of entity-type and attributes
+# 03. See entity in TRoE - make sure the entity type is correctly expanded
+# 04. See the attributes in the temporal database - make sure the attribute names are correctly expanded
+# 05. See the sub-attributes in the temporal database (spoiler - there aren't any)
+
+
+echo "01. Upsert/Create the entity E1, with a user context"
+echo "===================================================="
+payload='[
+  {
+    "id": "urn:ngsi-ld:entities:E1",
+    "type": "SoilSensor",
+    "humidity": {
+      "value": 32,
+      "type": "Property",
+      "unitCode": "P1",
+      "observedAt": "2021-03-05T12:00:40.228Z"
+    },
+    "description": {
+        "value": "Soil Humdity Sensor",
+        "type": "Property",
+        "observedAt": "2021-03-05T12:00:40.228Z"
+    },
+    "category": {
+      "type": "Property",
+      "value": "sensor",
+      "observedAt": "2021-03-05T12:00:40.228Z"
+    },
+    "controlledProperty": {
+      "value": "humidity",
+      "type": "Property",
+      "observedAt": "2021-03-05T12:00:40.228Z"
+    },
+    "supportedProtocol": {
+      "value": "ul20",
+      "type": "Property",
+      "observedAt": "2021-03-05T12:00:40.228Z"
+    }
+  }
+]'
+orionCurl --url /ngsi-ld/v1/entityOperations/upsert --payload "$payload" -H 'Link: <https://raw.githubusercontent.com/FIWARE/tutorials.NGSI-LD/master/app/public/data-models/ngsi-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+echo
+echo
+
+
+echo "02. GET the entity without context (core) and see the longnames of entity-type and attributes"
+echo "============================================================================================="
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entities:E1
+echo
+echo
+
+
+echo "03. See entity in TRoE - make sure the entity type is correctly expanded"
+echo "========================================================================"
+postgresCmd -sql "SELECT opMode,id,type,ts FROM entities"
+echo
+echo
+
+
+echo "04. See the attributes in the temporal database - make sure the attribute names are correctly expanded"
+echo "======================================================================================================"
+postgresCmd -sql "SELECT opMode,id,valueType,entityId,subProperties,unitcode,datasetid,text,number,boolean,ts FROM attributes"
+echo
+echo
+
+
+echo "05. See the sub-attributes in the temporal database (spoiler - there aren't any)"
+echo "================================================================================"
+postgresCmd -sql "SELECT id,valueType,entityId,attrInstanceId,unitcode,text,number,boolean,ts FROM subAttributes"
+echo
+echo
+
+
+--REGEXPECT--
+01. Upsert/Create the entity E1, with a user context
+====================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+02. GET the entity without context (core) and see the longnames of entity-type and attributes
+=============================================================================================
+HTTP/1.1 200 OK
+Content-Length: 741
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+{
+    "description": {
+        "observedAt": "2021-03-05T12:00:40.228Z",
+        "type": "Property",
+        "value": "Soil Humdity Sensor"
+    },
+    "https://uri.fiware.org/ns/data-models#category": {
+        "observedAt": "2021-03-05T12:00:40.228Z",
+        "type": "Property",
+        "value": "sensor"
+    },
+    "https://uri.fiware.org/ns/data-models#controlledProperty": {
+        "observedAt": "2021-03-05T12:00:40.228Z",
+        "type": "Property",
+        "value": "humidity"
+    },
+    "https://uri.fiware.org/ns/data-models#supportedProtocol": {
+        "observedAt": "2021-03-05T12:00:40.228Z",
+        "type": "Property",
+        "value": "ul20"
+    },
+    "https://w3id.org/saref#humidity": {
+        "observedAt": "2021-03-05T12:00:40.228Z",
+        "type": "Property",
+        "unitCode": "P1",
+        "value": 32
+    },
+    "id": "urn:ngsi-ld:entities:E1",
+    "type": "https://ngsi-ld-tutorials.readthedocs.io/en/latest/datamodels.html#SoilSensor"
+}
+
+
+03. See entity in TRoE - make sure the entity type is correctly expanded
+========================================================================
+opmode,id,type,ts
+Create,urn:ngsi-ld:entities:E1,https://ngsi-ld-tutorials.readthedocs.io/en/latest/datamodels.html#SoilSensor,REGEX(202.*)
+
+
+04. See the attributes in the temporal database - make sure the attribute names are correctly expanded
+======================================================================================================
+opmode,id,valuetype,entityid,subproperties,unitcode,datasetid,text,number,boolean,ts
+Replace,https://w3id.org/saref#humidity,Number,urn:ngsi-ld:entities:E1,f,P1,,,32,,202REGEX(.*)
+Replace,https://uri.etsi.org/ngsi-ld/description,String,urn:ngsi-ld:entities:E1,f,,,Soil Humdity Sensor,,,202REGEX(.*)
+Replace,https://uri.fiware.org/ns/data-models#category,String,urn:ngsi-ld:entities:E1,f,,,sensor,,,202REGEX(.*)
+Replace,https://uri.fiware.org/ns/data-models#controlledProperty,String,urn:ngsi-ld:entities:E1,f,,,humidity,,,202REGEX(.*)
+Replace,https://uri.fiware.org/ns/data-models#supportedProtocol,String,urn:ngsi-ld:entities:E1,f,,,ul20,,,202REGEX(.*)
+
+
+05. See the sub-attributes in the temporal database (spoiler - there aren't any)
+================================================================================
+id,valuetype,entityid,attrinstanceid,unitcode,text,number,boolean,ts
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB
+pgDrop $CB_DB_NAME

--- a/test/functionalTest/cases/0000_troe/troe_batch_upsert_with_same_entity_id.test
+++ b/test/functionalTest/cases/0000_troe/troe_batch_upsert_with_same_entity_id.test
@@ -34,13 +34,13 @@ brokerStart CB 100 IPv4 -troe
 #
 # 01. Upsert/Create the entity E1, with four different instances of E1 in the array
 # 02. GET all entities and see only the last instance of E1 from step 01
-# 03. See entities in TRoE - 4 instances of E1, all marked as REPLACED
+# 03. See entities in TRoE - 4 instances of E1, 3 REPLACED, 1 CREATED
 # 04. See the attributes in the temporal database
 # 05. See the sub-attributes in the temporal database
 #
-# 06. Upsert three instances of E1, with options=update - no new entity instance in TRoE entities table, but all new attrs in 'attributes' table marked as REPLACE
+# 06. Upsert three instances of E1, with options=update - three more instances in TRoE entities table, and all new attrs in 'attributes' table marked as REPLACE
 # 07. GET all entities and see the replaces attributes from step 6
-# 08. See entities in TRoE - still the same 4 instances of E1
+# 08. See entities in TRoE - now seven
 # 09. See the attributes in the temporal database - note the new ones, replacing the older ones
 # 10. See the sub-attributes in the temporal database
 
@@ -93,8 +93,8 @@ echo
 echo
 
 
-echo "03. See entities in TRoE - 4 instances of E1, all marked as REPLACED"
-echo "===================================================================="
+echo "03. See entities in TRoE - 4 instances of E1, 3 REPLACED, 1 CREATED"
+echo "==================================================================="
 postgresCmd -sql "SELECT opMode,id,type,ts FROM entities"
 echo
 echo
@@ -114,8 +114,8 @@ echo
 echo
 
 
-echo "06. Upsert three instances of E1, with options=update - no new entity instance in TRoE entities table, but all new attrs in 'attributes' table marked as REPLACE"
-echo "================================================================================================================================================================"
+echo "06. Upsert three instances of E1, with options=update - three more instances in TRoE entities table, and all new attrs in 'attributes' table marked as REPLACE"
+echo "=============================================================================================================================================================="
 payload='[
   {
     "id": "urn:ngsi-ld:entities:E1",
@@ -155,8 +155,8 @@ echo
 echo
 
 
-echo "08. See entities in TRoE - still the same 4 instances of E1"
-echo "==========================================================="
+echo "08. See entities in TRoE - now seven"
+echo "===================================="
 postgresCmd -sql "SELECT opMode,id,type,ts FROM entities"
 echo
 echo
@@ -222,13 +222,13 @@ Date: REGEX(.*)
 ]
 
 
-03. See entities in TRoE - 4 instances of E1, all marked as REPLACED
-====================================================================
+03. See entities in TRoE - 4 instances of E1, 3 REPLACED, 1 CREATED
+===================================================================
 opmode,id,type,ts
 Replace,urn:ngsi-ld:entities:E1,https://uri.etsi.org/ngsi-ld/default-context/T,REGEX(202.*)
 Replace,urn:ngsi-ld:entities:E1,https://uri.etsi.org/ngsi-ld/default-context/T,REGEX(202.*)
 Replace,urn:ngsi-ld:entities:E1,https://uri.etsi.org/ngsi-ld/default-context/T,REGEX(202.*)
-Replace,urn:ngsi-ld:entities:E1,https://uri.etsi.org/ngsi-ld/default-context/T,REGEX(202.*)
+Create,urn:ngsi-ld:entities:E1,https://uri.etsi.org/ngsi-ld/default-context/T,REGEX(202.*)
 
 
 04. See the attributes in the temporal database
@@ -245,8 +245,8 @@ Replace,https://uri.etsi.org/ngsi-ld/default-context/P4,String,urn:ngsi-ld:entit
 id,valuetype,entityid,attrinstanceid,unitcode,text,number,boolean,ts
 
 
-06. Upsert three instances of E1, with options=update - no new entity instance in TRoE entities table, but all new attrs in 'attributes' table marked as REPLACE
-================================================================================================================================================================
+06. Upsert three instances of E1, with options=update - three more instances in TRoE entities table, and all new attrs in 'attributes' table marked as REPLACE
+==============================================================================================================================================================
 HTTP/1.1 207 Multi-Status
 Content-Length: 246
 Content-Type: application/json
@@ -302,10 +302,13 @@ Date: REGEX(.*)
 ]
 
 
-08. See entities in TRoE - still the same 4 instances of E1
-===========================================================
+08. See entities in TRoE - now seven
+====================================
 opmode,id,type,ts
 Replace,urn:ngsi-ld:entities:E1,https://uri.etsi.org/ngsi-ld/default-context/T,REGEX(202.*)
+Replace,urn:ngsi-ld:entities:E1,https://uri.etsi.org/ngsi-ld/default-context/T,REGEX(202.*)
+Replace,urn:ngsi-ld:entities:E1,https://uri.etsi.org/ngsi-ld/default-context/T,REGEX(202.*)
+Create,urn:ngsi-ld:entities:E1,https://uri.etsi.org/ngsi-ld/default-context/T,REGEX(202.*)
 Replace,urn:ngsi-ld:entities:E1,https://uri.etsi.org/ngsi-ld/default-context/T,REGEX(202.*)
 Replace,urn:ngsi-ld:entities:E1,https://uri.etsi.org/ngsi-ld/default-context/T,REGEX(202.*)
 Replace,urn:ngsi-ld:entities:E1,https://uri.etsi.org/ngsi-ld/default-context/T,REGEX(202.*)

--- a/test/functionalTest/cases/0000_troe/troe_link_and_tenant_header_with_batch_op.test
+++ b/test/functionalTest/cases/0000_troe/troe_link_and_tenant_header_with_batch_op.test
@@ -86,7 +86,7 @@ Date: REGEX(.*)
 =============================================================================================================
 ENTITIES:
 opmode,id,type,ts
-Replace,urn:ngsi-ld:entities:E1,http://example.org/T,REGEX(202.*)
+Create,urn:ngsi-ld:entities:E1,http://example.org/T,REGEX(202.*)
 
 ATTRIBUTES:
 opmode,id,valuetype,entityid,subproperties,unitcode,datasetid,text,number,boolean,ts

--- a/test/functionalTest/cases/0000_troe/troe_tenants_and_batch_ops.test
+++ b/test/functionalTest/cases/0000_troe/troe_tenants_and_batch_ops.test
@@ -89,7 +89,7 @@ Date: REGEX(.*)
 ===============================================================================================
 ENTITIES:
 opmode,id,type,ts
-Replace,urn:ngsi-ld:entities:E1,https://uri.etsi.org/ngsi-ld/default-context/T,REGEX(202.*)
+Create,urn:ngsi-ld:entities:E1,https://uri.etsi.org/ngsi-ld/default-context/T,REGEX(202.*)
 
 ATTRIBUTES:
 opmode,id,valuetype,entityid,subproperties,unitcode,datasetid,text,number,boolean,ts


### PR DESCRIPTION
Improvements for TRoE:
- Retries when connecting to postgres (100 retries with a 100 ms sleep between attempts - as CLI in the future)
- Semaphore-protected creation of tenants (postgres DBs)
- Made BATCH Upsert aware of which entities already existed - to mark as CREATED or REPLACED - not always REPLACED