### PR TITLE
bug/altitude-in-uri-param-for-get-entities

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -13,3 +13,4 @@
 * Issue  #280   Important concurrency fix - avoiding to download the same context mopre than once
 * Issue  #737   Removed the check for forbidden characters in variable names in the 'q' URL parameter
 * Issue  #280   Fixed the response code and payload body of BATCH Delete
+* Issue  #280   GET /entities?coordinates=[] didn't allow for the altitude to be present

--- a/src/lib/ngsi/Scope.cpp
+++ b/src/lib/ngsi/Scope.cpp
@@ -354,7 +354,7 @@ int Scope::fill
 
     coords = stringSplit(pointStringV[ix], ',', coordV);
 
-    if ((coords != 2) && (geometry.areaType == "point"))
+    if ((coords != 2) && (coords != 3) && (geometry.areaType == "point"))
     {
       *errorStringP = "invalid coordinates for point";
       LM_E(("geometry.parse: %s (%d coords)", errorStringP->c_str(), coords));

--- a/src/lib/ngsi/Scope.cpp
+++ b/src/lib/ngsi/Scope.cpp
@@ -35,6 +35,7 @@
 
 #include "ngsi/Scope.h"
 #include "parse/forbiddenChars.h"
+#include "orionld/common/orionldState.h"
 
 using namespace orion;
 
@@ -354,13 +355,29 @@ int Scope::fill
 
     coords = stringSplit(pointStringV[ix], ',', coordV);
 
-    if ((coords != 2) && (coords != 3) && (geometry.areaType == "point"))
+    if (geometry.areaType == "point")
     {
-      *errorStringP = "invalid coordinates for point";
-      LM_E(("geometry.parse: %s (%d coords)", errorStringP->c_str(), coords));
-      pointVectorRelease(pointV);
-      pointV.clear();
-      return -1;
+      //
+      // NGSIv2 only allows for 2 coords (no altitude) while NGSI-LD allows for 2 or three
+      //
+      bool error = false;
+
+      if (orionldState.apiVersion == NGSI_LD_V1)
+      {
+        if ((coords != 2) && (coords != 3))
+          error = true;
+      }
+      else if (coords != 2)
+        error = true;
+
+      if (error == true)
+      {
+        *errorStringP = "invalid coordinates for point";
+        LM_E(("geometry.parse: %s (%d coords)", errorStringP->c_str(), coords));
+        pointVectorRelease(pointV);
+        pointV.clear();
+        return -1;
+      }
     }
 
     if (coords < 2)

--- a/test/functionalTest/cases/0000_ngsild/ngsild_geoqueries-point.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_geoqueries-point.test
@@ -98,7 +98,7 @@ echo
 
 echo "04. Geoquery with Max Distance 15 - nothing found"
 echo "================================================="
-orionCurl --url '/ngsi-ld/v1/entities?type=T_City&geometry=Point&coordinates=\[-3.7,40.4\]&georel=near;maxDistance==15'
+orionCurl --url '/ngsi-ld/v1/entities?type=T_City&geometry=Point&coordinates=\[-3.7,40.4,0\]&georel=near;maxDistance==15'
 echo
 echo
 


### PR DESCRIPTION
GET /entities?coordinates=[] didn't allow for the altitude to be present