### PR TITLE
Troe/exhaustive add attributes

### DIFF
--- a/src/lib/orionld/serviceRoutines/orionldPatchEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchEntity.cpp
@@ -238,13 +238,32 @@ bool orionldPatchEntity(ConnectionInfo* ciP)
     KjNode*  dbAttrP;
     char*    title;
     char*    detail;
+    char*    shortName = newAttrP->name;
 
     next = newAttrP->next;
 
-    if ((strcmp(newAttrP->name, "location")         != 0) &&
-        (strcmp(newAttrP->name, "observationSpace") != 0) &&
-        (strcmp(newAttrP->name, "operationSpace")   != 0) &&
-        (strcmp(newAttrP->name, "observedAt")       != 0))
+    if ((strcmp(newAttrP->name, "createdAt") == 0) || (strcmp(newAttrP->name, "modifiedAt") == 0))
+    {
+      attributeNotUpdated(notUpdatedP, newAttrP->name, "built-in timestamps are ignored");
+      newAttrP = next;
+      continue;
+    }
+    else if ((strcmp(newAttrP->name, "id") == 0) || (strcmp(newAttrP->name, "@id") == 0))
+    {
+      attributeNotUpdated(notUpdatedP, newAttrP->name, "the ID of an entity cannot be altered");
+      newAttrP = next;
+      continue;
+    }
+    else if ((strcmp(newAttrP->name, "type") == 0) || (strcmp(newAttrP->name, "@type") == 0))
+    {
+      attributeNotUpdated(notUpdatedP, newAttrP->name, "the TYPE of an entity cannot be altered");
+      newAttrP = next;
+      continue;
+    }
+    else if ((strcmp(newAttrP->name, "location")         != 0) &&
+             (strcmp(newAttrP->name, "observationSpace") != 0) &&
+             (strcmp(newAttrP->name, "operationSpace")   != 0) &&
+             (strcmp(newAttrP->name, "observedAt")       != 0))
     {
       newAttrP->name = orionldContextItemExpand(orionldState.contextP, newAttrP->name, true, NULL);
     }
@@ -253,7 +272,7 @@ bool orionldPatchEntity(ConnectionInfo* ciP)
     if (attributeCheck(ciP, newAttrP, &title, &detail) == false)
     {
       LM_E(("attributeCheck: %s: %s", title, detail));
-      attributeNotUpdated(notUpdatedP, newAttrP->name, detail);
+      attributeNotUpdated(notUpdatedP, shortName, detail);
       newAttrP = next;
       continue;
     }
@@ -264,7 +283,7 @@ bool orionldPatchEntity(ConnectionInfo* ciP)
     dbAttrP = kjLookup(inDbAttrsP, eqName);
     if (dbAttrP == NULL)  // Doesn't already exist - must be discarded
     {
-      attributeNotUpdated(notUpdatedP, newAttrP->name, "attribute doesn't exist");
+      attributeNotUpdated(notUpdatedP, shortName, "attribute doesn't exist");
       newAttrP = next;
       continue;
     }
@@ -274,7 +293,7 @@ bool orionldPatchEntity(ConnectionInfo* ciP)
     // Remove the attribute to be updated (from dbEntityP::inDbAttrsP) and insert the attribute from the payload data
     kjChildRemove(inDbAttrsP, dbAttrP);
     kjChildAdd(inDbAttrsP, newAttrP);
-    attributeUpdated(updatedP, newAttrP->name);
+    attributeUpdated(updatedP, shortName);
 
     ++newAttrs;
     newAttrP = next;

--- a/src/lib/orionld/troe/troeEntityArrayExpand.cpp
+++ b/src/lib/orionld/troe/troeEntityArrayExpand.cpp
@@ -36,6 +36,7 @@ extern "C"
 #include "orionld/context/orionldCoreContext.h"                // orionldCoreContextP
 #include "orionld/context/orionldContextCacheLookup.h"         // orionldContextCacheLookup
 #include "orionld/context/orionldContextItemExpand.h"          // orionldContextItemExpand
+#include "orionld/context/orionldContextFromTree.h"            // orionldContextFromTree
 #include "orionld/troe/troeEntityArrayExpand.h"                // Own interface
 
 
@@ -61,8 +62,10 @@ void troeEntityArrayExpand(KjNode* tree)
 
       if (contextNodeP != NULL)
       {
+        OrionldProblemDetails  pd;
+
         kjChildRemove(entityP, contextNodeP);
-        contextP = orionldContextCacheLookup(contextNodeP->value.s);
+        contextP = orionldContextFromTree(NULL, false, contextNodeP, &pd);
       }
     }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_crash-in-patch-entity-attrs-when-relationship-without-object.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_crash-in-patch-entity-attrs-when-relationship-without-object.test
@@ -76,7 +76,7 @@ Date: REGEX(.*)
 02. Update the attribute R1 using PATCH /ngsi-ld/v1/entities/urn:ngsi-ld:T:001/attrs, but without 'object' - see error and make sure no crash
 =============================================================================================================================================
 HTTP/1.1 207 Multi-Status
-Content-Length: 153
+Content-Length: 108
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -84,7 +84,7 @@ Date: REGEX(.*)
 {
     "notUpdated": [
         {
-            "attributeName": "https://uri.etsi.org/ngsi-ld/default-context/R1",
+            "attributeName": "R1",
             "reason": "Mandatory field missing: Relationship object"
         }
     ],

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0108.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0108.test
@@ -135,7 +135,7 @@ Date: REGEX(.*)
 04. Attempt to PATCH P1 and P2 (that doesn't exist) - see that P2 is ignored
 ============================================================================
 HTTP/1.1 207 Multi-Status
-Content-Length: 181
+Content-Length: 91
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -143,12 +143,12 @@ Date: REGEX(.*)
 {
     "notUpdated": [
         {
-            "attributeName": "https://uri.etsi.org/ngsi-ld/default-context/P2",
+            "attributeName": "P2",
             "reason": "attribute doesn't exist"
         }
     ],
     "updated": [
-        "https://uri.etsi.org/ngsi-ld/default-context/P1"
+        "P1"
     ]
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0302.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0302.test
@@ -199,7 +199,7 @@ Date: REGEX(.*)
 04. Attempt to patch a non-existing attribute P3 of E1 - see 207
 ================================================================
 HTTP/1.1 207 Multi-Status
-Content-Length: 132
+Content-Length: 87
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -207,7 +207,7 @@ Date: REGEX(.*)
 {
     "notUpdated": [
         {
-            "attributeName": "https://uri.etsi.org/ngsi-ld/default-context/P3",
+            "attributeName": "P3",
             "reason": "attribute doesn't exist"
         }
     ],
@@ -218,7 +218,7 @@ Date: REGEX(.*)
 05. Attempt to patch a non-existing attribute	P3 and an existing attribute P2 - see 207 MultiStatus
 ===================================================================================================
 HTTP/1.1 207 Multi-Status
-Content-Length: 181
+Content-Length: 91
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -226,12 +226,12 @@ Date: REGEX(.*)
 {
     "notUpdated": [
         {
-            "attributeName": "https://uri.etsi.org/ngsi-ld/default-context/P3",
+            "attributeName": "P3",
             "reason": "attribute doesn't exist"
         }
     ],
     "updated": [
-        "https://uri.etsi.org/ngsi-ld/default-context/P2"
+        "P2"
     ]
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_patch_entity_attr_with_subscription.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_patch_entity_attr_with_subscription.test
@@ -282,7 +282,7 @@ Content-Type: application/json; charset=utf-8
 07. Attempt to add a property A3 - should be ignored
 ====================================================
 HTTP/1.1 207 Multi-Status
-Content-Length: 132
+Content-Length: 87
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -290,7 +290,7 @@ Date: REGEX(.*)
 {
     "notUpdated": [
         {
-            "attributeName": "https://uri.etsi.org/ngsi-ld/default-context/A3",
+            "attributeName": "A3",
             "reason": "attribute doesn't exist"
         }
     ],

--- a/test/functionalTest/cases/0000_ngsild/ngsild_testSuite-partial-entity-update.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_testSuite-partial-entity-update.test
@@ -100,7 +100,7 @@ Date: REGEX(.*)
 02. Update the entity partially, the same way as the Test Suite Case 'Partial Attribute Update'
 ===============================================================================================
 HTTP/1.1 207 Multi-Status
-Content-Length: 142
+Content-Length: 97
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -113,7 +113,7 @@ Date: REGEX(.*)
         }
     ],
     "updated": [
-        "https://uri.etsi.org/ngsi-ld/default-context/P1"
+        "P1"
     ]
 }
 

--- a/test/functionalTest/cases/0000_troe/troe_batch_upsert_bug.test
+++ b/test/functionalTest/cases/0000_troe/troe_batch_upsert_bug.test
@@ -1,0 +1,288 @@
+# Copyright 2021 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Possible bug in Batch Upsert, not finding an expansion in a user context that is an array
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+dbInit CB openiot
+pgInit $CB_DB_NAME
+pgInit ${CB_DB_NAME}_openiot
+brokerStart CB 100 IPv4 -troe -multiservice
+
+--SHELL--
+
+#
+# 01. Use Batch Upsert to create an entity on tenant openiot, with a user context that is an array
+# 02. See the entity in mongo
+# 03. See TRoE entities in the openiot tenant
+#
+
+echo "01. Use Batch Upsert to create an entity on tenant openiot, with a user context that is an array"
+echo "================================================================================================"
+payload='[
+  {
+    "@context": [ "https://raw.githubusercontent.com/FIWARE/tutorials.NGSI-LD/master/app/public/data-models/ngsi-context.jsonld" ],
+    "id": "urn:ngsi-ld:Device:filling001",
+    "type": "FillingLevelSensor",
+    "filling": {
+      "type": "Property",
+      "value": {
+        "@type": "Intangible",
+        "@value": null
+      },
+      "unitCode": "C62"
+    },
+    "controllingAsset": {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:Building:farm001"
+    },
+    "supportedProtocol": {
+      "type": "Property",
+      "value": [
+        "ul20"
+      ]
+    },
+    "description": {
+      "type": "Property",
+      "value": "Barn filling Sensor"
+    },
+    "category": {
+      "type": "Property",
+      "value": [
+        "actuator",
+        "sensor"
+      ]
+    },
+    "controlledProperty": {
+      "type": "Property",
+      "value": [
+        "filling"
+      ]
+    },
+    "add_status": {
+      "type": "Property",
+      "value": {
+        "@type": "commandStatus",
+        "@value": "UNKNOWN"
+      }
+    },
+    "add_info": {
+      "type": "Property",
+      "value": {
+        "@type": "commandResult",
+        "@value": " "
+      }
+    },
+    "remove_status": {
+      "type": "Property",
+      "value": {
+        "@type": "commandStatus",
+        "@value": "UNKNOWN"
+      }
+    },
+    "remove_info": {
+      "type": "Property",
+      "value": {
+        "@type": "commandResult",
+        "@value": " "
+      }
+    }
+  }
+]'
+#
+# "headers": {
+#   "fiware-service": "openiot",
+#   "fiware-servicepath": "/",
+#   "NGSILD-Tenant": "openiot",
+#   "NGSILD-Path": "/",
+#   "Content-Type": "application/ld+json"
+# }
+#
+orionCurl --url /ngsi-ld/v1/entityOperations/upsert --payload "$payload" --tenant openiot --in application/ld+json
+echo
+echo
+
+
+echo "02. See the entity in mongo"
+echo "==========================="
+mongoCmd2 ftest-openiot "db.entities.findOne()"
+echo
+echo
+
+
+echo "03. See TRoE entities in the openiot tenant"
+echo "==========================================="
+postgresCmd -sql "SELECT opMode,id,type,ts FROM entities" -t ftest_openiot
+echo
+echo
+
+
+--REGEXPECT--
+01. Use Batch Upsert to create an entity on tenant openiot, with a user context that is an array
+================================================================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+02. See the entity in mongo
+===========================
+MongoDB shell version REGEX(.*)
+connecting to: REGEX(.*)
+MongoDB server version: REGEX(.*)
+{
+	"_id" : {
+		"id" : "urn:ngsi-ld:Device:filling001",
+		"type" : "https://ngsi-ld-tutorials.readthedocs.io/en/latest/datamodels.html#FillingLevelSensor",
+		"servicePath" : "/"
+	},
+	"attrNames" : [
+		"https://w3id.org/saref#fillingLevel",
+		"https://uri.etsi.org/ngsi-ld/default-context/controllingAsset",
+		"https://uri.fiware.org/ns/data-models#supportedProtocol",
+		"https://uri.etsi.org/ngsi-ld/description",
+		"https://uri.fiware.org/ns/data-models#category",
+		"https://uri.fiware.org/ns/data-models#controlledProperty",
+		"https://uri.etsi.org/ngsi-ld/default-context/add_status",
+		"https://uri.etsi.org/ngsi-ld/default-context/add_info",
+		"https://uri.etsi.org/ngsi-ld/default-context/remove_status",
+		"https://uri.etsi.org/ngsi-ld/default-context/remove_info"
+	],
+	"attrs" : {
+		"https://w3id=org/saref#fillingLevel" : {
+			"type" : "Property",
+			"creDate" : REGEX(.*),
+			"modDate" : REGEX(.*),
+			"value" : {
+				"@type" : "Intangible",
+				"@value" : null
+			},
+			"md" : {
+				"unitCode" : {
+					"value" : "C62"
+				}
+			},
+			"mdNames" : [
+				"unitCode"
+			]
+		},
+		"https://uri=etsi=org/ngsi-ld/default-context/controllingAsset" : {
+			"type" : "Relationship",
+			"creDate" : REGEX(.*),
+			"modDate" : REGEX(.*),
+			"value" : "urn:ngsi-ld:Building:farm001",
+			"mdNames" : [ ]
+		},
+		"https://uri=fiware=org/ns/data-models#supportedProtocol" : {
+			"type" : "Property",
+			"creDate" : REGEX(.*),
+			"modDate" : REGEX(.*),
+			"value" : "ul20",
+			"mdNames" : [ ]
+		},
+		"https://uri=etsi=org/ngsi-ld/description" : {
+			"type" : "Property",
+			"creDate" : REGEX(.*),
+			"modDate" : REGEX(.*),
+			"value" : "Barn filling Sensor",
+			"mdNames" : [ ]
+		},
+		"https://uri=fiware=org/ns/data-models#category" : {
+			"type" : "Property",
+			"creDate" : REGEX(.*),
+			"modDate" : REGEX(.*),
+			"value" : [
+				"actuator",
+				"sensor"
+			],
+			"mdNames" : [ ]
+		},
+		"https://uri=fiware=org/ns/data-models#controlledProperty" : {
+			"type" : "Property",
+			"creDate" : REGEX(.*),
+			"modDate" : REGEX(.*),
+			"value" : "filling",
+			"mdNames" : [ ]
+		},
+		"https://uri=etsi=org/ngsi-ld/default-context/add_status" : {
+			"type" : "Property",
+			"creDate" : REGEX(.*),
+			"modDate" : REGEX(.*),
+			"value" : {
+				"@type" : "commandStatus",
+				"@value" : "UNKNOWN"
+			},
+			"mdNames" : [ ]
+		},
+		"https://uri=etsi=org/ngsi-ld/default-context/add_info" : {
+			"type" : "Property",
+			"creDate" : REGEX(.*),
+			"modDate" : REGEX(.*),
+			"value" : {
+				"@type" : "commandResult",
+				"@value" : " "
+			},
+			"mdNames" : [ ]
+		},
+		"https://uri=etsi=org/ngsi-ld/default-context/remove_status" : {
+			"type" : "Property",
+			"creDate" : REGEX(.*),
+			"modDate" : REGEX(.*),
+			"value" : {
+				"@type" : "commandStatus",
+				"@value" : "UNKNOWN"
+			},
+			"mdNames" : [ ]
+		},
+		"https://uri=etsi=org/ngsi-ld/default-context/remove_info" : {
+			"type" : "Property",
+			"creDate" : REGEX(.*),
+			"modDate" : REGEX(.*),
+			"value" : {
+				"@type" : "commandResult",
+				"@value" : " "
+			},
+			"mdNames" : [ ]
+		}
+	},
+	"creDate" : REGEX(.*),
+	"modDate" : REGEX(.*),
+	"lastCorrelator" : ""
+}
+bye
+
+
+03. See TRoE entities in the openiot tenant
+===========================================
+opmode,id,type,ts
+Create,urn:ngsi-ld:Device:filling001,https://ngsi-ld-tutorials.readthedocs.io/en/latest/datamodels.html#FillingLevelSensor,202REGEX(.*)
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB
+dbDrop CB openiot
+pgDrop $CB_DB_NAME
+pgDrop ${CB_DB_NAME}_openiot

--- a/test/functionalTest/cases/0000_troe/troe_exhaustive_batch_delete.test
+++ b/test/functionalTest/cases/0000_troe/troe_exhaustive_batch_delete.test
@@ -420,7 +420,7 @@ Date: REGEX(.*)
 HTTP/1.1 207 Multi-Status
 Content-Length: 174
 Content-Type: application/json
-Date: Tue, REGEX(.*)
+Date: REGEX(.*)
 
 {
     "errors": [
@@ -442,7 +442,7 @@ Date: Tue, REGEX(.*)
 HTTP/1.1 207 Multi-Status
 Content-Length: 174
 Content-Type: application/json
-Date: Tue, REGEX(.*)
+Date: REGEX(.*)
 
 {
     "errors": [

--- a/test/functionalTest/cases/0000_troe/troe_patch_entity.test
+++ b/test/functionalTest/cases/0000_troe/troe_patch_entity.test
@@ -125,7 +125,7 @@ Date: REGEX(.*)
 02. Patch E1 with P1 and P2 (P1 will replace old P1, while P2 is ignored)
 =========================================================================
 HTTP/1.1 207 Multi-Status
-Content-Length: 181
+Content-Length: 91
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -133,12 +133,12 @@ Date: REGEX(.*)
 {
     "notUpdated": [
         {
-            "attributeName": "https://uri.etsi.org/ngsi-ld/default-context/P2",
+            "attributeName": "P2",
             "reason": "attribute doesn't exist"
         }
     ],
     "updated": [
-        "https://uri.etsi.org/ngsi-ld/default-context/P1"
+        "P1"
     ]
 }
 


### PR DESCRIPTION
* Fixed a bug about @context not being a simple string in TRoE for batch ops with @context in payload body
* Patch Entity fixes:
  * ignores createdAt+modifiedAt+id+type (notModified in 207 response)
  * attrs are not expanded in the response