### PR TITLE
MHD traces + less sleep in postgres connect retries

### DIFF
--- a/src/lib/orionld/troe/pgConnectionGet.cpp
+++ b/src/lib/orionld/troe/pgConnectionGet.cpp
@@ -117,7 +117,7 @@ PGconn* pgConnectionGet(const char* db)
     if (connectionP != NULL)
       break;
 
-    usleep(100000);  // Sleep 0.1 seconds before we try again
+    usleep(500);  // Sleep half a millisecond before we try again
   }
 
   if (connectionP == NULL)

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -1961,6 +1961,8 @@ static int restStart(IpVersion ipVersion, const char* httpsKey = NULL, const cha
 #endif
   }
 
+  serverMode |= MHD_USE_ERROR_LOG | MHD_USE_DEBUG;
+
   if ((ipVersion == IPV4) || (ipVersion == IPDUAL))
   {
     memset(&sad, 0, sizeof(sad));


### PR DESCRIPTION
* Turned on traces in MHD
* Lowered the sleep time in retries to connect to postgres