### PR TITLE
Troe/exhaustive test of sub attrs post entities

### DIFF
--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -67,7 +67,7 @@ extern "C"
 #include "orionld/common/orionldState.h"                       // orionldState
 #include "orionld/rest/OrionLdRestService.h"                   // OrionLdRestService
 #include "orionld/common/dotForEq.h"                           // dotForEq
-#include "orionld/context/orionldContextItemExpand.h"          // orionldContextItemExpand
+#include "orionld/context/orionldAttributeExpand.h"            // orionldAttributeExpand
 #include "orionld/serviceRoutines/orionldPostSubscriptions.h"  // orionldPostSubscriptions
 #endif
 
@@ -1427,18 +1427,14 @@ bool entitiesQuery
       else
       {
         BSONObj areaQuery;
+        bool    result;
 
-        bool result;
         if (scopeP->type == FIWARE_LOCATION_V2)
-        {
           result = processAreaScopeV2(scopeP, &areaQuery);
-        }
         else  // FIWARE Location NGSIv1 (legacy)
-        {
           result = processAreaScope(scopeP, &areaQuery);
-        }
 
-        if (result)
+        if (result == true)
         {
           if (orionldState.apiVersion == NGSI_LD_V1)
           {
@@ -1451,9 +1447,9 @@ bool entitiesQuery
             //
             // After that, "attrs.$ATTRNAME.coordinates" must be used
             //
-            if (orionldState.uriParams.geoproperty != NULL)
+            if ((orionldState.uriParams.geoproperty != NULL) && (strcmp(orionldState.uriParams.geoproperty, "location") != 0))
             {
-              attrNameP = orionldContextItemExpand(orionldState.contextP, orionldState.uriParams.geoproperty, true, NULL);
+              attrNameP = orionldAttributeExpand(orionldState.contextP, orionldState.uriParams.geoproperty, true, NULL);
               dotForEq(attrNameP);
             }
 

--- a/src/lib/orionld/common/duplicatedInstances.cpp
+++ b/src/lib/orionld/common/duplicatedInstances.cpp
@@ -36,7 +36,7 @@ extern "C"
 #include "logMsg/logMsg.h"                                     // LM_*
 #include "logMsg/traceLevels.h"                                // Lmt*
 
-#include "orionld/context/orionldContextItemExpand.h"          // orionldContextItemExpand
+#include "orionld/context/orionldAttributeExpand.h"            // orionldAttributeExpand
 #include "orionld/kjTree/kjStringValueLookupInArray.h"         // kjStringValueLookupInArray
 #include "orionld/common/orionldState.h"                       // orionldState
 #include "orionld/common/entityErrorPush.h"                    // entityErrorPush
@@ -168,7 +168,7 @@ static void kjEntityMergeIgnoringExistingAttributes(KjNode* entityP, char* entit
     //
     // Got an attribute - if found in 'DB entity' OR in previous instance - then ignore it
     //
-    char*   attrName   = orionldContextItemExpand(orionldState.contextP, attrP->name, true, NULL);
+    char*   attrName   = orionldAttributeExpand(orionldState.contextP, attrP->name, true, NULL);
     KjNode* dbEntityP  = entityInstanceLookup(dbEntityV, entityId, NULL);
     KjNode* attrNamesP = kjLookup(dbEntityP, "attrNames");
     KjNode* oldAttrP   = kjStringValueLookupInArray(attrNamesP, attrName);

--- a/src/lib/orionld/common/qAliasCompact.cpp
+++ b/src/lib/orionld/common/qAliasCompact.cpp
@@ -31,7 +31,7 @@ extern "C"
 #include "logMsg/traceLevels.h"                                  // Lmt*
 
 #include "orionld/context/orionldContextItemAliasLookup.h"       // orionldContextItemAliasLookup
-#include "orionld/context/orionldContextItemExpand.h"            // orionldContextItemExpand
+#include "orionld/context/orionldAttributeExpand.h"            // orionldAttributeExpand
 #include "orionld/common/orionldState.h"                         // orionldState
 #include "orionld/common/qAliasCompact.h"                        // Own interface
 
@@ -108,7 +108,7 @@ bool qAliasCompact(KjNode* qP, bool compact)
       else
       {
         // Expand the variable
-        alias = orionldContextItemExpand(orionldState.contextP, varStart, true, NULL);
+        alias = orionldAttributeExpand(orionldState.contextP, varStart, true, NULL);
       }
 
       if (alias != NULL)

--- a/src/lib/orionld/common/qParse.cpp
+++ b/src/lib/orionld/common/qParse.cpp
@@ -32,7 +32,8 @@ extern "C"
 #include "logMsg/logMsg.h"                                     // LM_*
 #include "logMsg/traceLevels.h"                                // Lmt*
 
-#include "orionld/context/orionldContextItemExpand.h"          // orionldContextItemExpand
+#include "orionld/context/orionldAttributeExpand.h"            // orionldAttributeExpand
+#include "orionld/context/orionldSubAttributeExpand.h"         // orionldSubAttributeExpand
 #include "orionld/common/orionldState.h"                       // orionldState
 #include "orionld/common/QNode.h"                              // QNode
 #include "orionld/common/qLexRender.h"                         // qLexRender - DEBUG
@@ -206,7 +207,7 @@ static char* varFix(char* varPath, char** detailsP)
   //
   // All OK - let's compose ...
   //
-  char* longNameP = orionldContextItemExpand(orionldState.contextP, attrNameP, true, NULL);
+  char* longNameP = orionldAttributeExpand(orionldState.contextP, attrNameP, true, NULL);
 
   //
   // Now 'longNameP' needs to be adjusted forthe DB model, that changes '.' for '=' in the database.
@@ -233,7 +234,7 @@ static char* varFix(char* varPath, char** detailsP)
   {
     if (strcmp(mdNameP, "observedAt") != 0)  // Don't expand "observedAt", nor ...
     {
-      char* mdLongNameP  = orionldContextItemExpand(orionldState.contextP, mdNameP, true, NULL);
+      char* mdLongNameP  = orionldSubAttributeExpand(orionldState.contextP, mdNameP, true, NULL);
 
       strncpy(mdLongName, mdLongNameP, sizeof(mdLongName) - 1);
 

--- a/src/lib/orionld/context/orionldAttributeExpand.cpp
+++ b/src/lib/orionld/context/orionldAttributeExpand.cpp
@@ -22,7 +22,7 @@
 *
 * Author: Ken Zangelin
 */
-#include <string.h>                                              // strchr
+#include <string.h>                                              // strcmp
 
 #include "logMsg/logMsg.h"                                       // LM_*
 #include "logMsg/traceLevels.h"                                  // Lmt*
@@ -30,6 +30,7 @@
 #include "orionld/context/orionldContextItemAlreadyExpanded.h"   // orionldContextItemAlreadyExpanded
 #include "orionld/context/orionldContextItemExpand.h"            // orionldContextItemExpand
 #include "orionld/context/orionldAttributeExpand.h"              // Own interface
+
 
 
 // -----------------------------------------------------------------------------
@@ -48,12 +49,12 @@ char* orionldAttributeExpand
   OrionldContextItem**  contextItemPP
 )
 {
-  if (orionldContextItemAlreadyExpanded(shortName) == true)
-    return shortName;
-
   if      (strcmp(shortName, "location")         == 0) return shortName;
   else if (strcmp(shortName, "observationSpace") == 0) return shortName;
   else if (strcmp(shortName, "operationSpace")   == 0) return shortName;
+
+  if (orionldContextItemAlreadyExpanded(shortName) == true)
+    return shortName;
 
   return orionldContextItemExpand(contextP, shortName, useDefaultUrlIfNotFound, contextItemPP);
 }

--- a/src/lib/orionld/context/orionldAttributeExpand.cpp
+++ b/src/lib/orionld/context/orionldAttributeExpand.cpp
@@ -52,6 +52,7 @@ char* orionldAttributeExpand
   if      (strcmp(shortName, "location")         == 0) return shortName;
   else if (strcmp(shortName, "observationSpace") == 0) return shortName;
   else if (strcmp(shortName, "operationSpace")   == 0) return shortName;
+  else if (strcmp(shortName, "observedAt")       == 0) return shortName;
 
   if (orionldContextItemAlreadyExpanded(shortName) == true)
     return shortName;

--- a/src/lib/orionld/context/orionldContextItemAlreadyExpanded.cpp
+++ b/src/lib/orionld/context/orionldContextItemAlreadyExpanded.cpp
@@ -23,6 +23,9 @@
 * Author: Ken Zangelin
 */
 #include <unistd.h>                                              // NULL
+#include <string.h>                                              // strncmp
+
+#include "orionld/context/orionldContextItemAlreadyExpanded.h"   // Own interface
 
 
 
@@ -35,12 +38,11 @@ bool orionldContextItemAlreadyExpanded(const char* value)
   if (value == NULL)
     return false;
 
-  for (int ix = 0; ix < 10; ix++)
+  if ((strncmp(value, "urn:",     4) == 0) ||
+      (strncmp(value, "http://",  7) == 0) ||
+      (strncmp(value, "https://", 8) == 0))
   {
-    if (value[ix] == 0)
-      return false;
-    else if (value[ix] == ':')
-      return true;
+    return true;
   }
 
   return false;

--- a/src/lib/orionld/kjTree/kjTreeFromQueryContextResponse.cpp
+++ b/src/lib/orionld/kjTree/kjTreeFromQueryContextResponse.cpp
@@ -43,7 +43,7 @@ extern "C"
 #include "orionld/common/SCOMPARE.h"                           // SCOMPAREx
 #include "orionld/common/orionldState.h"                       // orionldState
 #include "orionld/context/orionldCoreContext.h"                // orionldCoreContext
-#include "orionld/context/orionldContextItemExpand.h"          // orionldContextItemExpand
+#include "orionld/context/orionldAttributeExpand.h"            // orionldAttributeExpand
 #include "orionld/context/orionldContextItemAliasLookup.h"     // orionldContextItemAliasLookup
 #include "orionld/kjTree/kjTreeFromContextAttribute.h"         // kjTreeFromContextAttribute
 #include "orionld/kjTree/kjTreeFromCompoundValue.h"            // kjTreeFromCompoundValue
@@ -137,7 +137,7 @@ static void attrListParseAndExpand(int* attrsInAttrListP, char*** attrListExpand
   //
   for (int ix = 0; ix < attrs; ix++)
   {
-    expandedV[ix] = orionldContextItemExpand(orionldState.contextP, expandedV[ix], true, NULL);
+    expandedV[ix] = orionldAttributeExpand(orionldState.contextP, expandedV[ix], true, NULL);
   }
 
   *attrListExpandedVecP = expandedV;

--- a/src/lib/orionld/kjTree/kjTreeToEntIdVector.cpp
+++ b/src/lib/orionld/kjTree/kjTreeToEntIdVector.cpp
@@ -131,7 +131,7 @@ bool kjTreeToEntIdVector(KjNode* kNodeP, std::vector<ngsiv2::EntID>* entitiesP)
     if (idP)        entityInfo.id        = idP;
     if (idPatternP) entityInfo.idPattern = idPatternP;
 
-    entityInfo.type      = orionldContextItemExpand(orionldState.contextP, typeP, true, NULL);
+    entityInfo.type      = orionldContextItemExpand(orionldState.contextP, typeP, true, NULL);  // entity type
     entitiesP->push_back(entityInfo);
   }
 

--- a/src/lib/orionld/kjTree/kjTreeToMetadata.cpp
+++ b/src/lib/orionld/kjTree/kjTreeToMetadata.cpp
@@ -46,7 +46,7 @@ extern "C"
 //
 // FIXME: needs its own module under orionld/common
 //
-extern bool metadataAdd(ContextAttribute* caP, KjNode* nodeP, char* caName);
+extern bool metadataAdd(ContextAttribute* caP, KjNode* nodeP, char* attributeName);
 
 
 
@@ -54,11 +54,28 @@ extern bool metadataAdd(ContextAttribute* caP, KjNode* nodeP, char* caName);
 //
 // kjTreeToMetadata -
 //
-bool kjTreeToMetadata(ContextAttribute* caP, KjNode* nodeP, char* caName, char** detailP)
+bool kjTreeToMetadata(ContextAttribute* caP, KjNode* nodeP, char* attributeName, char** detailP)
 {
   //
-  // A sub-attribute must be a JSON object (except if key-values, but that's for GET only in NGSI-LD)
+  // A sub-attribute must be a JSON object (except if key-values, but that's for GET only in NGSI-LD  - for now ...)
+  // Exceptions are:
+  //   - createdAt (to be ignored)
+  //   - modifiedAt (to be ignored)
+  //   - observedAt (should ne made an exception but doesn't seem necessary right now ...)
+  //   - unitCode    -"-
+  //   - datasetId   -"-
   //
+  if ((strcmp(nodeP->name, "createdAt") == 0) || (strcmp(nodeP->name, "modifiedAt") == 0))
+    return true;  // OK, just ignored
+
+  //
+  // About these last three (observedAt, unitCode, datasetId) ...
+  // My gut tells me I should implement special cases for the three but all tests are working ...
+  // And I'm using all three of them!
+  //
+  // I'll probably have to revisit this soon enough ...
+  //
+
   if (nodeP->type != KjObject)
   {
     *detailP = (char*) "sub-attribute must be a JSON object";
@@ -80,7 +97,7 @@ bool kjTreeToMetadata(ContextAttribute* caP, KjNode* nodeP, char* caName, char**
     return false;
   }
 
-  if (metadataAdd(caP, nodeP, caName) == false)
+  if (metadataAdd(caP, nodeP, attributeName) == false)
   {
     // metadataAdd calls orionldErrorResponseCreate
     LM_E(("Error adding metadata '%s' to attribute", nodeP->name));

--- a/src/lib/orionld/kjTree/kjTreeToRegistration.cpp
+++ b/src/lib/orionld/kjTree/kjTreeToRegistration.cpp
@@ -39,6 +39,7 @@ extern "C"
 #include "orionld/common/orionldState.h"                       // orionldState
 #include "orionld/common/orionldErrorResponse.h"               // orionldErrorResponseCreate
 #include "orionld/context/orionldContextItemExpand.h"          // orionldContextItemExpand
+#include "orionld/context/orionldAttributeExpand.h"            // orionldAttributeExpand
 #include "orionld/payloadCheck/pcheckUri.h"                    // pcheckUri
 #include "orionld/kjTree/kjTreeToEntIdVector.h"                // kjTreeToEntIdVector
 #include "orionld/kjTree/kjTreeToTimeInterval.h"               // kjTreeToTimeInterval
@@ -119,7 +120,7 @@ static bool kjTreeToRegistrationInformation(KjNode* regInfoNodeP, ngsiv2::Regist
         {
           STRING_CHECK(propP, "PropertyInfo::name");
 
-          propP->value.s = orionldContextItemExpand(orionldState.contextP, propP->value.s, true, NULL);
+          propP->value.s = orionldAttributeExpand(orionldState.contextP, propP->value.s, true, NULL);
           regP->dataProvided.propertyV.push_back(propP->value.s);
         }
       }
@@ -137,7 +138,7 @@ static bool kjTreeToRegistrationInformation(KjNode* regInfoNodeP, ngsiv2::Regist
         {
           STRING_CHECK(relP, "RelationInfo::name");
 
-          relP->value.s = orionldContextItemExpand(orionldState.contextP, relP->value.s, true, NULL);
+          relP->value.s = orionldAttributeExpand(orionldState.contextP, relP->value.s, true, NULL);
           regP->dataProvided.relationshipV.push_back(relP->value.s);
         }
       }
@@ -337,7 +338,7 @@ bool kjTreeToRegistration(ngsiv2::Registration* regP, char** regIdPP)
       //
       // Expand the name of the property
       //
-      kNodeP->name = orionldContextItemExpand(orionldState.contextP, kNodeP->name, true, NULL);
+      kNodeP->name = orionldAttributeExpand(orionldState.contextP, kNodeP->name, true, NULL);
     }
 
     kNodeP = next;

--- a/src/lib/orionld/kjTree/kjTreeToStringList.cpp
+++ b/src/lib/orionld/kjTree/kjTreeToStringList.cpp
@@ -33,10 +33,10 @@ extern "C"
 #include "kjson/KjNode.h"                                      // KjNode
 }
 
-#include "orionld/common/CHECK.h"                              // CHECKx()
+#include "orionld/common/CHECK.h"                              // STRING_CHECK()
 #include "orionld/common/orionldState.h"                       // orionldState
 #include "orionld/common/orionldErrorResponse.h"               // orionldErrorResponseCreate
-#include "orionld/context/orionldContextItemExpand.h"          // orionldContextItemExpand
+#include "orionld/context/orionldAttributeExpand.h"            // orionldAttributeExpand
 #include "orionld/kjTree/kjTreeToStringList.h"                 // Own interface
 
 
@@ -45,6 +45,9 @@ extern "C"
 //
 // kjTreeToStringList -
 //
+// The list is supposed to contain a list of attribute names, and these names are expanded
+// if necessary, according to the current context.
+//
 bool kjTreeToStringList(KjNode* kNodeP, std::vector<std::string>* stringListP)
 {
   for (KjNode* attributeP = kNodeP->value.firstChildP; attributeP != NULL; attributeP = attributeP->next)
@@ -52,15 +55,7 @@ bool kjTreeToStringList(KjNode* kNodeP, std::vector<std::string>* stringListP)
     char*   expanded;
 
     STRING_CHECK(attributeP, "String-List item");
-
-    //
-    // Special attributes are not expanded
-    //
-    if (strcmp(attributeP->value.s, "location") == 0)
-      expanded = attributeP->value.s;
-    else
-      expanded = orionldContextItemExpand(orionldState.contextP, attributeP->value.s, true, NULL);
-
+    expanded = orionldAttributeExpand(orionldState.contextP, attributeP->value.s, true, NULL);
     stringListP->push_back(expanded);
   }
 

--- a/src/lib/orionld/kjTree/kjTreeToUpdateContextRequest.cpp
+++ b/src/lib/orionld/kjTree/kjTreeToUpdateContextRequest.cpp
@@ -283,7 +283,7 @@ void kjTreeToUpdateContextRequest(UpdateContextRequest* ucrP, KjNode* treeP, KjN
       entityType = dbEntityTypeP->value.s;
     }
 
-    entityTypeExpanded = orionldContextItemExpand(contextP, entityType, true, NULL);
+    entityTypeExpanded = orionldContextItemExpand(contextP, entityType, true, NULL);  // entity type
     if (entityTypeExpanded == NULL)
     {
       LM_E(("orionldContextItemExpand failed for '%s': %s", entityType, detail));

--- a/src/lib/orionld/mongoBackend/mongoLdRegistrationsGet.cpp
+++ b/src/lib/orionld/mongoBackend/mongoLdRegistrationsGet.cpp
@@ -37,6 +37,7 @@
 #include "orionld/common/urlCheck.h"                             // urlCheck
 #include "orionld/common/orionldErrorResponse.h"                 // orionldErrorResponseCreate
 #include "orionld/context/orionldContextItemExpand.h"            // orionldContextItemExpand
+#include "orionld/context/orionldAttributeExpand.h"              // orionldAttributeExpand
 #include "mongoBackend/MongoGlobal.h"                            // getMongoConnection
 #include "mongoBackend/safeMongo.h"                              // moreSafe
 #include "mongoBackend/connectionOperations.h"                   // collectionRangedQuery
@@ -173,7 +174,6 @@ static bool uriParamAttrsToFilter(mongo::BSONObjBuilder* queryBuilderP, char* at
   int                         attrs;
   mongo::BSONObjBuilder       bsonInExpression;
   mongo::BSONArrayBuilder     bsonArray;
-  char*                       details;
 
   attrs = stringSplit(attrsList, ',', attrsVec);
 
@@ -188,16 +188,8 @@ static bool uriParamAttrsToFilter(mongo::BSONObjBuilder* queryBuilderP, char* at
   {
     char* attr = (char*) attrsVec[ix].c_str();
 
-    if ((strncmp(attr, "http", 4) == 0) && (urlCheck(attr, &details) == true))
-    {
-      // No expansion desired, the attr is already a FQN
-      bsonArray.append(attr);
-    }
-    else
-    {
-      char* attrExpanded = orionldContextItemExpand(orionldState.contextP, attr, true, NULL);
-      bsonArray.append(attrExpanded);
-    }
+    attr = orionldAttributeExpand(orionldState.contextP, attr, true, NULL);
+    bsonArray.append(attr);
   }
 
   bsonInExpression.append("$in", bsonArray.arr());

--- a/src/lib/orionld/mongoBackend/mongoLdRegistrationsGet.cpp
+++ b/src/lib/orionld/mongoBackend/mongoLdRegistrationsGet.cpp
@@ -147,7 +147,7 @@ static bool uriParamTypeToFilter(mongo::BSONObjBuilder* queryBuilderP, char* typ
     }
     else
     {
-      char* typeExpanded = orionldContextItemExpand(orionldState.contextP, type, true, NULL);
+      char* typeExpanded = orionldContextItemExpand(orionldState.contextP, type, true, NULL);  // entity type
       bsonArray.append(typeExpanded);
     }
   }

--- a/src/lib/orionld/payloadCheck/pcheckAttrs.cpp
+++ b/src/lib/orionld/payloadCheck/pcheckAttrs.cpp
@@ -32,7 +32,7 @@ extern "C"
 
 #include "orionld/common/orionldState.h"                         // orionldState
 #include "orionld/common/orionldErrorResponse.h"                 // orionldErrorResponseCreate
-#include "orionld/context/orionldContextItemExpand.h"            // orionldContextItemExpand
+#include "orionld/context/orionldAttributeExpand.h"              // orionldAttributeExpand
 #include "orionld/payloadCheck/pcheckAttrs.h"                    // Own interface
 
 
@@ -60,7 +60,7 @@ bool pcheckAttrs(KjNode* tree)
       return false;
     }
 
-    attrP->value.s = orionldContextItemExpand(orionldState.contextP, attrP->value.s, true, NULL);
+    attrP->value.s = orionldAttributeExpand(orionldState.contextP, attrP->value.s, true, NULL);
   }
 
   return true;

--- a/src/lib/orionld/payloadCheck/pcheckEntityInfo.cpp
+++ b/src/lib/orionld/payloadCheck/pcheckEntityInfo.cpp
@@ -79,7 +79,7 @@ bool pcheckEntityInfo(KjNode* entityInfoP, bool typeMandatory)
       // If a ':' is found inside the first 10 chars, the value is assumed to be expanded ...
       //
       if (orionldContextItemAlreadyExpanded(entityItemP->value.s) == false)
-        entityItemP->value.s = orionldContextItemExpand(orionldState.contextP, entityItemP->value.s, true, NULL);
+        entityItemP->value.s = orionldContextItemExpand(orionldState.contextP, entityItemP->value.s, true, NULL);  // entity type
     }
     else
     {

--- a/src/lib/orionld/payloadCheck/pcheckGeoQ.cpp
+++ b/src/lib/orionld/payloadCheck/pcheckGeoQ.cpp
@@ -37,7 +37,7 @@ extern "C"
 #include "orionld/common/orionldErrorResponse.h"                // orionldErrorResponseCreate
 #include "orionld/common/dotForEq.h"                            // dotForEq
 #include "orionld/types/OrionldProblemDetails.h"                // OrionldProblemDetails
-#include "orionld/context/orionldContextItemExpand.h"           // orionldContextItemExpand
+#include "orionld/context/orionldAttributeExpand.h"             // orionldAttributeExpand
 #include "orionld/payloadCheck/pcheckGeoType.h"                 // pcheckGeoType
 #include "orionld/payloadCheck/pcheckGeoqCoordinates.h"         // pcheckGeoqCoordinates
 #include "orionld/payloadCheck/pcheckGeoqGeorel.h"              // pcheckGeoqGeorel
@@ -204,7 +204,7 @@ bool pcheckGeoQ(KjNode* geoqNodeP, bool coordsToString)
 
     if (strcmp(pName, "location") != 0)
     {
-      geopropertyP->value.s = orionldContextItemExpand(orionldState.contextP, pName, true, NULL);
+      geopropertyP->value.s = orionldAttributeExpand(orionldState.contextP, pName, true, NULL);
       dotForEq(geopropertyP->value.s);
     }
   }

--- a/src/lib/orionld/payloadCheck/pcheckInformationItem.cpp
+++ b/src/lib/orionld/payloadCheck/pcheckInformationItem.cpp
@@ -30,8 +30,7 @@ extern "C"
 #include "orionld/common/CHECK.h"                               // STRING_CHECK, ...
 #include "orionld/common/orionldState.h"                        // orionldState
 #include "orionld/common/orionldErrorResponse.h"                // orionldErrorResponseCreate
-#include "orionld/context/orionldContextItemAlreadyExpanded.h"  // orionldContextItemAlreadyExpanded
-#include "orionld/context/orionldContextItemExpand.h"           // orionldContextItemExpand
+#include "orionld/context/orionldAttributeExpand.h"             // orionldAttributeExpand
 #include "orionld/payloadCheck/pcheckEntityInfoArray.h"         // pcheckEntityInfoArray
 #include "orionld/payloadCheck/pcheckInformationItem.h"         // Own interface
 
@@ -74,8 +73,7 @@ bool pcheckInformationItem(KjNode* informationP)
       {
         STRING_CHECK(propP, "information[X]::properties[X]");
         EMPTY_STRING_CHECK(propP, "information[X]::properties[X]");
-        if (orionldContextItemAlreadyExpanded(propP->value.s) == false)
-          propP->value.s = orionldContextItemExpand(orionldState.contextP, propP->value.s, true, NULL);
+        propP->value.s = orionldAttributeExpand(orionldState.contextP, propP->value.s, true, NULL);
       }
     }
     else if (strcmp(infoItemP->name, "relationships") == 0)
@@ -87,8 +85,7 @@ bool pcheckInformationItem(KjNode* informationP)
       {
         STRING_CHECK(relP, "information[X]::relationships[X]");
         EMPTY_STRING_CHECK(relP, "information[X]::relationships[X]");
-        if (orionldContextItemAlreadyExpanded(relP->value.s) == false)
-          relP->value.s = orionldContextItemExpand(orionldState.contextP, relP->value.s, true, NULL);
+        relP->value.s = orionldAttributeExpand(orionldState.contextP, relP->value.s, true, NULL);
       }
     }
     else

--- a/src/lib/orionld/payloadCheck/pcheckNotification.cpp
+++ b/src/lib/orionld/payloadCheck/pcheckNotification.cpp
@@ -33,7 +33,7 @@ extern "C"
 #include "orionld/common/CHECK.h"                               // STRING_CHECK, ...
 #include "orionld/common/orionldState.h"                        // orionldState
 #include "orionld/common/orionldErrorResponse.h"                // orionldErrorResponseCreate
-#include "orionld/context/orionldContextItemExpand.h"           // orionldContextItemExpand
+#include "orionld/context/orionldAttributeExpand.h"             // orionldAttributeExpand
 #include "orionld/payloadCheck/pcheckEndpoint.h"                // pcheckEndpoint
 #include "orionld/payloadCheck/pcheckNotification.h"            // Own interface
 
@@ -63,7 +63,7 @@ bool pcheckNotification(KjNode* notificationP)
       for (KjNode* attrP = nItemP->value.firstChildP; attrP != NULL; attrP = attrP->next)
       {
         STRING_CHECK(attrP, "attributes array item");
-        attrP->value.s = orionldContextItemExpand(orionldState.contextP, attrP->value.s, true, NULL);
+        attrP->value.s = orionldAttributeExpand(orionldState.contextP, attrP->value.s, true, NULL);
       }
     }
     else if (strcmp(nItemP->name, "format") == 0)

--- a/src/lib/orionld/payloadCheck/pcheckSubscription.cpp
+++ b/src/lib/orionld/payloadCheck/pcheckSubscription.cpp
@@ -34,7 +34,7 @@ extern "C"
 #include "orionld/common/orionldState.h"                         // orionldState
 #include "orionld/common/orionldErrorResponse.h"                 // orionldErrorResponseCreate
 #include "orionld/common/qAliasCompact.h"                        // qAliasCompact
-#include "orionld/context/orionldContextItemExpand.h"            // orionldContextItemExpand
+#include "orionld/context/orionldAttributeExpand.h"              // orionldAttributeExpand
 #include "orionld/payloadCheck/pcheckGeoQ.h"                     // pcheckGeoQ
 #include "orionld/payloadCheck/pcheckEntityInfoArray.h"          // pcheckEntityInfoArray
 #include "orionld/payloadCheck/pcheckNotification.h"             // pcheckNotification
@@ -135,7 +135,7 @@ bool pcheckSubscription
       for (KjNode* itemP = nodeP->value.firstChildP; itemP != NULL; itemP = itemP->next)
       {
         STRING_CHECK(itemP, "watchedAttributes item");
-        itemP->value.s = orionldContextItemExpand(orionldState.contextP, itemP->value.s, true, NULL);
+        itemP->value.s = orionldAttributeExpand(orionldState.contextP, itemP->value.s, true, NULL);
       }
       *watchedAttributesPP = watchedAttributesP;
     }

--- a/src/lib/orionld/serviceRoutines/orionldGetEntities.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntities.cpp
@@ -56,6 +56,7 @@ extern "C"
 #include "orionld/kjTree/kjTreeFromQueryContextResponse.h"     // kjTreeFromQueryContextResponse
 #include "orionld/context/orionldCoreContext.h"                // orionldDefaultUrl
 #include "orionld/context/orionldContextItemExpand.h"          // orionldContextItemExpand
+#include "orionld/context/orionldAttributeExpand.h"            // orionldAttributeExpand
 #include "orionld/serviceRoutines/orionldGetEntity.h"          // orionldGetEntity - if URI param 'id' is given
 #include "orionld/serviceRoutines/orionldGetEntities.h"        // Own Interface
 
@@ -349,7 +350,7 @@ bool orionldGetEntities(ConnectionInfo* ciP)
     //   null out prefix expansion so, I'veremoved the call to pcheckUri() and
     //   I always expand ...
     //
-    type = orionldContextItemExpand(orionldState.contextP, type, true, NULL);
+    type = orionldContextItemExpand(orionldState.contextP, type, true, NULL);  // entity type
 
     isTypePattern = false;  // Just in case ...
   }
@@ -367,7 +368,7 @@ bool orionldGetEntities(ConnectionInfo* ciP)
     for (int ix = 0; ix < typeVecItems; ix++)
     {
       if (pcheckUri(typeVector[ix], &detail) == false)
-        typeExpanded = orionldContextItemExpand(orionldState.contextP, typeVector[ix], true, NULL);
+        typeExpanded = orionldContextItemExpand(orionldState.contextP, typeVector[ix], true, NULL);  // entity type
       else
         typeExpanded = typeVector[ix];
 
@@ -396,7 +397,7 @@ bool orionldGetEntities(ConnectionInfo* ciP)
           (strcmp(attrsV[ix], "observationSpace") != 0) &&
           (strcmp(attrsV[ix], "operationSpace")   != 0))
       {
-        attrsV[ix] = orionldContextItemExpand(orionldState.contextP, attrsV[ix], true, NULL);
+        attrsV[ix] = orionldAttributeExpand(orionldState.contextP, attrsV[ix], true, NULL);
       }
 
       mongoRequest.attributeList.push_back(attrsV[ix]);
@@ -557,7 +558,7 @@ bool orionldGetEntities(ConnectionInfo* ciP)
           (strcmp(geoPropertyName, "observationSpace") != 0) &&
           (strcmp(geoPropertyName, "operationSpace")   != 0))
       {
-        geoPropertyNameExpanded = orionldContextItemExpand(orionldState.contextP, geoPropertyName, true, NULL);
+        geoPropertyNameExpanded = orionldAttributeExpand(orionldState.contextP, (char*) geoPropertyName, true, NULL);
 
         geoPropertyNameExpanded = kaStrdup(&orionldState.kalloc, geoPropertyNameExpanded);
         dotForEq(geoPropertyNameExpanded);

--- a/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
@@ -49,7 +49,7 @@ extern "C"
 #include "orionld/common/performance.h"                          // REQUEST_PERFORMANCE
 #include "orionld/payloadCheck/pcheckUri.h"                      // pcheckUri
 #include "orionld/context/orionldContextItemAliasLookup.h"       // orionldContextItemAliasLookup
-#include "orionld/context/orionldContextItemExpand.h"            // orionldContextItemExpand
+#include "orionld/context/orionldAttributeExpand.h"              // orionldAttributeExpand
 #include "orionld/db/dbConfiguration.h"                          // dbRegistrationLookup, dbEntityRetrieve
 #include "orionld/kjTree/kjTreeFromQueryContextResponse.h"       // kjTreeFromQueryContextResponse
 #include "orionld/kjTree/kjTreeRegistrationInfoExtract.h"        // kjTreeRegistrationInfoExtract
@@ -369,7 +369,7 @@ static char** attrsListToArray(char* attrList, char* dotAttrV[], char* eqAttrV[]
   {
     if (strcmp(eqAttrV[ix], "location") != 0)
     {
-      eqAttrV[ix]  = orionldContextItemExpand(orionldState.contextP, eqAttrV[ix], true, NULL);
+      eqAttrV[ix]  = orionldAttributeExpand(orionldState.contextP, eqAttrV[ix], true, NULL);
       dotAttrV[ix] = kaStrdup(&orionldState.kalloc, eqAttrV[ix]);
 
       // Copy eqAttrV[ix] before converting '.' to '=' - to not destroy the @context
@@ -480,7 +480,7 @@ bool orionldGetEntity(ConnectionInfo* ciP)
   {
     if ((orionldState.uriParams.geometryProperty != NULL) && (strcmp(orionldState.uriParams.geometryProperty, "location") != 0))
     {
-      geometryProperty = orionldContextItemExpand(orionldState.contextP, orionldState.uriParams.geometryProperty, true, NULL);
+      geometryProperty = orionldAttributeExpand(orionldState.contextP, orionldState.uriParams.geometryProperty, true, NULL);
       geometryProperty = kaStrdup(&orionldState.kalloc, geometryProperty);
       dotForEq(geometryProperty);
     }

--- a/src/lib/orionld/serviceRoutines/orionldPatchAttribute.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchAttribute.cpp
@@ -51,7 +51,7 @@ extern "C"
 #include "orionld/context/orionldCoreContext.h"                  // orionldCoreContextP
 #include "orionld/context/orionldContextFromTree.h"              // orionldContextFromTree
 #include "orionld/context/orionldContextItemAliasLookup.h"       // orionldContextItemAliasLookup
-#include "orionld/context/orionldContextItemExpand.h"            // orionldUriExpand
+#include "orionld/context/orionldAttributeExpand.h"              // orionldAttributeExpand
 #include "orionld/kjTree/kjTreeToEntity.h"                       // kjTreeToEntity
 #include "orionld/kjTree/kjTreeRegistrationInfoExtract.h"        // kjTreeRegistrationInfoExtract
 #include "orionld/mongoBackend/mongoAttributeExists.h"           // mongoAttributeExists
@@ -382,7 +382,7 @@ bool orionldPatchAttribute(ConnectionInfo* ciP)
       (strcmp(attrName, "operationSpace")   != 0) &&
       (strcmp(attrName, "observedAt")       != 0))
   {
-    attrName = orionldContextItemExpand(orionldState.contextP, attrName, true, NULL);
+    attrName = orionldAttributeExpand(orionldState.contextP, attrName, true, NULL);
   }
 
   if (forwarding)

--- a/src/lib/orionld/serviceRoutines/orionldPatchEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchEntity.cpp
@@ -47,7 +47,7 @@ extern "C"
 #include "orionld/common/attributeUpdated.h"                     // attributeUpdated
 #include "orionld/common/attributeNotUpdated.h"                  // attributeNotUpdated
 #include "orionld/payloadCheck/pcheckUri.h"                      // pcheckUri
-#include "orionld/context/orionldContextItemExpand.h"            // orionldContextItemExpand
+#include "orionld/context/orionldAttributeExpand.h"              // orionldAttributeExpand
 #include "orionld/kjTree/kjTreeToContextAttribute.h"             // kjTreeToContextAttribute
 #include "orionld/kjTree/kjStringValueLookupInArray.h"           // kjStringValueLookupInArray
 #include "orionld/mongoBackend/mongoAttributeExists.h"           // mongoAttributeExists
@@ -271,13 +271,8 @@ bool orionldPatchEntity(ConnectionInfo* ciP)
       newAttrP = next;
       continue;
     }
-    else if ((strcmp(newAttrP->name, "location")         != 0) &&
-             (strcmp(newAttrP->name, "observationSpace") != 0) &&
-             (strcmp(newAttrP->name, "operationSpace")   != 0) &&
-             (strcmp(newAttrP->name, "observedAt")       != 0))
-    {
-      newAttrP->name = orionldContextItemExpand(orionldState.contextP, newAttrP->name, true, NULL);
-    }
+    else
+      newAttrP->name = orionldAttributeExpand(orionldState.contextP, newAttrP->name, true, NULL);
 
     // Is the attribute in the incoming payload a valid attribute?
     if (attributeCheck(ciP, newAttrP, &title, &detail) == false)

--- a/src/lib/orionld/serviceRoutines/orionldPatchRegistration.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchRegistration.cpp
@@ -39,8 +39,7 @@ extern "C"
 #include "orionld/common/orionldState.h"                        // orionldState
 #include "orionld/common/orionldErrorResponse.h"                // orionldErrorResponseCreate
 #include "orionld/common/numberToDate.h"                        // numberToDate
-#include "orionld/context/orionldContextItemExpand.h"           // orionldContextItemExpand
-#include "orionld/context/orionldContextItemAlreadyExpanded.h"  // orionldContextItemAlreadyExpanded
+#include "orionld/context/orionldAttributeExpand.h"             // orionldAttributeExpand
 #include "orionld/db/dbConfiguration.h"                         // dbRegistrationGet, dbRegistrationReplace
 #include "orionld/payloadCheck/pcheckRegistration.h"            // pcheckRegistration
 #include "orionld/payloadCheck/pcheckUri.h"                     // pcheckUri
@@ -603,8 +602,7 @@ bool orionldPatchRegistration(ConnectionInfo* ciP)
 
     next = propertyP->next;
 
-    if (orionldContextItemAlreadyExpanded(propertyP->name) == false)
-      propertyP->name = orionldContextItemExpand(orionldState.contextP, propertyP->name, true, NULL);
+    propertyP->name = orionldAttributeExpand(orionldState.contextP, propertyP->name, true, NULL);
 
     if ((dbPropertyP = kjLookup(dbPropertiesP, propertyP->name)) == NULL)
     {

--- a/src/lib/orionld/serviceRoutines/orionldPostBatchUpdate.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostBatchUpdate.cpp
@@ -61,6 +61,7 @@ extern "C"
 #include "orionld/context/orionldContextPresent.h"             // orionldContextPresent
 #include "orionld/context/orionldContextItemAliasLookup.h"     // orionldContextItemAliasLookup
 #include "orionld/context/orionldContextItemExpand.h"          // orionldContextItemExpand
+#include "orionld/context/orionldAttributeExpand.h"            // orionldAttributeExpand
 #include "orionld/context/orionldContextFromTree.h"            // orionldContextFromTree
 #include "orionld/kjTree/kjStringValueLookupInArray.h"         // kjStringValueLookupInArray
 #include "orionld/kjTree/kjTreeToUpdateContextRequest.h"       // kjTreeToUpdateContextRequest
@@ -186,7 +187,7 @@ bool orionldPostBatchUpdate(ConnectionInfo* ciP)
         else if (orionldState.contextP != NULL)  contextP = orionldState.contextP;
         else                                     contextP = orionldCoreContextP;
 
-        char* expandedType = orionldContextItemExpand(contextP, inTypeP->value.s, true, NULL);
+        char* expandedType = orionldContextItemExpand(contextP, inTypeP->value.s, true, NULL);  // entity type
         if (strcmp(expandedType, dbTypeP->value.s) != 0)
         {
           LM_W(("Bad Input (non-matching entity type: '%s' vs '%s')", expandedType, dbTypeP->value.s));
@@ -238,7 +239,7 @@ bool orionldPostBatchUpdate(ConnectionInfo* ciP)
             continue;
           }
           else
-            longName = orionldContextItemExpand(orionldState.contextP, aP->name, true, NULL);
+            longName = orionldAttributeExpand(orionldState.contextP, aP->name, true, NULL);
 
           if (kjStringValueLookupInArray(attrNames, longName) != NULL)
             kjChildRemove(entityP, aP);

--- a/src/lib/orionld/serviceRoutines/orionldPostBatchUpsert.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostBatchUpsert.cpp
@@ -237,7 +237,7 @@ bool orionldPostBatchUpsert(ConnectionInfo* ciP)
       //
       if (typeInPayload != NULL)
       {
-        char* typeInPayloadExpanded = orionldContextItemExpand(contextP, typeInPayload, true, NULL);
+        char* typeInPayloadExpanded = orionldContextItemExpand(contextP, typeInPayload, true, NULL);  // entity type
 
         if (strcmp(typeInPayloadExpanded, typeInDb) != 0)
         {

--- a/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
@@ -59,6 +59,7 @@ extern "C"
 #include "orionld/payloadCheck/pcheckEntity.h"                   // pcheckEntity
 #include "orionld/payloadCheck/pcheckUri.h"                      // pcheckUri
 #include "orionld/context/orionldContextItemExpand.h"            // orionldContextItemExpand
+#include "orionld/context/orionldAttributeExpand.h"              // orionldAttributeExpand
 #include "orionld/kjTree/kjTreeToContextAttribute.h"             // kjTreeToContextAttribute
 #include "orionld/mongoBackend/mongoEntityExists.h"              // mongoEntityExists
 #include "orionld/serviceRoutines/orionldPostEntities.h"         // Own interface
@@ -92,7 +93,7 @@ KjNode* datasetInstances(KjNode* datasets, KjNode* attrV, char* attributeName, d
   KjNode*          createdAt;
   char*            longName = NULL;
 
-  longName      = orionldContextItemExpand(orionldState.contextP, attributeName, true, NULL);
+  longName      = orionldAttributeExpand(orionldState.contextP, attributeName, true, NULL);
   attributeName = kaStrdup(&orionldState.kalloc, longName);
   dotForEq(attributeName);
 
@@ -268,7 +269,7 @@ bool orionldPostEntities(ConnectionInfo* ciP)
   entityIdP->creDate       = orionldState.requestTime;
   entityIdP->modDate       = orionldState.requestTime;
   entityIdP->isTypePattern = false;
-  entityIdP->type          = orionldContextItemExpand(orionldState.contextP, entityType, true, NULL);
+  entityIdP->type          = orionldContextItemExpand(orionldState.contextP, entityType, true, NULL);  // entity type
 
 
   //
@@ -354,7 +355,7 @@ bool orionldPostEntities(ConnectionInfo* ciP)
       kjChildAdd(kNodeP, modifiedAt);
 
       // Change to longName
-      char*  longName = orionldContextItemExpand(orionldState.contextP, kNodeP->name, true, NULL);
+      char*  longName = orionldAttributeExpand(orionldState.contextP, kNodeP->name, true, NULL);
 
       longName = kaStrdup(&orionldState.kalloc, longName);
       dotForEq(longName);

--- a/src/lib/orionld/serviceRoutines/orionldPostEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntity.cpp
@@ -58,7 +58,7 @@ extern "C"
 #include "orionld/db/dbEntityLookup.h"                           // dbEntityLookup
 #include "orionld/db/dbEntityUpdate.h"                           // dbEntityUpdate
 #include "orionld/payloadCheck/pcheckUri.h"                      // pcheckUri
-#include "orionld/context/orionldContextItemExpand.h"            // orionldContextItemExpand
+#include "orionld/context/orionldAttributeExpand.h"              // orionldAttributeExpand
 #include "orionld/context/orionldContextItemAliasLookup.h"       // orionldContextItemAliasLookup
 #include "orionld/kjTree/kjTreeToContextAttribute.h"             // kjTreeToContextAttribute
 #include "orionld/kjTree/kjStringValueLookupInArray.h"           // kjStringValueLookupInArray
@@ -262,7 +262,7 @@ bool orionldPostEntity(ConnectionInfo* ciP)
     //
     // The attribute name must be expanded before any comparisons can take place
     //
-    attrP->name = orionldContextItemExpand(orionldState.contextP, attrP->name, true, NULL);
+    attrP->name = orionldAttributeExpand(orionldState.contextP, attrP->name, true, NULL);
 
     // If overwrite is NOT allowed, attrs already in the the entity must be left alone and an error item added to the response
     if (overwrite == false)

--- a/src/lib/orionld/serviceRoutines/orionldPostEntityOverwrite.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntityOverwrite.cpp
@@ -477,7 +477,7 @@ static bool expandAttrNames(KjNode* treeP, char** detailsP)
     // FIXME: ignore also createdAt, modifiedAt, ... ?
     //
 
-    attrP->name = orionldContextItemExpand(orionldState.contextP, attrP->name, true, NULL);
+    attrP->name = orionldAttributeExpand(orionldState.contextP, attrP->name, true, NULL);
 
     //
     // Expand also sub-attr names
@@ -491,7 +491,7 @@ static bool expandAttrNames(KjNode* treeP, char** detailsP)
       if (strcmp(subAttrP->name, "object") == 0)  // FIXME: Only if "Relationship"
         continue;
 
-      subAttrP->name = orionldContextItemExpand(orionldState.contextP, subAttrP->name, true, NULL);
+      subAttrP->name = orionldSubAttributeExpand(orionldState.contextP, subAttrP->name, true, NULL);
     }
   }
 

--- a/src/lib/orionld/troe/troeEntityArrayExpand.cpp
+++ b/src/lib/orionld/troe/troeEntityArrayExpand.cpp
@@ -36,6 +36,8 @@ extern "C"
 #include "orionld/context/orionldCoreContext.h"                // orionldCoreContextP
 #include "orionld/context/orionldContextCacheLookup.h"         // orionldContextCacheLookup
 #include "orionld/context/orionldContextItemExpand.h"          // orionldContextItemExpand
+#include "orionld/context/orionldAttributeExpand.h"            // orionldAttributeExpand
+#include "orionld/context/orionldSubAttributeExpand.h"         // orionldSubAttributeExpand
 #include "orionld/context/orionldContextFromTree.h"            // orionldContextFromTree
 #include "orionld/troe/troeEntityArrayExpand.h"                // Own interface
 
@@ -79,14 +81,11 @@ void troeEntityArrayExpand(KjNode* tree)
     for (KjNode* attrP = entityP->value.firstChildP; attrP != NULL; attrP = attrP->next)
     {
       if (strcmp(attrP->name, "type") == 0)
-        attrP->value.s = orionldContextItemExpand(contextP, attrP->value.s, true, NULL);
+        attrP->value.s = orionldContextItemExpand(contextP, attrP->value.s, true, NULL);  // entity type
       else if (strcmp(attrP->name, "id")       == 0) {}
-      else if (strcmp(attrP->name, "location") == 0) {}
-      else if (strcmp(attrP->name, "observationSpace") == 0) {}
-      else if (strcmp(attrP->name, "operationSpace")   == 0) {}
       else
       {
-        attrP->name = orionldContextItemExpand(contextP, attrP->name, true, NULL);
+        attrP->name = orionldAttributeExpand(contextP, attrP->name, true, NULL);
 
         if (attrP->type == KjObject)
         {
@@ -101,7 +100,7 @@ void troeEntityArrayExpand(KjNode* tree)
             else if (strcmp(subAttrP->name, "unitCode")    == 0) {}
             else if (strcmp(subAttrP->name, "datasetId")   == 0) {}
             else
-              subAttrP->name = orionldContextItemExpand(contextP, subAttrP->name, true, NULL);
+              subAttrP->name = orionldSubAttributeExpand(contextP, subAttrP->name, true, NULL);
           }
         }
       }

--- a/src/lib/orionld/troe/troePatchAttribute.cpp
+++ b/src/lib/orionld/troe/troePatchAttribute.cpp
@@ -37,6 +37,7 @@ extern "C"
 #include "orionld/common/orionldState.h"                       // orionldState
 #include "orionld/common/orionldErrorResponse.h"               // orionldErrorResponseCreate
 #include "orionld/context/orionldContextItemExpand.h"          // orionldContextItemExpand
+#include "orionld/context/orionldAttributeExpand.h"            // orionldAttributeExpand
 #include "orionld/troe/pgConnectionGet.h"                      // pgConnectionGet
 #include "orionld/troe/pgConnectionRelease.h"                  // pgConnectionRelease
 #include "orionld/troe/pgTransactionBegin.h"                   // pgTransactionBegin
@@ -79,7 +80,7 @@ bool troePatchAttribute(ConnectionInfo* ciP)
   // pgAttributeTreat assumes the name of the attribute comes as part of the tree.
   // So, let's name the tree then! :)
   //
-  orionldState.requestTree->name = orionldContextItemExpand(orionldState.contextP, attributeName, true, NULL);  // FIXME: unitCode, datasetId, ... no expansion!!!
+  orionldState.requestTree->name = orionldAttributeExpand(orionldState.contextP, attributeName, true, NULL);
 
   if (pgAttributeTreat(connectionP, orionldState.requestTree, entityId, TROE_ATTRIBUTE_UPDATE) == false)
   {

--- a/src/lib/orionld/troe/troePostEntities.cpp
+++ b/src/lib/orionld/troe/troePostEntities.cpp
@@ -35,6 +35,8 @@ extern "C"
 #include "orionld/common/orionldState.h"                       // orionldState
 #include "orionld/common/orionldErrorResponse.h"               // orionldErrorResponseCreate
 #include "orionld/context/orionldContextItemExpand.h"          // orionldContextItemExpand
+#include "orionld/context/orionldAttributeExpand.h"            // orionldAttributeExpand
+#include "orionld/context/orionldSubAttributeExpand.h"         // orionldSubAttributeExpand
 #include "orionld/troe/pgConnectionGet.h"                      // pgConnectionGet
 #include "orionld/troe/pgConnectionRelease.h"                  // pgConnectionRelease
 #include "orionld/troe/pgTransactionBegin.h"                   // pgTransactionBegin
@@ -61,20 +63,17 @@ void troeEntityExpand(KjNode* entityP)
     if (strcmp(attrP->name, "type") == 0)
     {
       LM_TMP(("EXPAND: FROM '%s' (entity type value)", attrP->value.s));
-      attrP->value.s = orionldContextItemExpand(orionldState.contextP, attrP->value.s, true, NULL);
+      attrP->value.s = orionldContextItemExpand(orionldState.contextP, attrP->value.s, true, NULL);  // entity type
       LM_TMP(("EXPAND: TO '%s' (entity type value)", attrP->value.s));
     }
-    else if (strcmp(attrP->name, "id")               == 0) {}
-    else if (strcmp(attrP->name, "location")         == 0) {}
-    else if (strcmp(attrP->name, "observationSpace") == 0) {}
-    else if (strcmp(attrP->name, "operationSpace")   == 0) {}
+    else if (strcmp(attrP->name, "id") == 0) {}
     else if ((strcmp(attrP->name, "createdAt") == 0) || (strcmp(attrP->name, "modifiedAt") == 0))
     {
       kjChildRemove(entityP, attrP);
     }
     else
     {
-      attrP->name = orionldContextItemExpand(orionldState.contextP, attrP->name, true, NULL);
+      attrP->name = orionldAttributeExpand(orionldState.contextP, attrP->name, true, NULL);
 
       if (attrP->type == KjObject)
       {
@@ -89,10 +88,6 @@ void troeEntityExpand(KjNode* entityP)
           else if (strcmp(subAttrP->name, "id")          == 0) {}
           else if (strcmp(subAttrP->name, "value")       == 0) {}
           else if (strcmp(subAttrP->name, "object")      == 0) {}
-          else if (strcmp(subAttrP->name, "observedAt")  == 0) {}
-          else if (strcmp(subAttrP->name, "location")    == 0) {}
-          else if (strcmp(subAttrP->name, "unitCode")    == 0) {}
-          else if (strcmp(subAttrP->name, "datasetId")   == 0) {}
           else if ((strcmp(subAttrP->name, "createdAt") == 0) || (strcmp(subAttrP->name, "modifiedAt") == 0))
           {
             kjChildRemove(attrP, subAttrP);
@@ -100,7 +95,7 @@ void troeEntityExpand(KjNode* entityP)
           else
           {
             LM_TMP(("EXPAND: FROM '%s'", subAttrP->name));
-            subAttrP->name = orionldContextItemExpand(orionldState.contextP, subAttrP->name,  true, NULL);
+            subAttrP->name = orionldSubAttributeExpand(orionldState.contextP, subAttrP->name,  true, NULL);
             LM_TMP(("EXPAND: TO '%s'", subAttrP->name));
           }
 
@@ -140,7 +135,7 @@ bool troePostEntities(ConnectionInfo* ciP)
 
   LM_TMP(("TEMP: Calling pgEntityTreat for entity at %p", entityP));
   char* entityId   = orionldState.payloadIdNode->value.s;
-  char* entityType = orionldContextItemExpand(orionldState.contextP, orionldState.payloadTypeNode->value.s, true, NULL);
+  char* entityType = orionldContextItemExpand(orionldState.contextP, orionldState.payloadTypeNode->value.s, true, NULL);  // entity type
   if (pgEntityTreat(connectionP, entityP, entityId, entityType, TROE_ENTITY_CREATE, TROE_ENTITY_CREATE) == false)
   {
     LM_E(("Database Error (post entities TRoE layer failed)"));

--- a/src/lib/orionld/troe/troeSubAttrsExpand.cpp
+++ b/src/lib/orionld/troe/troeSubAttrsExpand.cpp
@@ -30,7 +30,7 @@ extern "C"
 #include "logMsg/logMsg.h"                                     // LM_*
 #include "logMsg/traceLevels.h"                                // Lmt*
 
-#include "orionld/context/orionldContextItemExpand.h"          // orionldContextItemExpand
+#include "orionld/context/orionldSubAttributeExpand.h"         // orionldSubAttributeExpand
 #include "orionld/common/orionldState.h"                       // orionldState
 
 
@@ -46,15 +46,9 @@ void troeSubAttrsExpand(KjNode* treeP)
     if      (strcmp(subAttrP->name, "type")        == 0) {}
     else if (strcmp(subAttrP->name, "value")       == 0) {}
     else if (strcmp(subAttrP->name, "object")      == 0) {}
-    else if (strcmp(subAttrP->name, "location")    == 0) {}
-    else if (strcmp(subAttrP->name, "observedAt")  == 0) {}
-    else if (strcmp(subAttrP->name, "unitCode")    == 0) {}
-    else if (strcmp(subAttrP->name, "datasetId")   == 0) {}
     else
     {
-      LM_TMP(("EXPAND: FROM '%s' (entity type value)", subAttrP->name));
-      subAttrP->name = orionldContextItemExpand(orionldState.contextP, subAttrP->name, true, NULL);
-      LM_TMP(("EXPAND: TO '%s'", subAttrP->name));
+      subAttrP->name = orionldSubAttributeExpand(orionldState.contextP, subAttrP->name, true, NULL);
     }
   }
 }

--- a/src/lib/rest/StringFilter.cpp
+++ b/src/lib/rest/StringFilter.cpp
@@ -48,7 +48,7 @@ extern "C"
 #ifdef ORIONLD
 #include "orionld/common/orionldState.h"                         // orionldState
 #include "orionld/common/eqForDot.h"                             // eqForDot
-#include "orionld/context/orionldContextItemExpand.h"            // orionldContextItemExpand
+#include "orionld/context/orionldAttributeExpand.h"              // orionldAttributeExpand
 #endif
 #include "rest/StringFilter.h"
 
@@ -659,7 +659,7 @@ bool StringFilterItem::parse(char* qItem, std::string* errorStringP, StringFilte
   //
   if (orionldState.apiVersion == NGSI_LD_V1)
   {
-    char* expanded = orionldContextItemExpand(orionldState.contextP, attributeName.c_str(), true, NULL);
+    char* expanded = orionldAttributeExpand(orionldState.contextP, (char*) attributeName.c_str(), true, NULL);
 
     //
     // After expanding we need to replace all dots ('.') with equal signs ('='), because, that is how the attribute name is stored in mongo

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0073.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0073.test
@@ -31,12 +31,12 @@ brokerStart CB 0-255
 --SHELL--
 
 #
-# 01. Create an entity with inline context and attr-names usibng prefix expansion
+# 01. Create an entity with inline context and attr-names using prefix expansion
 # 02. Check mongo content
 #
 
-echo "01. Create an entity with inline context and attr-names usibng prefix expansion"
-echo "==============================================================================="
+echo "01. Create an entity with inline context and attr-names using prefix expansion"
+echo "=============================================================================="
 payload='{
   "id": "urn:ngsi-ld:EntityWithPrefixExpansion",
   "type": "me:T1",
@@ -61,8 +61,8 @@ echo
 
 
 --REGEXPECT--
-01. Create an entity with inline context and attr-names usibng prefix expansion
-===============================================================================
+01. Create an entity with inline context and attr-names using prefix expansion
+==============================================================================
 HTTP/1.1 201 Created
 Content-Length: 0
 Location: /ngsi-ld/v1/entities/urn:ngsi-ld:EntityWithPrefixExpansion

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_ngsiv2_notification.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_ngsiv2_notification.test
@@ -634,7 +634,7 @@ Date: REGEX(.*)
 =======================================================================================================
 POST http://REGEX(.*)/notify
 Fiware-Servicepath: /
-Content-Length: 417
+Content-Length: 388
 User-Agent: orion/REGEX(.*)
 Ngsiv2-Attrsformat: x-ngsiv2-normalized
 Host: REGEX(.*)
@@ -644,7 +644,20 @@ Content-Type: application/json; charset=utf-8
 {
     "data": [
         {
-            "https://uri.etsi.org/ngsi-ld/observationSpace": {
+            "id": "urn:ngsi-ld:entities:E4", 
+            "location": {
+                "metadata": {}, 
+                "type": "GeoProperty", 
+                "value": {
+                    "coordinates": [
+                        1, 
+                        2, 
+                        3
+                    ], 
+                    "type": "Point"
+                }
+            }, 
+            "observationSpace": {
                 "metadata": {
                     "r1": {
                         "type": "Relationship", 
@@ -657,19 +670,6 @@ Content-Type: application/json; charset=utf-8
                         1, 
                         3, 
                         1
-                    ], 
-                    "type": "Point"
-                }
-            }, 
-            "id": "urn:ngsi-ld:entities:E4", 
-            "location": {
-                "metadata": {}, 
-                "type": "GeoProperty", 
-                "value": {
-                    "coordinates": [
-                        1, 
-                        2, 
-                        3
                     ], 
                     "type": "Point"
                 }
@@ -693,7 +693,7 @@ Date: REGEX(.*)
 =====================================================================================================
 POST http://REGEX(.*)/notify
 Fiware-Servicepath: /
-Content-Length: 594
+Content-Length: 536
 User-Agent: orion/REGEX(.*)
 Ngsiv2-Attrsformat: x-ngsiv2-normalized
 Host: REGEX(.*)
@@ -703,7 +703,20 @@ Content-Type: application/json; charset=utf-8
 {
     "data": [
         {
-            "https://uri.etsi.org/ngsi-ld/observationSpace": {
+            "id": "urn:ngsi-ld:entities:E4", 
+            "location": {
+                "metadata": {}, 
+                "type": "GeoProperty", 
+                "value": {
+                    "coordinates": [
+                        1, 
+                        2, 
+                        3
+                    ], 
+                    "type": "Point"
+                }
+            }, 
+            "observationSpace": {
                 "metadata": {
                     "r1": {
                         "type": "Relationship", 
@@ -720,7 +733,7 @@ Content-Type: application/json; charset=utf-8
                     "type": "Point"
                 }
             }, 
-            "https://uri.etsi.org/ngsi-ld/operationSpace": {
+            "operationSpace": {
                 "metadata": {
                     "r2": {
                         "type": "Relationship", 
@@ -733,19 +746,6 @@ Content-Type: application/json; charset=utf-8
                         2, 
                         4, 
                         2
-                    ], 
-                    "type": "Point"
-                }
-            }, 
-            "id": "urn:ngsi-ld:entities:E4", 
-            "location": {
-                "metadata": {}, 
-                "type": "GeoProperty", 
-                "value": {
-                    "coordinates": [
-                        1, 
-                        2, 
-                        3
                     ], 
                     "type": "Point"
                 }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_testSuite-case-079.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_testSuite-case-079.test
@@ -241,7 +241,7 @@ MongoDB server version: REGEX(.*)
 	"attrNames" : [
 		"https://uri.etsi.org/ngsi-ld/default-context/P1",
 		"https://uri.etsi.org/ngsi-ld/default-context/R1",
-		"https://uri.etsi.org/ngsi-ld/location"
+		"location"
 	],
 	"attrs" : {
 		"https://uri=etsi=org/ngsi-ld/default-context/P1" : {
@@ -288,7 +288,7 @@ MongoDB server version: REGEX(.*)
 			"creDate" : REGEX(.*),
 			"modDate" : REGEX(.*)
 		},
-		"https://uri=etsi=org/ngsi-ld/location" : {
+		"location" : {
 			"value" : {
 				"type" : "Point",
 				"coordinates" : [

--- a/test/functionalTest/cases/0000_troe/troe_exhaustive_post_entities_subattrs.test
+++ b/test/functionalTest/cases/0000_troe/troe_exhaustive_post_entities_subattrs.test
@@ -1,0 +1,437 @@
+# Copyright 2021 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Exhaustive test of creation of an Entity, focussing on sub attributes
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+dbInit CB t1
+pgInit $CB_DB_NAME
+pgInit ${CB_DB_NAME}_t1
+brokerStart CB 100 IPv4 -troe -multiservice
+
+--SHELL--
+
+#
+# 01. Create entity E1 on default tenant and without context
+# 02. Create entity E2 on T1 tenant and without context
+# 03. Create entity E3 on default tenant and with user context in Link Header
+# 04. Create entity E4 on T1 tenant and with user context in Link Header
+# 05. Create entity E5 on default tenant and with user context in payload body
+# 06. Create entity E6 on T1 tenant and with user context in payload body
+# 07. See all entities in TRoE DB, default tenant
+# 08. See all attributes in TRoE DB, default tenant
+# 09. See all sub-attributes in TRoE DB, default tenant
+# 10. See all entities in TRoE DB, tenant T1
+# 11. See all attributes in TRoE DB, tenant T1
+# 12. See all sub-attributes in TRoE DB, tenant T1
+#
+
+echo "01. Create entity E1 on default tenant and without context"
+echo "=========================================================="
+payload='{
+  "id": "urn:ngsi-ld:entity:E1",
+  "type": "Device",
+  "owner": {
+    "type": "Property",
+    "value": "Peter Farmer",
+    "unitCode": "kg",
+    "createdAt":  "2021-03-07T08:30:01.123Z",
+    "modifiedAt": "2021-03-07T08:30:02.123Z",
+    "observedAt": "2021-03-07T08:30:03.123Z",
+    "R1": {
+      "type":  "Relationship",
+      "object": "urn:ngsi-ld:x:1",
+      "observedAt": "2021-03-07T08:30:04.123Z"
+    },
+    "weight": {
+      "type": "Property",
+      "value": 250,
+      "observedAt": "2021-03-07T08:30:05.123Z"
+    },
+    "location": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 2 ]
+      },
+      "observedAt": "2021-03-07T08:30:06.123Z"
+    }
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "02. Create entity E2 on T1 tenant and without context"
+echo "====================================================="
+payload='{
+  "id": "urn:ngsi-ld:entity:E2",
+  "type": "Device",
+  "owner": {
+    "type": "Property",
+    "value": "Peter Farmer",
+    "unitCode": "kg",
+    "createdAt":  "2021-03-07T08:30:01.123Z",
+    "modifiedAt": "2021-03-07T08:30:02.123Z",
+    "observedAt": "2021-03-07T08:30:03.123Z",
+    "R1": {
+      "type":  "Relationship",
+      "object": "urn:ngsi-ld:x:1",
+      "observedAt": "2021-03-07T08:30:04.123Z"
+    },
+    "weight": {
+      "type": "Property",
+      "value": 250,
+      "observedAt": "2021-03-07T08:30:05.123Z"
+    },
+    "location": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 2 ]
+      },
+      "observedAt": "2021-03-07T08:30:06.123Z"
+    }
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload" --tenant t1
+echo
+echo
+
+
+echo "03. Create entity E3 on default tenant and with user context in Link Header"
+echo "==========================================================================="
+payload='{
+  "id": "urn:ngsi-ld:entity:E3",
+  "type": "Device",
+  "owner": {
+    "type": "Property",
+    "value": "Peter Farmer",
+    "unitCode": "kg",
+    "createdAt":  "2021-03-07T08:30:01.123Z",
+    "modifiedAt": "2021-03-07T08:30:02.123Z",
+    "observedAt": "2021-03-07T08:30:03.123Z",
+    "R1": {
+      "type":  "Relationship",
+      "object": "urn:ngsi-ld:x:1",
+      "observedAt": "2021-03-07T08:30:04.123Z"
+    },
+    "weight": {
+      "type": "Property",
+      "value": 250,
+      "observedAt": "2021-03-07T08:30:05.123Z"
+    },
+    "location": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 2 ]
+      },
+      "observedAt": "2021-03-07T08:30:06.123Z"
+    }
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload" -H 'Link: <https://raw.githubusercontent.com/FIWARE/tutorials.NGSI-LD/master/app/public/data-models/ngsi-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+echo
+echo
+
+
+echo "04. Create entity E4 on T1 tenant and with user context in Link Header"
+echo "======================================================================"
+payload='{
+  "id": "urn:ngsi-ld:entity:E4",
+  "type": "Device",
+  "owner": {
+    "type": "Property",
+    "value": "Peter Farmer",
+    "unitCode": "kg",
+    "createdAt":  "2021-03-07T08:30:01.123Z",
+    "modifiedAt": "2021-03-07T08:30:02.123Z",
+    "observedAt": "2021-03-07T08:30:03.123Z",
+    "R1": {
+      "type":  "Relationship",
+      "object": "urn:ngsi-ld:x:1",
+      "observedAt": "2021-03-07T08:30:04.123Z"
+    },
+    "weight": {
+      "type": "Property",
+      "value": 250,
+      "observedAt": "2021-03-07T08:30:05.123Z"
+    },
+    "location": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 2 ]
+      },
+      "observedAt": "2021-03-07T08:30:06.123Z"
+    }
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload" --tenant t1 -H 'Link: <https://raw.githubusercontent.com/FIWARE/tutorials.NGSI-LD/master/app/public/data-models/ngsi-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+echo
+echo
+
+
+echo "05. Create entity E5 on default tenant and with user context in payload body"
+echo "============================================================================"
+payload='{
+  "@context": [ "https://raw.githubusercontent.com/FIWARE/tutorials.NGSI-LD/master/app/public/data-models/ngsi-context.jsonld" ],
+  "id": "urn:ngsi-ld:entity:E5",
+  "type": "Device",
+  "owner": {
+    "type": "Property",
+    "value": "Peter Farmer",
+    "unitCode": "kg",
+    "createdAt":  "2021-03-07T08:30:01.123Z",
+    "modifiedAt": "2021-03-07T08:30:02.123Z",
+    "observedAt": "2021-03-07T08:30:03.123Z",
+    "R1": {
+      "type":  "Relationship",
+      "object": "urn:ngsi-ld:x:1",
+      "observedAt": "2021-03-07T08:30:04.123Z"
+    },
+    "weight": {
+      "type": "Property",
+      "value": 250,
+      "observedAt": "2021-03-07T08:30:05.123Z"
+    },
+    "location": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 2 ]
+      },
+      "observedAt": "2021-03-07T08:30:06.123Z"
+    }
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload" --in application/ld+json
+echo
+echo
+
+
+echo "06. Create entity E6 on T1 tenant and with user context in payload body"
+echo "======================================================================="
+payload='{
+  "@context": [ "https://raw.githubusercontent.com/FIWARE/tutorials.NGSI-LD/master/app/public/data-models/ngsi-context.jsonld" ],
+  "id": "urn:ngsi-ld:entity:E6",
+  "type": "Device",
+  "owner": {
+    "type": "Property",
+    "value": "Peter Farmer",
+    "unitCode": "kg",
+    "createdAt":  "2021-03-07T08:30:01.123Z",
+    "modifiedAt": "2021-03-07T08:30:02.123Z",
+    "observedAt": "2021-03-07T08:30:03.123Z",
+    "R1": {
+      "type":  "Relationship",
+      "object": "urn:ngsi-ld:x:1",
+      "observedAt": "2021-03-07T08:30:04.123Z"
+    },
+    "weight": {
+      "type": "Property",
+      "value": 250,
+      "observedAt": "2021-03-07T08:30:05.123Z"
+    },
+    "location": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [ 1, 2 ]
+      },
+      "observedAt": "2021-03-07T08:30:06.123Z"
+    }
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload" --tenant t1 --in application/ld+json
+echo
+echo
+
+
+echo "07. See all entities in TRoE DB, default tenant"
+echo "==============================================="
+postgresCmd -sql "SELECT opMode,id,type,ts FROM entities"
+echo
+echo
+
+
+echo "08. See all attributes in TRoE DB, default tenant"
+echo "================================================="
+postgresCmd -sql "SELECT opMode,id,valueType,entityId,subProperties,unitcode,datasetid,text,number,boolean,observedAt,ts FROM attributes"
+echo
+echo
+
+
+echo "09. See all sub-attributes in TRoE DB, default tenant"
+echo "====================================================="
+postgresCmd -sql "SELECT id,valuetype,entityid,unitcode,text,number,boolean,observedat,ts FROM subAttributes"
+echo
+echo
+
+
+echo "10. See all entities in TRoE DB, tenant T1"
+echo "=========================================="
+postgresCmd -sql "SELECT opMode,id,type,ts FROM entities" -t ftest_t1
+echo
+echo
+
+
+echo "11. See all attributes in TRoE DB, tenant T1"
+echo "============================================"
+postgresCmd -sql "SELECT opMode,id,valueType,entityId,subProperties,unitcode,datasetid,text,number,boolean,observedAt,ts FROM attributes" -t ftest_t1
+echo
+echo
+
+
+echo "12. See all sub-attributes in TRoE DB, tenant T1"
+echo "================================================"
+postgresCmd -sql "SELECT id,valuetype,entityid,unitcode,text,number,boolean,observedat,ts FROM subAttributes" -t ftest_t1
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity E1 on default tenant and without context
+==========================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:entity:E1
+Date: REGEX(.*)
+
+
+
+02. Create entity E2 on T1 tenant and without context
+=====================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:entity:E2
+Date: REGEX(.*)
+
+
+
+03. Create entity E3 on default tenant and with user context in Link Header
+===========================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:entity:E3
+Date: REGEX(.*)
+
+
+
+04. Create entity E4 on T1 tenant and with user context in Link Header
+======================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:entity:E4
+Date: REGEX(.*)
+
+
+
+05. Create entity E5 on default tenant and with user context in payload body
+============================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:entity:E5
+Date: REGEX(.*)
+
+
+
+06. Create entity E6 on T1 tenant and with user context in payload body
+=======================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:entity:E6
+Date: REGEX(.*)
+
+
+
+07. See all entities in TRoE DB, default tenant
+===============================================
+opmode,id,type,ts
+Create,urn:ngsi-ld:entity:E1,https://uri.etsi.org/ngsi-ld/default-context/Device,202REGEX(.*)
+Create,urn:ngsi-ld:entity:E3,https://uri.fiware.org/ns/data-models#Device,202REGEX(.*)
+Create,urn:ngsi-ld:entity:E5,https://uri.fiware.org/ns/data-models#Device,202REGEX(.*)
+
+
+08. See all attributes in TRoE DB, default tenant
+=================================================
+opmode,id,valuetype,entityid,subproperties,unitcode,datasetid,text,number,boolean,observedat,ts
+Create,https://uri.etsi.org/ngsi-ld/default-context/owner,String,urn:ngsi-ld:entity:E1,t,,,Peter Farmer,,,2021-03-07 08:30:03.123,202REGEX(.*)
+Create,https://uri.fiware.org/ns/data-models#owner,String,urn:ngsi-ld:entity:E3,t,,,Peter Farmer,,,2021-03-07 08:30:03.123,202REGEX(.*)
+Create,https://uri.fiware.org/ns/data-models#owner,String,urn:ngsi-ld:entity:E5,t,,,Peter Farmer,,,2021-03-07 08:30:03.123,202REGEX(.*)
+
+
+09. See all sub-attributes in TRoE DB, default tenant
+=====================================================
+id,valuetype,entityid,unitcode,text,number,boolean,observedat,ts
+https://uri.etsi.org/ngsi-ld/default-context/R1,Relationship,urn:ngsi-ld:entity:E1,,urn:ngsi-ld:x:1,,,2021-03-07 08:30:04.123,202REGEX(.*)
+https://uri.etsi.org/ngsi-ld/default-context/weight,Number,urn:ngsi-ld:entity:E1,,,250,,2021-03-07 08:30:05.123,202REGEX(.*)
+location,GeoPoint,urn:ngsi-ld:entity:E1,,,,,2021-03-07 08:30:06.123,202REGEX(.*)
+https://uri.etsi.org/ngsi-ld/default-context/R1,Relationship,urn:ngsi-ld:entity:E3,,urn:ngsi-ld:x:1,,,2021-03-07 08:30:04.123,202REGEX(.*)
+https://w3id.org/saref#weight,Number,urn:ngsi-ld:entity:E3,,,250,,2021-03-07 08:30:05.123,202REGEX(.*)
+location,GeoPoint,urn:ngsi-ld:entity:E3,,,,,2021-03-07 08:30:06.123,202REGEX(.*)
+https://uri.etsi.org/ngsi-ld/default-context/R1,Relationship,urn:ngsi-ld:entity:E5,,urn:ngsi-ld:x:1,,,2021-03-07 08:30:04.123,202REGEX(.*)
+https://w3id.org/saref#weight,Number,urn:ngsi-ld:entity:E5,,,250,,2021-03-07 08:30:05.123,202REGEX(.*)
+location,GeoPoint,urn:ngsi-ld:entity:E5,,,,,2021-03-07 08:30:06.123,202REGEX(.*)
+
+
+10. See all entities in TRoE DB, tenant T1
+==========================================
+opmode,id,type,ts
+Create,urn:ngsi-ld:entity:E2,https://uri.etsi.org/ngsi-ld/default-context/Device,202REGEX(.*)
+Create,urn:ngsi-ld:entity:E4,https://uri.fiware.org/ns/data-models#Device,202REGEX(.*)
+Create,urn:ngsi-ld:entity:E6,https://uri.fiware.org/ns/data-models#Device,202REGEX(.*)
+
+
+11. See all attributes in TRoE DB, tenant T1
+============================================
+opmode,id,valuetype,entityid,subproperties,unitcode,datasetid,text,number,boolean,observedat,ts
+Create,https://uri.etsi.org/ngsi-ld/default-context/owner,String,urn:ngsi-ld:entity:E2,t,,,Peter Farmer,,,2021-03-07 08:30:03.123,202REGEX(.*)
+Create,https://uri.fiware.org/ns/data-models#owner,String,urn:ngsi-ld:entity:E4,t,,,Peter Farmer,,,2021-03-07 08:30:03.123,202REGEX(.*)
+Create,https://uri.fiware.org/ns/data-models#owner,String,urn:ngsi-ld:entity:E6,t,,,Peter Farmer,,,2021-03-07 08:30:03.123,202REGEX(.*)
+
+
+12. See all sub-attributes in TRoE DB, tenant T1
+================================================
+id,valuetype,entityid,unitcode,text,number,boolean,observedat,ts
+https://uri.etsi.org/ngsi-ld/default-context/R1,Relationship,urn:ngsi-ld:entity:E2,,urn:ngsi-ld:x:1,,,2021-03-07 08:30:04.123,202REGEX(.*)
+https://uri.etsi.org/ngsi-ld/default-context/weight,Number,urn:ngsi-ld:entity:E2,,,250,,2021-03-07 08:30:05.123,202REGEX(.*)
+location,GeoPoint,urn:ngsi-ld:entity:E2,,,,,2021-03-07 08:30:06.123,202REGEX(.*)
+https://uri.etsi.org/ngsi-ld/default-context/R1,Relationship,urn:ngsi-ld:entity:E4,,urn:ngsi-ld:x:1,,,2021-03-07 08:30:04.123,202REGEX(.*)
+https://w3id.org/saref#weight,Number,urn:ngsi-ld:entity:E4,,,250,,2021-03-07 08:30:05.123,202REGEX(.*)
+location,GeoPoint,urn:ngsi-ld:entity:E4,,,,,2021-03-07 08:30:06.123,202REGEX(.*)
+https://uri.etsi.org/ngsi-ld/default-context/R1,Relationship,urn:ngsi-ld:entity:E6,,urn:ngsi-ld:x:1,,,2021-03-07 08:30:04.123,202REGEX(.*)
+https://w3id.org/saref#weight,Number,urn:ngsi-ld:entity:E6,,,250,,2021-03-07 08:30:05.123,202REGEX(.*)
+location,GeoPoint,urn:ngsi-ld:entity:E6,,,,,2021-03-07 08:30:06.123,202REGEX(.*)
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB
+dbDrop CB t1
+pgDrop $CB_DB_NAME
+pgDrop ${CB_DB_NAME}_t1


### PR DESCRIPTION
* Using `orionldAttributeExpand` and `orionldSubAttributeExpand` instead of `orionldContextItemExpand`
* Fixed a bug about createdAt/modified in sub-attrs for sub-attributes
* Added troe_exhaustive_post_entities_subattrs.test 