### PR TITLE
hardening/troe_delete_entity_tests

### DIFF
--- a/src/lib/orionld/context/CMakeLists.txt
+++ b/src/lib/orionld/context/CMakeLists.txt
@@ -48,6 +48,8 @@ SET (SOURCES
     orionldContextCacheGet.cpp
     orionldContextCacheRelease.cpp
     orionldContextItemAlreadyExpanded.cpp
+    orionldAttributeExpand.cpp
+    orionldSubAttributeExpand.cpp
 )
 
 # Include directories

--- a/src/lib/orionld/context/orionldAttributeExpand.cpp
+++ b/src/lib/orionld/context/orionldAttributeExpand.cpp
@@ -1,0 +1,59 @@
+/*
+*
+* Copyright 2021 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+#include <string.h>                                              // strchr
+
+#include "logMsg/logMsg.h"                                       // LM_*
+#include "logMsg/traceLevels.h"                                  // Lmt*
+
+#include "orionld/context/orionldContextItemAlreadyExpanded.h"   // orionldContextItemAlreadyExpanded
+#include "orionld/context/orionldContextItemExpand.h"            // orionldContextItemExpand
+#include "orionld/context/orionldAttributeExpand.h"              // Own interface
+
+
+// -----------------------------------------------------------------------------
+//
+// orionldAttributeExpand -
+//
+// This function expands unless:
+//   - has already been expanded
+//   - is a special attribute such as 'location'
+//
+char* orionldAttributeExpand
+(
+  OrionldContext*       contextP,
+  char*                 shortName,
+  bool                  useDefaultUrlIfNotFound,
+  OrionldContextItem**  contextItemPP
+)
+{
+  if (orionldContextItemAlreadyExpanded(shortName) == true)
+    return shortName;
+
+  if      (strcmp(shortName, "location")         == 0) return shortName;
+  else if (strcmp(shortName, "observationSpace") == 0) return shortName;
+  else if (strcmp(shortName, "operationSpace")   == 0) return shortName;
+
+  return orionldContextItemExpand(contextP, shortName, useDefaultUrlIfNotFound, contextItemPP);
+}

--- a/src/lib/orionld/context/orionldAttributeExpand.h
+++ b/src/lib/orionld/context/orionldAttributeExpand.h
@@ -1,3 +1,6 @@
+#ifndef SRC_LIB_ORIONLD_CONTEXT_ORIONLDATTRIBUTEEXPAND_H_
+#define SRC_LIB_ORIONLD_CONTEXT_ORIONLDATTRIBUTEEXPAND_H_
+
 /*
 *
 * Copyright 2019 FIWARE Foundation e.V.
@@ -22,26 +25,25 @@
 *
 * Author: Ken Zangelin
 */
-#include <unistd.h>                                              // NULL
+#include "orionld/context/OrionldContext.h"                      // OrionldContext
+#include "orionld/context/OrionldContextItem.h"                  // OrionldContextItem
 
 
 
 // -----------------------------------------------------------------------------
 //
-// orionldContextItemAlreadyExpanded -
+// orionldAttributeExpand.h -
 //
-bool orionldContextItemAlreadyExpanded(const char* value)
-{
-  if (value == NULL)
-    return false;
+// This function expands unless:
+//   - has already been expanded
+//   - is a special attribute such as location, datasetId, ...
+//
+extern char* orionldAttributeExpand
+(
+  OrionldContext*       contextP,
+  char*                 shortName,
+  bool                  useDefaultUrlIfNotFound,
+  OrionldContextItem**  contextItemPP
+);
 
-  for (int ix = 0; ix < 10; ix++)
-  {
-    if (value[ix] == 0)
-      return false;
-    else if (value[ix] == ':')
-      return true;
-  }
-
-  return false;
-}
+#endif  // SRC_LIB_ORIONLD_CONTEXT_ORIONLDATTRIBUTEEXPAND_H_

--- a/src/lib/orionld/context/orionldContextItemAlreadyExpanded.h
+++ b/src/lib/orionld/context/orionldContextItemAlreadyExpanded.h
@@ -32,6 +32,6 @@
 //
 // orionldContextItemAlreadyExpanded -
 //
-extern bool orionldContextItemAlreadyExpanded(char* value);
+extern bool orionldContextItemAlreadyExpanded(const char* value);
 
 #endif  // SRC_LIB_ORIONLD_CONTEXT_ORIONLDCONTEXTITEMALREADYEXPANDED_H_

--- a/src/lib/orionld/context/orionldSubAttributeExpand.cpp
+++ b/src/lib/orionld/context/orionldSubAttributeExpand.cpp
@@ -1,0 +1,60 @@
+/*
+*
+* Copyright 2021 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+#include <string.h>                                              // strchr
+
+#include "logMsg/logMsg.h"                                       // LM_*
+#include "logMsg/traceLevels.h"                                  // Lmt*
+
+#include "orionld/context/orionldContextItemAlreadyExpanded.h"   // orionldContextItemAlreadyExpanded
+#include "orionld/context/orionldContextItemExpand.h"            // orionldContextItemExpand
+#include "orionld/context/orionldSubAttributeExpand.h"           // Own interface
+
+
+// -----------------------------------------------------------------------------
+//
+// orionldSubAttributeExpand -
+//
+// This function expands unless:
+//   - has already been expanded
+//   - is a special sub-attribute such as 'location', 'datasetyId', ...
+//
+char* orionldSubAttributeExpand
+(
+  OrionldContext*       contextP,
+  char*                 shortName,
+  bool                  useDefaultUrlIfNotFound,
+  OrionldContextItem**  contextItemPP
+)
+{
+  if (orionldContextItemAlreadyExpanded(shortName) == true)
+    return shortName;
+
+  if      (strcmp(shortName, "location")   == 0) return shortName;
+  else if (strcmp(shortName, "observedAt") == 0) return shortName;
+  else if (strcmp(shortName, "unitCode")   == 0) return shortName;
+  else if (strcmp(shortName, "datasetId")  == 0) return shortName;
+
+  return orionldContextItemExpand(contextP, shortName, useDefaultUrlIfNotFound, contextItemPP);
+}

--- a/src/lib/orionld/context/orionldSubAttributeExpand.h
+++ b/src/lib/orionld/context/orionldSubAttributeExpand.h
@@ -1,3 +1,6 @@
+#ifndef SRC_LIB_ORIONLD_CONTEXT_ORIONLDSUBATTRIBUTEEXPAND_H_
+#define SRC_LIB_ORIONLD_CONTEXT_ORIONLDSUBATTRIBUTEEXPAND_H_
+
 /*
 *
 * Copyright 2019 FIWARE Foundation e.V.
@@ -22,26 +25,25 @@
 *
 * Author: Ken Zangelin
 */
-#include <unistd.h>                                              // NULL
+#include "orionld/context/OrionldContext.h"                      // OrionldContext
+#include "orionld/context/OrionldContextItem.h"                  // OrionldContextItem
 
 
 
 // -----------------------------------------------------------------------------
 //
-// orionldContextItemAlreadyExpanded -
+// orionldSubAttributeExpand.h -
 //
-bool orionldContextItemAlreadyExpanded(const char* value)
-{
-  if (value == NULL)
-    return false;
+// This function expands unless:
+//   - has already been expanded
+//   - is a special attribute such as location, datasetId, ...
+//
+extern char* orionldSubAttributeExpand
+(
+  OrionldContext*       contextP,
+  char*                 shortName,
+  bool                  useDefaultUrlIfNotFound,
+  OrionldContextItem**  contextItemPP
+);
 
-  for (int ix = 0; ix < 10; ix++)
-  {
-    if (value[ix] == 0)
-      return false;
-    else if (value[ix] == ':')
-      return true;
-  }
-
-  return false;
-}
+#endif  // SRC_LIB_ORIONLD_CONTEXT_ORIONLDSUBATTRIBUTEEXPAND_H_

--- a/src/lib/orionld/kjTree/kjTreeToMetadata.cpp
+++ b/src/lib/orionld/kjTree/kjTreeToMetadata.cpp
@@ -34,7 +34,8 @@ extern "C"
 #include "ngsi/ContextAttribute.h"                               // ContextAttribute
 #include "orionld/common/orionldState.h"                         // orionldState
 #include "orionld/common/orionldErrorResponse.h"                 // orionldErrorResponseCreate
-#include "orionld/context/orionldContextItemExpand.h"            // orionldContextItemExpand
+#include "orionld/context/orionldAttributeExpand.h"              // orionldAttributeExpand
+#include "orionld/context/orionldSubAttributeExpand.h"           // orionldSubAttributeExpand
 #include "orionld/kjTree/kjTreeToMetadata.h"                     // Own interface
 
 
@@ -46,53 +47,6 @@ extern "C"
 // FIXME: needs its own module under orionld/common
 //
 extern bool metadataAdd(ContextAttribute* caP, KjNode* nodeP, char* caName);
-
-
-
-// -----------------------------------------------------------------------------
-//
-// orionldSubAttributeExpand - expand the name of a sub-attribute
-//
-// FIXME: needs its own module under orionld/context
-//
-char* orionldSubAttributeExpand
-(
-  OrionldContext*       contextP,
-  char*                 shortName,
-  bool                  useDefaultUrlIfNotFound,
-  OrionldContextItem**  contextItemPP
-)
-{
-  if      (strcmp(shortName, "location")   == 0) return shortName;
-  else if (strcmp(shortName, "observedAt") == 0) return shortName;
-  else if (strcmp(shortName, "unitCode")   == 0) return shortName;
-  else if (strcmp(shortName, "datasetId")  == 0) return shortName;
-
-  return orionldContextItemExpand(contextP, shortName, useDefaultUrlIfNotFound, contextItemPP);
-}
-
-
-
-// -----------------------------------------------------------------------------
-//
-// orionldAttributeExpand - expand the name of an attribute
-//
-// FIXME: needs its own module under orionld/context
-//
-char* orionldAttributeExpand
-(
-  OrionldContext*       contextP,
-  char*                 shortName,
-  bool                  useDefaultUrlIfNotFound,
-  OrionldContextItem**  contextItemPP
-)
-{
-  if      (strcmp(shortName, "location")         == 0) return shortName;
-  else if (strcmp(shortName, "observationSpace") == 0) return shortName;
-  else if (strcmp(shortName, "operationSpace")   == 0) return shortName;
-
-  return orionldContextItemExpand(contextP, shortName, useDefaultUrlIfNotFound, contextItemPP);
-}
 
 
 

--- a/src/lib/orionld/serviceRoutines/orionldDeleteAttribute.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldDeleteAttribute.cpp
@@ -48,7 +48,7 @@ extern "C"
 #include "orionld/common/eqForDot.h"                             // eqForDot
 #include "orionld/payloadCheck/pcheckUri.h"                      // pcheckUri
 #include "orionld/db/dbConfiguration.h"                          // dbEntityAttributeLookup, dbEntityAttributesDelete
-#include "orionld/context/orionldContextItemExpand.h"            // orionldContextItemExpand
+#include "orionld/context/orionldAttributeExpand.h"              // orionldAttributeExpand
 #include "orionld/serviceRoutines/orionldDeleteAttribute.h"      // Own Interface
 
 
@@ -81,14 +81,7 @@ bool orionldDeleteAttribute(ConnectionInfo* ciP)
     return false;
   }
 
-  if ((strncmp(attrName, "http://", 7) == 0) || (strncmp(attrName, "https://", 8) == 0))
-    attrNameP = attrName;
-  else
-  {
-    attrNameP = orionldContextItemExpand(orionldState.contextP, attrName, true, NULL);
-    // attrNameP might point to a field inside the context cache - must make our own copy as 'dotForEq' will modifyit
-    attrNameP = kaStrdup(&orionldState.kalloc, attrNameP);
-  }
+  attrNameP = orionldAttributeExpand(orionldState.contextP, attrName, true, NULL);
 
   // IMPORTANT: Must call dbEntityAttributeLookup before replacing dots for eqs
   if (dbEntityAttributeLookup(entityId, attrNameP) == NULL)

--- a/src/lib/orionld/troe/troeDeleteAttribute.cpp
+++ b/src/lib/orionld/troe/troeDeleteAttribute.cpp
@@ -29,7 +29,7 @@
 #include "orionld/common/orionldState.h"                       // orionldState
 #include "orionld/common/orionldErrorResponse.h"               // orionldErrorResponseCreate
 #include "orionld/common/uuidGenerate.h"                       // uuidGenerate
-#include "orionld/context/orionldContextItemExpand.h"          // orionldContextItemExpand
+#include "orionld/context/orionldAttributeExpand.h"            // orionldAttributeExpand
 #include "orionld/troe/pgConnectionGet.h"                      // pgConnectionGet
 #include "orionld/troe/pgConnectionRelease.h"                  // pgConnectionRelease
 #include "orionld/troe/pgTransactionBegin.h"                   // pgTransactionBegin
@@ -62,7 +62,7 @@ bool troeDeleteAttribute(ConnectionInfo* ciP)
   char  instanceId[80];
   uuidGenerate(instanceId, sizeof(instanceId), true);
 
-  attributeName = orionldContextItemExpand(orionldState.contextP, attributeName, true, NULL);
+  attributeName = orionldAttributeExpand(orionldState.contextP, attributeName, true, NULL);
   if (pgAttributeDelete(connectionP, entityId, instanceId, attributeName, orionldState.requestTimeString) == false)
   {
     LM_E(("Database Error (delete attribute troe layer failed)"));

--- a/test/functionalTest/cases/0000_troe/troe_exhaustive_batch_upsert-replace.test
+++ b/test/functionalTest/cases/0000_troe/troe_exhaustive_batch_upsert-replace.test
@@ -29,7 +29,7 @@ dbInit CB
 dbInit CB t1
 pgInit $CB_DB_NAME
 pgInit ${CB_DB_NAME}_t1
-brokerStart CB 100 IPv4 -troe -multiservice
+brokerStart CB 0 IPv4 -troe -multiservice
 
 --SHELL--
 

--- a/test/functionalTest/cases/0000_troe/troe_exhaustive_delete_attribute.test
+++ b/test/functionalTest/cases/0000_troe/troe_exhaustive_delete_attribute.test
@@ -1,0 +1,445 @@
+# Copyright 2021 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Exhaustive tests of Deletion of entities for TRoE
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+dbInit CB t1
+pgInit $CB_DB_NAME
+pgInit ${CB_DB_NAME}_t1
+brokerStart CB 0 IPv4 -troe -multiservice
+
+--SHELL--
+
+#
+# 01. Create E1 on default tenant
+# 02. Create E2 on T1 tenant
+# 03. Delete E1/weight on default tenant with user context in Link header - not found
+# 04. Delete E1/weight on default tenant without context - ok
+# 05. Delete E1/location on default tenant without context - ok
+# 06. Delete E1/https://uri.etsi.org/ngsi-ld/default-context/owner on default tenant without context - ok
+# 07. Delete E1/weight on default tenant without context - does not exist
+# 08. Delete E2/weight on T1 tenant with user context in Link header - not found
+# 09. Delete E2/weight on T1 tenant without context - ok
+# 10. Delete E2/location on T1 tenant without context - ok
+# 11. Delete E2/https://uri.etsi.org/ngsi-ld/default-context/owner on T1 tenant without context - ok
+# 12. Delete E2/weight on T1 tenant without context - does not exist
+# 13. See all entities in TRoE DB, default tenant
+# 14. See all attributes in TRoE DB, default tenant
+# 15. See all sub-attributes in TRoE DB, default tenant - there aren't any
+# 16. See all entities in TRoE DB, tenant T1
+# 17. See all attributes in TRoE DB, tenant T1
+# 18. See all sub-attributes in TRoE DB, tenant T1 - there aren't any
+# 
+
+echo "01. Create E1 on default tenant"
+echo "==============================="
+payload='[
+  {
+    "id": "urn:ngsi-ld:entity:E1",
+    "type": "Device",
+    "location": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 2 ]
+      }
+    },
+    "createdAt": "2021-03-07T08:30:00.123Z",
+    "modifiedAt": "2021-03-07T08:30:00.123Z",
+    "observationSpace": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 3 ]
+      }
+    },
+    "operationSpace": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 4 ]
+      }
+    },
+    "weight": {
+      "type":  "Property",
+      "value": 250,
+      "unitCode": "kg",
+      "observedAt": "2021-03-07T08:31:00.123Z"
+    },
+    "owner": {
+      "type":  "Relationship",
+      "object": "urn:ngsi-ld:owner:1",
+      "observedAt": "2021-03-07T08:32:00.123Z"
+    }
+  }
+]'
+orionCurl --url /ngsi-ld/v1/entityOperations/create --payload "$payload"
+echo
+echo
+
+
+echo "02. Create E2 on T1 tenant"
+echo "=========================="
+payload='[
+  {
+    "id": "urn:ngsi-ld:entity:E2",
+    "type": "Device",
+    "location": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 2 ]
+      }
+    },
+    "createdAt": "2021-03-07T08:30:00.123Z",
+    "modifiedAt": "2021-03-07T08:30:00.123Z",
+    "observationSpace": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 3 ]
+      }
+    },
+    "operationSpace": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 4 ]
+      }
+    },
+    "weight": {
+      "type":  "Property",
+      "value": 250,
+      "unitCode": "kg",
+      "observedAt": "2021-03-07T08:31:00.123Z"
+    },
+    "owner": {
+      "type":  "Relationship",
+      "object": "urn:ngsi-ld:owner:1",
+      "observedAt": "2021-03-07T08:32:00.123Z"
+    }
+  }
+]'
+orionCurl --url /ngsi-ld/v1/entityOperations/create --payload "$payload" --tenant t1
+echo
+echo
+
+
+echo "03. Delete E1/weight on default tenant with user context in Link header - not found"
+echo "==================================================================================="
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entity:E1/attrs/weight -X DELETE -H 'Link: <https://raw.githubusercontent.com/FIWARE/tutorials.NGSI-LD/master/app/public/data-models/ngsi-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+echo
+echo
+
+
+echo "04. Delete E1/weight on default tenant without context - ok"
+echo "==========================================================="
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entity:E1/attrs/weight -X DELETE
+echo
+echo
+
+
+echo "05. Delete E1/location on default tenant without context - ok"
+echo "============================================================="
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entity:E1/attrs/location -X DELETE
+echo
+echo
+
+
+echo "06. Delete E1/https://uri.etsi.org/ngsi-ld/default-context/owner on default tenant without context - ok"
+echo "======================================================================================================="
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entity:E1/attrs/https://uri.etsi.org/ngsi-ld/default-context/owner -X DELETE
+echo
+echo
+
+
+echo "07. Delete E1/weight on default tenant without context - does not exist"
+echo "======================================================================="
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entity:E1/attrs/weight -X DELETE
+echo
+echo
+
+
+echo "08. Delete E2/weight on T1 tenant with user context in Link header - not found"
+echo "=============================================================================="
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entity:E2/attrs/weight -X DELETE --tenant t1 -H 'Link: <https://raw.githubusercontent.com/FIWARE/tutorials.NGSI-LD/master/app/public/data-models/ngsi-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+echo
+echo
+
+
+echo "09. Delete E2/weight on T1 tenant without context - ok"
+echo "======================================================"
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entity:E2/attrs/weight -X DELETE --tenant t1
+echo
+echo
+
+
+echo "10. Delete E2/location on T1 tenant without context - ok"
+echo "========================================================"
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entity:E2/attrs/location -X DELETE --tenant t1
+echo
+echo
+
+
+echo "11. Delete E2/https://uri.etsi.org/ngsi-ld/default-context/owner on T1 tenant without context - ok"
+echo "=================================================================================================="
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entity:E2/attrs/https://uri.etsi.org/ngsi-ld/default-context/owner -X DELETE --tenant t1
+echo
+echo
+
+
+echo "12. Delete E2/weight on T1 tenant without context - does not exist"
+echo "=================================================================="
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entity:E2/attrs/weight -X DELETE --tenant t1
+echo
+echo
+
+
+echo "13. See all entities in TRoE DB, default tenant"
+echo "==============================================="
+postgresCmd -sql "SELECT opMode,id,type,ts FROM entities"
+echo
+echo
+
+
+echo "14. See all attributes in TRoE DB, default tenant"
+echo "================================================="
+postgresCmd -sql "SELECT opMode,id,valueType,entityId,subProperties,unitcode,datasetid,text,number,boolean,observedAt,ts FROM attributes"
+echo
+echo
+
+
+echo "15. See all sub-attributes in TRoE DB, default tenant - there aren't any"
+echo "========================================================================"
+postgresCmd -sql "SELECT id,valueType,entityId,attrInstanceId,unitcode,text,number,boolean FROM subAttributes"
+echo
+echo
+
+
+echo "16. See all entities in TRoE DB, tenant T1"
+echo "=========================================="
+postgresCmd -sql "SELECT opMode,id,type,ts FROM entities" -t ftest_t1
+echo
+echo
+
+
+echo "17. See all attributes in TRoE DB, tenant T1"
+echo "============================================"
+postgresCmd -sql "SELECT opMode,id,valueType,entityId,subProperties,unitcode,datasetid,text,number,boolean,observedAt,ts FROM attributes" -t ftest_t1
+echo
+echo
+
+
+echo "18. See all sub-attributes in TRoE DB, tenant T1 - there aren't any"
+echo "==================================================================="
+postgresCmd -sql "SELECT id,valueType,entityId,attrInstanceId,unitcode,text,number,boolean FROM subAttributes" -t ftest_t1
+echo
+echo
+
+
+--REGEXPECT--
+01. Create E1 on default tenant
+===============================
+HTTP/1.1 200 OK
+Content-Length: 49
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "errors": [],
+    "success": [
+        "urn:ngsi-ld:entity:E1"
+    ]
+}
+
+
+02. Create E2 on T1 tenant
+==========================
+HTTP/1.1 200 OK
+Content-Length: 49
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "errors": [],
+    "success": [
+        "urn:ngsi-ld:entity:E2"
+    ]
+}
+
+
+03. Delete E1/weight on default tenant with user context in Link header - not found
+===================================================================================
+HTTP/1.1 404 Not Found
+Content-Length: 132
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "https://w3id.org/saref#weight",
+    "title": "Attribute Not Found",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+04. Delete E1/weight on default tenant without context - ok
+===========================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+05. Delete E1/location on default tenant without context - ok
+=============================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+06. Delete E1/https://uri.etsi.org/ngsi-ld/default-context/owner on default tenant without context - ok
+=======================================================================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+07. Delete E1/weight on default tenant without context - does not exist
+=======================================================================
+HTTP/1.1 404 Not Found
+Content-Length: 154
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "https://uri.etsi.org/ngsi-ld/default-context/weight",
+    "title": "Attribute Not Found",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+08. Delete E2/weight on T1 tenant with user context in Link header - not found
+==============================================================================
+HTTP/1.1 404 Not Found
+Content-Length: 132
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "https://w3id.org/saref#weight",
+    "title": "Attribute Not Found",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+09. Delete E2/weight on T1 tenant without context - ok
+======================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+10. Delete E2/location on T1 tenant without context - ok
+========================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+11. Delete E2/https://uri.etsi.org/ngsi-ld/default-context/owner on T1 tenant without context - ok
+==================================================================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+12. Delete E2/weight on T1 tenant without context - does not exist
+==================================================================
+HTTP/1.1 404 Not Found
+Content-Length: 154
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "https://uri.etsi.org/ngsi-ld/default-context/weight",
+    "title": "Attribute Not Found",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+13. See all entities in TRoE DB, default tenant
+===============================================
+opmode,id,type,ts
+Create,urn:ngsi-ld:entity:E1,https://uri.etsi.org/ngsi-ld/default-context/Device,202REGEX(.*)
+
+
+14. See all attributes in TRoE DB, default tenant
+=================================================
+opmode,id,valuetype,entityid,subproperties,unitcode,datasetid,text,number,boolean,observedat,ts
+Create,location,GeoPoint,urn:ngsi-ld:entity:E1,f,,,,,,,202REGEX(.*)
+Create,observationSpace,GeoPoint,urn:ngsi-ld:entity:E1,f,,,,,,,202REGEX(.*)
+Create,operationSpace,GeoPoint,urn:ngsi-ld:entity:E1,f,,,,,,,202REGEX(.*)
+Create,https://uri.etsi.org/ngsi-ld/default-context/weight,Number,urn:ngsi-ld:entity:E1,f,kg,,,250,,2021-03-07 08:31:00.123,202REGEX(.*)
+Create,https://uri.etsi.org/ngsi-ld/default-context/owner,Relationship,urn:ngsi-ld:entity:E1,f,,,urn:ngsi-ld:owner:1,,,2021-03-07 08:32:00.123,202REGEX(.*)
+Delete,https://uri.etsi.org/ngsi-ld/default-context/weight,,urn:ngsi-ld:entity:E1,,,,,,,,202REGEX(.*)
+Delete,location,,urn:ngsi-ld:entity:E1,,,,,,,,202REGEX(.*)
+Delete,https://uri.etsi.org/ngsi-ld/default-context/owner,,urn:ngsi-ld:entity:E1,,,,,,,,202REGEX(.*)
+
+
+15. See all sub-attributes in TRoE DB, default tenant - there aren't any
+========================================================================
+id,valuetype,entityid,attrinstanceid,unitcode,text,number,boolean
+
+
+16. See all entities in TRoE DB, tenant T1
+==========================================
+opmode,id,type,ts
+Create,urn:ngsi-ld:entity:E2,https://uri.etsi.org/ngsi-ld/default-context/Device,202REGEX(.*)
+
+
+17. See all attributes in TRoE DB, tenant T1
+============================================
+opmode,id,valuetype,entityid,subproperties,unitcode,datasetid,text,number,boolean,observedat,ts
+Create,location,GeoPoint,urn:ngsi-ld:entity:E2,f,,,,,,,202REGEX(.*)
+Create,observationSpace,GeoPoint,urn:ngsi-ld:entity:E2,f,,,,,,,202REGEX(.*)
+Create,operationSpace,GeoPoint,urn:ngsi-ld:entity:E2,f,,,,,,,202REGEX(.*)
+Create,https://uri.etsi.org/ngsi-ld/default-context/weight,Number,urn:ngsi-ld:entity:E2,f,kg,,,250,,2021-03-07 08:31:00.123,202REGEX(.*)
+Create,https://uri.etsi.org/ngsi-ld/default-context/owner,Relationship,urn:ngsi-ld:entity:E2,f,,,urn:ngsi-ld:owner:1,,,2021-03-07 08:32:00.123,202REGEX(.*)
+Delete,https://uri.etsi.org/ngsi-ld/default-context/weight,,urn:ngsi-ld:entity:E2,,,,,,,,202REGEX(.*)
+Delete,location,,urn:ngsi-ld:entity:E2,,,,,,,,202REGEX(.*)
+Delete,https://uri.etsi.org/ngsi-ld/default-context/owner,,urn:ngsi-ld:entity:E2,,,,,,,,202REGEX(.*)
+
+
+18. See all sub-attributes in TRoE DB, tenant T1 - there aren't any
+===================================================================
+id,valuetype,entityid,attrinstanceid,unitcode,text,number,boolean
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB
+dbDrop CB t1
+pgDrop $CB_DB_NAME
+pgDrop ${CB_DB_NAME}_t1

--- a/test/functionalTest/cases/0000_troe/troe_exhaustive_delete_entity.test
+++ b/test/functionalTest/cases/0000_troe/troe_exhaustive_delete_entity.test
@@ -1,0 +1,435 @@
+# Copyright 2021 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Exhaustive tests of Deletion of entities for TRoE
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+dbInit CB t1
+pgInit $CB_DB_NAME
+pgInit ${CB_DB_NAME}_t1
+brokerStart CB 0 IPv4 -troe -multiservice
+
+--SHELL--
+
+#
+# 01. Create E1,E3,E5 on default tenant
+# 02. Create E2,E4,E6 on T1 tenant
+# 03. Delete E1 on default tenant
+# 04. Delete E2 on T1 tenant
+# 05. Attempt to delete E1 on default tenant
+# 06. Attempt to delete E2 on T1 tenant
+# 07. See all entities in TRoE DB, default tenant
+# 08. See all entities in TRoE DB, tenant T1
+#
+
+echo "01. Create E1,E3,E5 on default tenant"
+echo "====================================="
+payload='[
+  {
+    "id": "urn:ngsi-ld:entity:E1",
+    "type": "DeviceX",
+    "location": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 2 ]
+      }
+    },
+    "createdAt": "2021-03-07T08:30:00.123Z",
+    "modifiedAt": "2021-03-07T08:30:00.123Z",
+    "observationSpace": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 3 ]
+      }
+    },
+    "operationSpace": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 4 ]
+      }
+    },
+    "weight": {
+      "type": "Property",
+      "value": 250,
+      "unitCode": "kg",
+      "observedAt": "2021-03-07T08:31:00.123Z"
+    },
+    "owner": {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:owner:1",
+      "observedAt": "2021-03-07T08:32:00.123Z"
+    }
+  },
+  {
+    "id": "urn:ngsi-ld:entity:E3",
+    "type": "DeviceX",
+    "location": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 2 ]
+      }
+    },
+    "createdAt": "2021-03-07T08:30:00.123Z",
+    "modifiedAt": "2021-03-07T08:30:00.123Z",
+    "observationSpace": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 3 ]
+      }
+    },
+    "operationSpace": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 4 ]
+      }
+    },
+    "weight": {
+      "type": "Property",
+      "value": 250,
+      "unitCode": "kg",
+      "observedAt": "2021-03-07T08:31:00.123Z"
+    },
+    "owner": {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:owner:1",
+      "observedAt": "2021-03-07T08:32:00.123Z"
+    }
+  },
+  {
+    "id": "urn:ngsi-ld:entity:E5",
+    "type": "DeviceX",
+    "location": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 2 ]
+      }
+    },
+    "createdAt": "2021-03-07T08:30:00.123Z",
+    "modifiedAt": "2021-03-07T08:30:00.123Z",
+    "observationSpace": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 3 ]
+      }
+    },
+    "operationSpace": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 4 ]
+      }
+    },
+    "weight": {
+      "type": "Property",
+      "value": 250,
+      "unitCode": "kg",
+      "observedAt": "2021-03-07T08:31:00.123Z"
+    },
+    "owner": {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:owner:1",
+      "observedAt": "2021-03-07T08:32:00.123Z"
+    }
+  }
+]'
+orionCurl --url /ngsi-ld/v1/entityOperations/create --payload "$payload"
+echo
+echo
+
+
+echo "02. Create E2,E4,E6 on T1 tenant"
+echo "================================"
+payload='[
+  {
+    "id": "urn:ngsi-ld:entity:E2",
+    "type": "DeviceX",
+    "location": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 2 ]
+      }
+    },
+    "createdAt": "2021-03-07T08:30:00.123Z",
+    "modifiedAt": "2021-03-07T08:30:00.123Z",
+    "observationSpace": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 3 ]
+      }
+    },
+    "operationSpace": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 4 ]
+      }
+    },
+    "weight": {
+      "type": "Property",
+      "value": 250,
+      "unitCode": "kg",
+      "observedAt": "2021-03-07T08:31:00.123Z"
+    },
+    "owner": {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:owner:1",
+      "observedAt": "2021-03-07T08:32:00.123Z"
+    }
+  },
+  {
+    "id": "urn:ngsi-ld:entity:E4",
+    "type": "DeviceX",
+    "location": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 2 ]
+      }
+    },
+    "createdAt": "2021-03-07T08:30:00.123Z",
+    "modifiedAt": "2021-03-07T08:30:00.123Z",
+    "observationSpace": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 3 ]
+      }
+    },
+    "operationSpace": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 4 ]
+      }
+    },
+    "weight": {
+      "type": "Property",
+      "value": 250,
+      "unitCode": "kg",
+      "observedAt": "2021-03-07T08:31:00.123Z"
+    },
+    "owner": {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:owner:1",
+      "observedAt": "2021-03-07T08:32:00.123Z"
+    }
+  },
+  {
+    "id": "urn:ngsi-ld:entity:E6",
+    "type": "DeviceX",
+    "location": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 2 ]
+      }
+    },
+    "createdAt": "2021-03-07T08:30:00.123Z",
+    "modifiedAt": "2021-03-07T08:30:00.123Z",
+    "observationSpace": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 3 ]
+      }
+    },
+    "operationSpace": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 4 ]
+      }
+    },
+    "weight": {
+      "type": "Property",
+      "value": 250,
+      "unitCode": "kg",
+      "observedAt": "2021-03-07T08:31:00.123Z"
+    },
+    "owner": {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:owner:1",
+      "observedAt": "2021-03-07T08:32:00.123Z"
+    }
+  }
+]'
+orionCurl --url /ngsi-ld/v1/entityOperations/create --payload "$payload" --tenant t1
+echo
+echo
+
+
+echo "03. Delete E1 on default tenant"
+echo "==============================="
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entity:E1 -X DELETE
+echo
+echo
+
+
+echo "04. Delete E2 on T1 tenant"
+echo "=========================="
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entity:E2 -X DELETE --tenant t1
+echo
+echo
+
+
+echo "05. Attempt to delete E1 on default tenant"
+echo "=========================================="
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entity:E1 -X DELETE
+echo
+echo
+
+
+echo "06. Attempt to delete E2 on T1 tenant"
+echo "====================================="
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entity:E2 -X DELETE --tenant t1
+echo
+echo
+
+
+echo "07. See all entities in TRoE DB, default tenant"
+echo "==============================================="
+postgresCmd -sql "SELECT opMode,id,type,ts FROM entities"
+echo
+echo
+
+
+echo "08. See all entities in TRoE DB, tenant T1"
+echo "=========================================="
+postgresCmd -sql "SELECT opMode,id,type,ts FROM entities" -t ftest_t1
+echo
+echo
+
+
+--REGEXPECT--
+01. Create E1,E3,E5 on default tenant
+=====================================
+HTTP/1.1 200 OK
+Content-Length: 97
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "errors": [],
+    "success": [
+        "urn:ngsi-ld:entity:E1",
+        "urn:ngsi-ld:entity:E3",
+        "urn:ngsi-ld:entity:E5"
+    ]
+}
+
+
+02. Create E2,E4,E6 on T1 tenant
+================================
+HTTP/1.1 200 OK
+Content-Length: 97
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "errors": [],
+    "success": [
+        "urn:ngsi-ld:entity:E2",
+        "urn:ngsi-ld:entity:E4",
+        "urn:ngsi-ld:entity:E6"
+    ]
+}
+
+
+03. Delete E1 on default tenant
+===============================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+04. Delete E2 on T1 tenant
+==========================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+05. Attempt to delete E1 on default tenant
+==========================================
+HTTP/1.1 404 Not Found
+Content-Length: 160
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "urn:ngsi-ld:entity:E1",
+    "title": "The requested entity has not been found. Check its id",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/ResourceNotFound"
+}
+
+
+06. Attempt to delete E2 on T1 tenant
+=====================================
+HTTP/1.1 404 Not Found
+Content-Length: 160
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "urn:ngsi-ld:entity:E2",
+    "title": "The requested entity has not been found. Check its id",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/ResourceNotFound"
+}
+
+
+07. See all entities in TRoE DB, default tenant
+===============================================
+opmode,id,type,ts
+Create,urn:ngsi-ld:entity:E1,https://uri.etsi.org/ngsi-ld/default-context/DeviceX,202REGEX(.*)
+Create,urn:ngsi-ld:entity:E3,https://uri.etsi.org/ngsi-ld/default-context/DeviceX,202REGEX(.*)
+Create,urn:ngsi-ld:entity:E5,https://uri.etsi.org/ngsi-ld/default-context/DeviceX,202REGEX(.*)
+Delete,urn:ngsi-ld:entity:E1,NULL,202REGEX(.*)
+
+
+08. See all entities in TRoE DB, tenant T1
+==========================================
+opmode,id,type,ts
+Create,urn:ngsi-ld:entity:E2,https://uri.etsi.org/ngsi-ld/default-context/DeviceX,202REGEX(.*)
+Create,urn:ngsi-ld:entity:E4,https://uri.etsi.org/ngsi-ld/default-context/DeviceX,202REGEX(.*)
+Create,urn:ngsi-ld:entity:E6,https://uri.etsi.org/ngsi-ld/default-context/DeviceX,202REGEX(.*)
+Delete,urn:ngsi-ld:entity:E2,NULL,202REGEX(.*)
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB
+dbDrop CB t1
+pgDrop $CB_DB_NAME
+pgDrop ${CB_DB_NAME}_t1


### PR DESCRIPTION
* Fixed a bug about expanding the attribute name in the URL
* Moved `orionldAttributeExpand` and `orionldSubAttributeExpand` to their own modules
*  Added an exhaustive TRoE test for deleting attributes