### PR TITLE
hardening/getStringField-with-pointer-not-reference

### DIFF
--- a/src/lib/apiTypesV2/HttpInfo.cpp
+++ b/src/lib/apiTypesV2/HttpInfo.cpp
@@ -125,24 +125,24 @@ std::string HttpInfo::toJson()
 *
 * HttpInfo::fill -
 */
-void HttpInfo::fill(const BSONObj& bo)
+void HttpInfo::fill(const BSONObj* boP)
 {
-  this->url    = bo.hasField(CSUB_REFERENCE)? getStringFieldF(bo, CSUB_REFERENCE) : "";
-  this->custom = bo.hasField(CSUB_CUSTOM)?    getBoolFieldF(bo,   CSUB_CUSTOM)    : false;
+  this->url    = boP->hasField(CSUB_REFERENCE)? getStringFieldF(boP,  CSUB_REFERENCE) : "";
+  this->custom = boP->hasField(CSUB_CUSTOM)?    getBoolFieldF(*boP,   CSUB_CUSTOM)    : false;
 
   bool mqtt = (strncmp(url.c_str(), "mqtt", 4) == 0);
 
 #ifdef ORIONLD
-  char* mimeTypeString = (char*) getStringFieldF(bo, CSUB_MIMETYPE);
+  char* mimeTypeString = (char*) getStringFieldF(boP, CSUB_MIMETYPE);
 
   if (mimeTypeString[0] == 0)
     mimeTypeString = (char*) "application/json";  // Default value
 
   this->mimeType = longStringToMimeType(mimeTypeString);
 
-  if (bo.hasField("notifierInfo"))
+  if (boP->hasField("notifierInfo"))
   {
-    BSONObj ni = getObjectFieldF(bo, "notifierInfo");
+    BSONObj ni = getObjectFieldF(*boP, "notifierInfo");
 
     for (BSONObj::iterator iter = ni.begin(); iter.more();)
     {
@@ -162,17 +162,17 @@ void HttpInfo::fill(const BSONObj& bo)
 
   if (this->custom)
   {
-    this->payload  = bo.hasField(CSUB_PAYLOAD)? getStringFieldF(bo, CSUB_PAYLOAD) : "";
+    this->payload  = boP->hasField(CSUB_PAYLOAD)? getStringFieldF(boP, CSUB_PAYLOAD) : "";
 
-    if (bo.hasField(CSUB_METHOD))
+    if (boP->hasField(CSUB_METHOD))
     {
-      this->verb = str2Verb(getStringFieldF(bo, CSUB_METHOD));
+      this->verb = str2Verb(getStringFieldF(boP, CSUB_METHOD));
     }
 
     // qs
-    if (bo.hasField(CSUB_QS))
+    if (boP->hasField(CSUB_QS))
     {
-      BSONObj qs = getObjectFieldF(bo, CSUB_QS);
+      BSONObj qs = getObjectFieldF(*boP, CSUB_QS);
 
       for (BSONObj::iterator i = qs.begin(); i.more();)
       {
@@ -186,9 +186,9 @@ void HttpInfo::fill(const BSONObj& bo)
   if (this->custom || mqtt)
   {
     // headers
-    if (bo.hasField(CSUB_HEADERS))
+    if (boP->hasField(CSUB_HEADERS))
     {
-      BSONObj headers = getObjectFieldF(bo, CSUB_HEADERS);
+      BSONObj headers = getObjectFieldF(*boP, CSUB_HEADERS);
 
       for (BSONObj::iterator i = headers.begin(); i.more();)
       {

--- a/src/lib/apiTypesV2/HttpInfo.h
+++ b/src/lib/apiTypesV2/HttpInfo.h
@@ -91,7 +91,7 @@ struct HttpInfo
   explicit HttpInfo(const std::string& _url);
 
   std::string  toJson();
-  void         fill(const mongo::BSONObj& bo);
+  void         fill(const mongo::BSONObj* boP);
 };
 }
 

--- a/src/lib/mongoBackend/MongoCommonRegister.cpp
+++ b/src/lib/mongoBackend/MongoCommonRegister.cpp
@@ -279,7 +279,7 @@ static bool addTriggeredSubscriptions
     {
       ngsiv2::HttpInfo httpInfo;
 
-      httpInfo.url = getStringFieldF(sub, CASUB_REFERENCE);
+      httpInfo.url = getStringFieldF(&sub, CASUB_REFERENCE);
 
       LM_T(LmtMongo, ("adding subscription: '%s'", sub.toString().c_str()));
 
@@ -287,7 +287,7 @@ static bool addTriggeredSubscriptions
       // FIXME P4: Once ctx availability notification formats get defined for NGSIv2,
       //           the first parameter for TriggeredSubscription will have "normalized" as default value
       //
-      RenderFormat           renderFormat = sub.hasField(CASUB_FORMAT)? stringToRenderFormat(getStringFieldF(sub, CASUB_FORMAT)) : NGSI_V1_LEGACY;
+      RenderFormat           renderFormat = sub.hasField(CASUB_FORMAT)? stringToRenderFormat(getStringFieldF(&sub, CASUB_FORMAT)) : NGSI_V1_LEGACY;
       TriggeredSubscription* trigs        = new TriggeredSubscription(renderFormat, httpInfo, subToAttributeList(sub));
 
       subs.insert(std::pair<std::string, TriggeredSubscription*>(subIdStr, trigs));

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -207,8 +207,8 @@ static bool equalMetadataValues(const BSONObj& md1, const BSONObj& md2)
       break;
 
     case mongo::String:
-      md1Type = (char*) getStringFieldF(md1, ENT_ATTRS_MD_TYPE);
-      md2Type = (char*) getStringFieldF(md2, ENT_ATTRS_MD_TYPE);
+      md1Type = (char*) getStringFieldF(&md1, ENT_ATTRS_MD_TYPE);
+      md2Type = (char*) getStringFieldF(&md2, ENT_ATTRS_MD_TYPE);
 
       if (strcmp(md1Type, md2Type) != 0)
         return false;
@@ -255,8 +255,8 @@ static bool equalMetadataValues(const BSONObj& md1, const BSONObj& md2)
     return getBoolFieldF(md1, ENT_ATTRS_MD_VALUE) == getBoolFieldF(md2, ENT_ATTRS_MD_VALUE);
 
   case mongo::String:
-    md1Value = (char*) getStringFieldF(md1, ENT_ATTRS_MD_VALUE);
-    md2Value = (char*) getStringFieldF(md2, ENT_ATTRS_MD_VALUE);
+    md1Value = (char*) getStringFieldF(&md1, ENT_ATTRS_MD_VALUE);
+    md2Value = (char*) getStringFieldF(&md2, ENT_ATTRS_MD_VALUE);
     return (strcmp(md1Value, md2Value) == 0);
 
   case mongo::jstNULL:
@@ -342,7 +342,7 @@ static bool attrValueChanges(const BSONObj& attr, ContextAttribute* caP, ApiVers
   case mongo::String:
     // getStringFieldF is OK here as caP->stringValue is a std::string ...
     // Should be amended though. Some day
-    return caP->valueType != orion::ValueTypeString || caP->stringValue != getStringFieldF(attr, ENT_ATTRS_VALUE);
+    return caP->valueType != orion::ValueTypeString || caP->stringValue != getStringFieldF(&attr, ENT_ATTRS_VALUE);
 
   case mongo::jstNULL:
     return caP->valueType != orion::ValueTypeNull;
@@ -476,7 +476,7 @@ static bool mergeAttrInfo(const BSONObj& attr, ContextAttribute* caP, BSONObj* m
    *    'copied' from DB to the variable 'ab' and sent back to mongo, to not destroy the value  */
   if (caP->valueType != orion::ValueTypeNotGiven)
   {
-    caP->valueBson(ab, getStringFieldF(attr, ENT_ATTRS_TYPE), ngsiv1Autocast && (apiVersion == V1));
+    caP->valueBson(ab, getStringFieldF(&attr, ENT_ATTRS_TYPE), ngsiv1Autocast && (apiVersion == V1));
   }
   else
   {
@@ -503,7 +503,7 @@ static bool mergeAttrInfo(const BSONObj& attr, ContextAttribute* caP, BSONObj* m
       break;
 
     case mongo::String:
-      ab.append(ENT_ATTRS_VALUE, getStringFieldF(attr, ENT_ATTRS_VALUE));
+      ab.append(ENT_ATTRS_VALUE, getStringFieldF(&attr, ENT_ATTRS_VALUE));
       break;
 
     case mongo::jstNULL:
@@ -524,7 +524,7 @@ static bool mergeAttrInfo(const BSONObj& attr, ContextAttribute* caP, BSONObj* m
   {
     if (attr.hasField(ENT_ATTRS_TYPE))
     {
-      ab.append(ENT_ATTRS_TYPE, getStringFieldF(attr, ENT_ATTRS_TYPE));
+      ab.append(ENT_ATTRS_TYPE, getStringFieldF(&attr, ENT_ATTRS_TYPE));
     }
   }
 
@@ -563,7 +563,7 @@ static bool mergeAttrInfo(const BSONObj& attr, ContextAttribute* caP, BSONObj* m
     {
       const char*  currentMd = i->c_str();
       BSONObj      mdItem    = getObjectFieldF(md, currentMd);
-      Metadata     md(currentMd, mdItem);
+      Metadata     md(currentMd, &mdItem);
 
       mdSize++;
 
@@ -620,7 +620,7 @@ static bool mergeAttrInfo(const BSONObj& attr, ContextAttribute* caP, BSONObj* m
       actualUpdate = true;
     else
     {
-      const char* attrType        = getStringFieldF(attr, ENT_ATTRS_TYPE);
+      const char* attrType        = getStringFieldF(&attr, ENT_ATTRS_TYPE);
       bool        attrTypeChanged = (strcmp(attrType, caP->type.c_str()) != 0);
 
       actualUpdate = (attrValueChanges(attr, caP, apiVersion)  ||
@@ -1559,11 +1559,11 @@ static bool addTriggeredSubscriptions_noCache
       //
       double            throttling         = sub.hasField(CSUB_THROTTLING)?       getNumberFieldAsDoubleF(sub, CSUB_THROTTLING)       : -1;
       double            lastNotification   = sub.hasField(CSUB_LASTNOTIFICATION)? getNumberFieldAsDoubleF(sub, CSUB_LASTNOTIFICATION) : -1;
-      const char*       renderFormatString = sub.hasField(CSUB_FORMAT)? getStringFieldF(sub, CSUB_FORMAT) : "legacy";
+      const char*       renderFormatString = sub.hasField(CSUB_FORMAT)? getStringFieldF(&sub, CSUB_FORMAT) : "legacy";
       RenderFormat      renderFormat       = stringToRenderFormat(renderFormatString);
       ngsiv2::HttpInfo  httpInfo;
 
-      httpInfo.fill(sub);
+      httpInfo.fill(&sub);
 
       TriggeredSubscription* trigs = new TriggeredSubscription
         (
@@ -1584,11 +1584,11 @@ static bool addTriggeredSubscriptions_noCache
       {
         BSONObj expr = getObjectFieldF(sub, CSUB_EXPR);
 
-        std::string q        = expr.hasField(CSUB_EXPR_Q)      ? getStringFieldF(expr, CSUB_EXPR_Q)      : "";
-        std::string mq       = expr.hasField(CSUB_EXPR_MQ)     ? getStringFieldF(expr, CSUB_EXPR_MQ)     : "";
-        std::string georel   = expr.hasField(CSUB_EXPR_GEOREL) ? getStringFieldF(expr, CSUB_EXPR_GEOREL) : "";
-        std::string geometry = expr.hasField(CSUB_EXPR_GEOM)   ? getStringFieldF(expr, CSUB_EXPR_GEOM)   : "";
-        std::string coords   = expr.hasField(CSUB_EXPR_COORDS) ? getStringFieldF(expr, CSUB_EXPR_COORDS) : "";
+        std::string q        = expr.hasField(CSUB_EXPR_Q)      ? getStringFieldF(&expr, CSUB_EXPR_Q)      : "";
+        std::string mq       = expr.hasField(CSUB_EXPR_MQ)     ? getStringFieldF(&expr, CSUB_EXPR_MQ)     : "";
+        std::string georel   = expr.hasField(CSUB_EXPR_GEOREL) ? getStringFieldF(&expr, CSUB_EXPR_GEOREL) : "";
+        std::string geometry = expr.hasField(CSUB_EXPR_GEOM)   ? getStringFieldF(&expr, CSUB_EXPR_GEOM)   : "";
+        std::string coords   = expr.hasField(CSUB_EXPR_COORDS) ? getStringFieldF(&expr, CSUB_EXPR_COORDS) : "";
 
         trigs->fillExpression(georel, geometry, coords);
 
@@ -3318,9 +3318,9 @@ static void updateEntity
 
   BSONObj            idField           = getObjectFieldF(r, "_id");
 
-  std::string        entityId          = getStringFieldF(idField, ENT_ENTITY_ID);
-  std::string        entityType        = getStringFieldF(idField, ENT_ENTITY_TYPE);
-  std::string        entitySPath       = getStringFieldF(idField, ENT_SERVICE_PATH);
+  std::string        entityId          = getStringFieldF(&idField, ENT_ENTITY_ID);
+  std::string        entityType        = getStringFieldF(&idField, ENT_ENTITY_TYPE);
+  std::string        entitySPath       = getStringFieldF(&idField, ENT_SERVICE_PATH);
 
   ContextElementResponse* cerP = new ContextElementResponse();
   cerP->contextElement.entityId.fill(entityId, entityType, "false");
@@ -3359,7 +3359,7 @@ static void updateEntity
   {
     BSONObj loc    = getObjectFieldF(r, ENT_LOCATION);
 
-    locAttr        = getStringFieldF(loc, ENT_LOCATION_ATTRNAME);
+    locAttr        = getStringFieldF(&loc, ENT_LOCATION_ATTRNAME);
     currentGeoJson = getObjectFieldF(loc, ENT_LOCATION_COORDS);
   }
 
@@ -3419,7 +3419,7 @@ static void updateEntity
   bool loopDetected = false;
   if ((ngsiV2AttrsFormat == "custom") && (r.hasField(ENT_LAST_CORRELATOR)))
   {
-    loopDetected = (strcmp(getStringFieldF(r, ENT_LAST_CORRELATOR), fiwareCorrelator.c_str()) == 0);
+    loopDetected = (strcmp(getStringFieldF(&r, ENT_LAST_CORRELATOR), fiwareCorrelator.c_str()) == 0);
   }
 
   if (!processContextAttributeVector(ceP,

--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -500,7 +500,7 @@ bool getOrionDatabases(std::vector<std::string>* dbsP)
   for (std::vector<BSONElement>::iterator i = databases.begin(); i != databases.end(); ++i)
   {
     BSONObj      db      = (*i).Obj();
-    const char*  dbName  = getStringFieldF(db, "name");
+    const char*  dbName  = getStringFieldF(&db, "name");
     std::string  prefix  = dbPrefix + "-";
 
     if (strncmp(prefix.c_str(), dbName, strlen(prefix.c_str())) == 0)
@@ -1813,8 +1813,8 @@ static void processEntity(ContextRegistrationResponse* crr, const EntityIdVector
 {
   EntityId en;
 
-  en.id   = getStringFieldF(entity, REG_ENTITY_ID);
-  en.type = getStringFieldF(entity, REG_ENTITY_TYPE);
+  en.id   = getStringFieldF(&entity, REG_ENTITY_ID);
+  en.type = getStringFieldF(&entity, REG_ENTITY_TYPE);
 
   /* isPattern = true is not allowed in registrations so it is not in the
    * document retrieved with the query; however we will set it to be formally correct
@@ -1836,12 +1836,12 @@ static void processEntity(ContextRegistrationResponse* crr, const EntityIdVector
 *
 * processAttribute -
 */
-static void processAttribute(ContextRegistrationResponse* crr, const StringList& attrL, const BSONObj& attribute)
+static void processAttribute(ContextRegistrationResponse* crr, const StringList& attrL, BSONObj* attrObjP)
 {
   ContextRegistrationAttribute attr(
-    getStringFieldF(attribute, REG_ATTRS_NAME),
-    getStringFieldF(attribute, REG_ATTRS_TYPE),
-    getStringFieldF(attribute, REG_ATTRS_ISDOMAIN));
+    getStringFieldF(attrObjP, REG_ATTRS_NAME),
+    getStringFieldF(attrObjP, REG_ATTRS_TYPE),
+    getStringFieldF(attrObjP, REG_ATTRS_ISDOMAIN));
 
   // FIXME: we don't take metadata into account at the moment
   // attr.metadataV = ..
@@ -1870,7 +1870,7 @@ static void processContextRegistrationElement
 {
   ContextRegistrationResponse crr;
 
-  crr.contextRegistration.providingApplication.set(getStringFieldF(cr, REG_PROVIDING_APPLICATION));
+  crr.contextRegistration.providingApplication.set(getStringFieldF(&cr, REG_PROVIDING_APPLICATION));
   crr.contextRegistration.providingApplication.setMimeType(mimeType);
 
   std::vector<BSONElement> queryEntityV = getFieldF(cr, REG_ENTITIES).Array();
@@ -1889,7 +1889,8 @@ static void processContextRegistrationElement
 
       for (unsigned int ix = 0; ix < queryAttrV.size(); ++ix)
       {
-        processAttribute(&crr, attrL, queryAttrV[ix].embeddedObject());
+        BSONObj qaObj =  queryAttrV[ix].embeddedObject();
+        processAttribute(&crr, attrL, &qaObj);
       }
     }
   }
@@ -2162,9 +2163,9 @@ EntityIdVector subToEntityIdVector(const BSONObj& sub)
   for (unsigned int ix = 0; ix < subEnts.size() ; ++ix)
   {
     BSONObj    subEnt = subEnts[ix].embeddedObject();
-    EntityId*  en     = new EntityId(getStringFieldF(subEnt, CSUB_ENTITY_ID),
-                                     subEnt.hasField(CSUB_ENTITY_TYPE) ? getStringFieldF(subEnt, CSUB_ENTITY_TYPE) : "",
-                                     getStringFieldF(subEnt, CSUB_ENTITY_ISPATTERN));
+    EntityId*  en     = new EntityId(getStringFieldF(&subEnt, CSUB_ENTITY_ID),
+                                     subEnt.hasField(CSUB_ENTITY_TYPE) ? getStringFieldF(&subEnt, CSUB_ENTITY_TYPE) : "",
+                                     getStringFieldF(&subEnt, CSUB_ENTITY_ISPATTERN));
     enV.push_back(en);
   }
 

--- a/src/lib/mongoBackend/mongoConnectionPool.cpp
+++ b/src/lib/mongoBackend/mongoConnectionPool.cpp
@@ -269,7 +269,7 @@ static DBClientBase* mongoConnect
   BSONObj     result;
   std::string extra;
   runCollectionCommand(connection, "admin", BSON("buildinfo" << 1), &result, &err);
-  std::string versionString = std::string(getStringFieldF(result, "version"));
+  std::string versionString = std::string(getStringFieldF(&result, "version"));
   if (!versionParse(versionString, mongoVersionMayor, mongoVersionMinor, extra))
   {
     LM_E(("Database Startup Error (invalid version format: %s)", versionString.c_str()));

--- a/src/lib/mongoBackend/mongoGetSubscriptions.cpp
+++ b/src/lib/mongoBackend/mongoGetSubscriptions.cpp
@@ -85,9 +85,9 @@ static void setNewSubscriptionId(Subscription* s, const BSONObj& r)
 *
 * setDescription -
 */
-static void setDescription(Subscription* s, const BSONObj& r)
+static void setDescription(Subscription* s, const BSONObj* bobjP)
 {
-  s->description = r.hasField(CSUB_DESCRIPTION) ? getStringFieldF(r, CSUB_DESCRIPTION) : "";
+  s->description = bobjP->hasField(CSUB_DESCRIPTION) ? getStringFieldF(bobjP, CSUB_DESCRIPTION) : "";
 }
 
 
@@ -103,9 +103,9 @@ static void setSubject(Subscription* s, const BSONObj& r)
   for (unsigned int ix = 0; ix < ents.size(); ++ix)
   {
     BSONObj ent               = ents[ix].embeddedObject();
-    std::string id            = getStringFieldF(ent, CSUB_ENTITY_ID);
-    std::string type          = ent.hasField(CSUB_ENTITY_TYPE)? getStringFieldF(ent, CSUB_ENTITY_TYPE) : "";
-    std::string isPattern     = getStringFieldF(ent, CSUB_ENTITY_ISPATTERN);
+    std::string id            = getStringFieldF(&ent, CSUB_ENTITY_ID);
+    std::string type          = ent.hasField(CSUB_ENTITY_TYPE)? getStringFieldF(&ent, CSUB_ENTITY_TYPE) : "";
+    std::string isPattern     = getStringFieldF(&ent, CSUB_ENTITY_ISPATTERN);
     bool        isTypePattern = ent.hasField(CSUB_ENTITY_ISTYPEPATTERN)?
                                   getBoolFieldF(ent, CSUB_ENTITY_ISTYPEPATTERN) : false;
 
@@ -139,12 +139,12 @@ static void setSubject(Subscription* s, const BSONObj& r)
   {
     mongo::BSONObj expression = getObjectFieldF(r, CSUB_EXPR);
 
-    const char*  q           = getStringFieldF(expression, CSUB_EXPR_Q);
-    const char*  mq          = getStringFieldF(expression, CSUB_EXPR_MQ);
-    const char*  geo         = getStringFieldF(expression, CSUB_EXPR_GEOM);
-    const char*  coords      = getStringFieldF(expression, CSUB_EXPR_COORDS);
-    const char*  georel      = getStringFieldF(expression, CSUB_EXPR_GEOREL);
-    const char*  geoproperty = getStringFieldF(expression, "geoproperty");
+    const char*  q           = getStringFieldF(&expression, CSUB_EXPR_Q);
+    const char*  mq          = getStringFieldF(&expression, CSUB_EXPR_MQ);
+    const char*  geo         = getStringFieldF(&expression, CSUB_EXPR_GEOM);
+    const char*  coords      = getStringFieldF(&expression, CSUB_EXPR_COORDS);
+    const char*  georel      = getStringFieldF(&expression, CSUB_EXPR_GEOREL);
+    const char*  geoproperty = getStringFieldF(&expression, "geoproperty");
 
     if (q[0]  != 0)           s->subject.condition.expression.q           = q;
     if (mq[0] != 0)           s->subject.condition.expression.mq          = mq;
@@ -172,7 +172,7 @@ static void setNotification(Subscription* subP, const BSONObj& r, const std::str
     setStringVectorF(r, CSUB_METADATA, &(subP->notification.metadata));
   }
 
-  subP->notification.httpInfo.fill(r);
+  subP->notification.httpInfo.fill(&r);
 
   ngsiv2::Notification* nP = &subP->notification;
 
@@ -184,7 +184,7 @@ static void setNotification(Subscription* subP, const BSONObj& r, const std::str
   nP->lastSuccess       = r.hasField(CSUB_LASTSUCCESS)?      getNumberFieldAsDoubleF(r, CSUB_LASTSUCCESS)      : -1;
 
   // Attributes format
-  subP->attrsFormat = r.hasField(CSUB_FORMAT)? stringToRenderFormat(getStringFieldF(r, CSUB_FORMAT)) : NGSI_V1_LEGACY;
+  subP->attrsFormat = r.hasField(CSUB_FORMAT)? stringToRenderFormat(getStringFieldF(&r, CSUB_FORMAT)) : NGSI_V1_LEGACY;
 
 
   //
@@ -247,7 +247,7 @@ static void setStatus(Subscription* s, const BSONObj& r)
   //
   if ((s->expires > orionldState.requestTime) || (s->expires == -1))
   {
-    s->status = r.hasField(CSUB_STATUS) ? getStringFieldF(r, CSUB_STATUS) : STATUS_ACTIVE;
+    s->status = r.hasField(CSUB_STATUS) ? getStringFieldF(&r, CSUB_STATUS) : STATUS_ACTIVE;
   }
   else
   {
@@ -262,9 +262,9 @@ static void setStatus(Subscription* s, const BSONObj& r)
 *
 * setSubscriptionId -
 */
-static void setSubscriptionId(Subscription* s, const BSONObj& r)
+static void setSubscriptionId(Subscription* s, const BSONObj* rP)
 {
-  s->id = getStringFieldF(r, "_id");
+  s->id = getStringFieldF(rP, "_id");
 }
 
 
@@ -273,9 +273,9 @@ static void setSubscriptionId(Subscription* s, const BSONObj& r)
 *
 * setName -
 */
-static void setName(Subscription* s, const BSONObj& r)
+static void setName(Subscription* s, const BSONObj* rP)
 {
-  s->name = getStringFieldF(r, CSUB_NAME);
+  s->name = getStringFieldF(rP, CSUB_NAME);
 }
 
 
@@ -284,9 +284,9 @@ static void setName(Subscription* s, const BSONObj& r)
 *
 * setContext -
 */
-static void setContext(Subscription* s, const BSONObj& r)
+static void setContext(Subscription* s, const BSONObj* rP)
 {
-  s->ldContext = getStringFieldF(r, CSUB_LDCONTEXT);
+  s->ldContext = getStringFieldF(rP, CSUB_LDCONTEXT);
 }
 
 
@@ -295,9 +295,9 @@ static void setContext(Subscription* s, const BSONObj& r)
 *
 * setCsf -
 */
-static void setCsf(Subscription* s, const BSONObj& r)
+static void setCsf(Subscription* s, const BSONObj* rP)
 {
-  s->csf = getStringFieldF(r, "csf");
+  s->csf = getStringFieldF(rP, "csf");
 }
 
 
@@ -306,11 +306,11 @@ static void setCsf(Subscription* s, const BSONObj& r)
 *
 * setMimeType -
 */
-static void setMimeType(Subscription* s, const BSONObj& r)
+static void setMimeType(Subscription* s, const BSONObj* rP)
 {
-  if (r.hasField(CSUB_NAME))
+  if (rP->hasField(CSUB_NAME))
   {
-    const char* mimeTypeString = getStringFieldF(r, CSUB_MIMETYPE);
+    const char* mimeTypeString = getStringFieldF(rP, CSUB_MIMETYPE);
 
     s->notification.httpInfo.mimeType = longStringToMimeType(mimeTypeString);
   }
@@ -406,7 +406,7 @@ void mongoListSubscriptions
     Subscription  s;
 
     setNewSubscriptionId(&s, r);
-    setDescription(&s, r);
+    setDescription(&s, &r);
     setSubject(&s, r);
     setStatus(&s, r);
     setNotification(&s, r, tenant);
@@ -481,7 +481,7 @@ void mongoGetSubscription
     LM_T(LmtMongo, ("retrieved document: '%s'", r.toString().c_str()));
 
     setNewSubscriptionId(sub, r);
-    setDescription(sub, r);
+    setDescription(sub, &r);
     setSubject(sub, r);
     setNotification(sub, r, tenant);
     setStatus(sub, r);
@@ -567,15 +567,15 @@ bool mongoGetLdSubscription
     }
     LM_T(LmtMongo, ("retrieved document: '%s'", r.toString().c_str()));
 
-    setSubscriptionId(subP, r);
-    setDescription(subP, r);
-    setMimeType(subP, r);
+    setSubscriptionId(subP, &r);
+    setDescription(subP, &r);
+    setMimeType(subP, &r);
     setSubject(subP, r);
     setNotification(subP, r, tenant);
     setStatus(subP, r);
-    setName(subP, r);
-    setContext(subP, r);
-    setCsf(subP, r);
+    setName(subP, &r);
+    setContext(subP, &r);
+    setCsf(subP, &r);
     setTimeInterval(subP, r);
     mongoSetLdTimestamp(&subP->createdAt, "createdAt", r);
     mongoSetLdTimestamp(&subP->modifiedAt, "modifiedAt", r);
@@ -696,15 +696,15 @@ bool mongoGetLdSubscriptions
 
     Subscription s;
 
-    setSubscriptionId(&s, r);
-    setDescription(&s, r);
-    setMimeType(&s, r);
+    setSubscriptionId(&s, &r);
+    setDescription(&s, &r);
+    setMimeType(&s, &r);
     setSubject(&s, r);
     setNotification(&s, r, tenant);
     setStatus(&s, r);
-    setName(&s, r);
-    setContext(&s, r);
-    setCsf(&s, r);
+    setName(&s, &r);
+    setContext(&s, &r);
+    setCsf(&s, &r);
     setTimeInterval(&s, r);
 
     subVecP->push_back(s);

--- a/src/lib/mongoBackend/mongoQueryTypes.cpp
+++ b/src/lib/mongoBackend/mongoQueryTypes.cpp
@@ -151,7 +151,7 @@ static void getAttributeTypes
       if (strncmp(currentAttr, attrName.c_str(), cmpLen) == 0)
       {
         BSONObj attr = getObjectFieldF(attrs, currentAttr);
-        attrTypes->push_back(getStringFieldF(attr, ENT_ATTRS_TYPE));
+        attrTypes->push_back(getStringFieldF(&attr, ENT_ATTRS_TYPE));
       }
     }
   }
@@ -362,7 +362,7 @@ HttpStatusCode mongoEntityTypesValues
     }
     else
     {
-      type = getStringFieldF(resultItem, "_id");
+      type = getStringFieldF(&resultItem, "_id");
     }
 
     responseP->entityTypeVector.push_back(new EntityType(type));
@@ -542,7 +542,7 @@ HttpStatusCode mongoEntityTypes
     std::vector<BSONElement>  attrsArray  = getFieldF(resultItem, "attrs").Array();
     EntityType*               entityType;
 
-    entityType = new EntityType(getStringFieldF(resultItem, "_id"));
+    entityType = new EntityType(getStringFieldF(&resultItem, "_id"));
 
     entityType->count = countEntities(tenant, servicePathV, entityType->type);
 

--- a/src/lib/mongoBackend/mongoRegistrationAux.cpp
+++ b/src/lib/mongoBackend/mongoRegistrationAux.cpp
@@ -60,11 +60,11 @@ void mongoSetRegistrationId(ngsiv2::Registration* regP, const mongo::BSONObj& r)
 *
 * mongoSetDescription -
 */
-void mongoSetDescription(ngsiv2::Registration* regP, const mongo::BSONObj& r)
+void mongoSetDescription(ngsiv2::Registration* regP, const mongo::BSONObj* rP)
 {
-  if (r.hasField(REG_DESCRIPTION))
+  if (rP->hasField(REG_DESCRIPTION))
   {
-    regP->description         = getStringFieldF(r, REG_DESCRIPTION);
+    regP->description         = getStringFieldF(rP, REG_DESCRIPTION);
     regP->descriptionProvided = true;
   }
   else
@@ -80,9 +80,9 @@ void mongoSetDescription(ngsiv2::Registration* regP, const mongo::BSONObj& r)
 *
 * mongoSetProvider -
 */
-void mongoSetProvider(ngsiv2::Registration* regP, const mongo::BSONObj& r)
+void mongoSetProvider(ngsiv2::Registration* regP, const mongo::BSONObj* rP)
 {
-  regP->provider.http.url = (r.hasField(REG_PROVIDING_APPLICATION))? getStringFieldF(r, REG_PROVIDING_APPLICATION): "";
+  regP->provider.http.url = (rP->hasField(REG_PROVIDING_APPLICATION))? getStringFieldF(rP, REG_PROVIDING_APPLICATION): "";
 
   //
   // FIXME #3106: for the moment supportedForwardingMode is hardwired (i.e. DB is not taken
@@ -90,7 +90,7 @@ void mongoSetProvider(ngsiv2::Registration* regP, const mongo::BSONObj& r)
   //
   regP->provider.supportedForwardingMode = ngsiv2::ForwardAll;
 
-  std::string format = r.hasField(REG_FORMAT)? getStringFieldF(r, REG_FORMAT) : "JSON";
+  std::string format = rP->hasField(REG_FORMAT)? getStringFieldF(rP, REG_FORMAT) : "JSON";
   if (format == "JSON")
   {
     regP->provider.legacyForwardingMode = true;
@@ -119,40 +119,40 @@ void mongoSetEntities(ngsiv2::Registration* regP, const mongo::BSONObj& cr0)
 
     if (ce.hasField(REG_ENTITY_ISPATTERN))
     {
-      std::string isPattern = getStringFieldF(ce, REG_ENTITY_ISPATTERN);
+      std::string isPattern = getStringFieldF(&ce, REG_ENTITY_ISPATTERN);
 
       if (isPattern == "true")
       {
-        entity.idPattern = getStringFieldF(ce, REG_ENTITY_ID);
+        entity.idPattern = getStringFieldF(&ce, REG_ENTITY_ID);
       }
       else
       {
-        entity.id = getStringFieldF(ce, REG_ENTITY_ID);
+        entity.id = getStringFieldF(&ce, REG_ENTITY_ID);
       }
     }
     else
     {
-      entity.id = getStringFieldF(ce, REG_ENTITY_ID);
+      entity.id = getStringFieldF(&ce, REG_ENTITY_ID);
     }
 
     if (ce.hasField(REG_ENTITY_ISTYPEPATTERN))
     {
-      std::string isPattern = getStringFieldF(ce, REG_ENTITY_ISTYPEPATTERN);
+      std::string isPattern = getStringFieldF(&ce, REG_ENTITY_ISTYPEPATTERN);
 
       if (isPattern == "true")
       {
-        entity.typePattern = getStringFieldF(ce, REG_ENTITY_TYPE);
+        entity.typePattern = getStringFieldF(&ce, REG_ENTITY_TYPE);
       }
       else
       {
         typeGiven = true;
-        entity.type = getStringFieldF(ce, REG_ENTITY_TYPE);
+        entity.type = getStringFieldF(&ce, REG_ENTITY_TYPE);
       }
     }
     else
     {
       typeGiven = true;
-      entity.type = getStringFieldF(ce, REG_ENTITY_TYPE);
+      entity.type = getStringFieldF(&ce, REG_ENTITY_TYPE);
 
       if (orionldState.apiVersion == NGSI_LD_V1)
         entity.type = orionldContextItemAliasLookup(orionldState.contextP, entity.type.c_str(), NULL, NULL);
@@ -178,7 +178,7 @@ void mongoSetAttributes(ngsiv2::Registration* regP, const mongo::BSONObj& cr0)
   for (unsigned int ix = 0; ix < dbAttributeV.size(); ++ix)
   {
     mongo::BSONObj  aobj     = dbAttributeV[ix].embeddedObject();
-    std::string     attrName = getStringFieldF(aobj, REG_ATTRS_NAME);
+    std::string     attrName = getStringFieldF(&aobj, REG_ATTRS_NAME);
 
     if (attrName != "")
     {
@@ -214,7 +214,7 @@ bool mongoSetDataProvided(ngsiv2::Registration* regP, const mongo::BSONObj& r, b
 
   mongoSetEntities(regP, cr0);
   mongoSetAttributes(regP, cr0);
-  mongoSetProvider(regP, cr0);
+  mongoSetProvider(regP, &cr0);
 
 #ifdef ORIONLD
   mongoSetLdPropertyV(regP, cr0);
@@ -241,7 +241,7 @@ void mongoSetExpires(ngsiv2::Registration* regP, const mongo::BSONObj& r)
 *
 * mongoSetStatus -
 */
-void mongoSetStatus(ngsiv2::Registration* regP, const mongo::BSONObj& r)
+void mongoSetStatus(ngsiv2::Registration* regP, const mongo::BSONObj* rP)
 {
-  regP->status = (r.hasField(REG_STATUS))? getStringFieldF(r, REG_STATUS): "";
+  regP->status = (rP->hasField(REG_STATUS))? getStringFieldF(rP, REG_STATUS): "";
 }

--- a/src/lib/mongoBackend/mongoRegistrationAux.h
+++ b/src/lib/mongoBackend/mongoRegistrationAux.h
@@ -36,12 +36,12 @@
 * mongo set functions
 */
 extern void mongoSetRegistrationId(ngsiv2::Registration* regP, const mongo::BSONObj& r);
-extern void mongoSetDescription(ngsiv2::Registration* regP, const mongo::BSONObj& r);
-extern void mongoSetProvider(ngsiv2::Registration* regP, const mongo::BSONObj& r);
-extern void mongoSetEntities(ngsiv2::Registration* regP, const mongo::BSONObj& cr0);
-extern void mongoSetAttributes(ngsiv2::Registration* regP, const mongo::BSONObj& cr0);
-extern void mongoSetExpires(ngsiv2::Registration* regP, const mongo::BSONObj& r);
-extern void mongoSetStatus(ngsiv2::Registration* regP, const mongo::BSONObj& r);
-extern bool mongoSetDataProvided(ngsiv2::Registration* regP, const mongo::BSONObj& r, bool arrayAllowed);
+extern void mongoSetDescription(ngsiv2::Registration* regP,    const mongo::BSONObj* rP);
+extern void mongoSetProvider(ngsiv2::Registration* regP,       const mongo::BSONObj* rP);
+extern void mongoSetEntities(ngsiv2::Registration* regP,       const mongo::BSONObj& cr0);
+extern void mongoSetAttributes(ngsiv2::Registration* regP,     const mongo::BSONObj& cr0);
+extern void mongoSetExpires(ngsiv2::Registration* regP,        const mongo::BSONObj& r);
+extern void mongoSetStatus(ngsiv2::Registration* regP,         const mongo::BSONObj* rP);
+extern bool mongoSetDataProvided(ngsiv2::Registration* regP,   const mongo::BSONObj& r, bool arrayAllowed);
 
 #endif  // SRC_LIB_MONGOBACKEND_MONGOREGISTRATIONAUX_H_

--- a/src/lib/mongoBackend/mongoRegistrationGet.cpp
+++ b/src/lib/mongoBackend/mongoRegistrationGet.cpp
@@ -113,7 +113,7 @@ void mongoRegistrationGet
     // Fill in the Registration with data retrieved from the data base
     //
     mongoSetRegistrationId(regP, bob);
-    mongoSetDescription(regP, bob);
+    mongoSetDescription(regP, &bob);
 
     if (mongoSetDataProvided(regP, bob, false) == false)
     {
@@ -130,7 +130,7 @@ void mongoRegistrationGet
     mongoSetLdManagementInterval(regP, bob);
 #endif
     mongoSetExpires(regP, bob);
-    mongoSetStatus(regP, bob);
+    mongoSetStatus(regP, &bob);
 
     if (moreSafe(cursor))  // Can only be one ...
     {
@@ -227,7 +227,7 @@ void mongoRegistrationsGet
     // Fill in the Registration with data retrieved from the data base
     //
     mongoSetRegistrationId(&reg, bob);
-    mongoSetDescription(&reg, bob);
+    mongoSetDescription(&reg, &bob);
 
     if (mongoSetDataProvided(&reg, bob, false) == false)
     {
@@ -239,7 +239,7 @@ void mongoRegistrationsGet
     }
 
     mongoSetExpires(&reg, bob);
-    mongoSetStatus(&reg, bob);
+    mongoSetStatus(&reg, &bob);
 
     regV->push_back(reg);
   }

--- a/src/lib/mongoBackend/mongoSubCache.cpp
+++ b/src/lib/mongoBackend/mongoSubCache.cpp
@@ -142,8 +142,8 @@ int mongoSubCacheItemInsert(const char* tenant, const BSONObj& sub)
   //
   // NOTE: NGSIv1 JSON is 'default' (for old db-content)
   //
-  const char*    ldContext          = sub.hasField(CSUB_LDCONTEXT)? getStringFieldF(sub, CSUB_LDCONTEXT) : NULL;
-  const char*    renderFormatString = sub.hasField(CSUB_FORMAT)? getStringFieldF(sub, CSUB_FORMAT) : "legacy";
+  const char*    ldContext          = sub.hasField(CSUB_LDCONTEXT)? getStringFieldF(&sub, CSUB_LDCONTEXT) : NULL;
+  const char*    renderFormatString = sub.hasField(CSUB_FORMAT)? getStringFieldF(&sub, CSUB_FORMAT) : "legacy";
   RenderFormat   renderFormat       = stringToRenderFormat(renderFormatString);
 
   if ((ldContext != NULL) && (ldContext[0] != 0))  // NGSI-LD subscription
@@ -165,12 +165,12 @@ int mongoSubCacheItemInsert(const char* tenant, const BSONObj& sub)
   }
 
   cSubP->tenant                = (tenant[0] == 0)? strdup("") : strdup(tenant);  // FIXME: strdup("") ... really?
-  cSubP->servicePath           = strdup(sub.hasField(CSUB_SERVICE_PATH)? getStringFieldF(sub, CSUB_SERVICE_PATH) : "/");
+  cSubP->servicePath           = strdup(sub.hasField(CSUB_SERVICE_PATH)? getStringFieldF(&sub, CSUB_SERVICE_PATH) : "/");
   cSubP->renderFormat          = renderFormat;
   cSubP->throttling            = sub.hasField(CSUB_THROTTLING)?       getNumberFieldAsDoubleF(sub, CSUB_THROTTLING)       : -1;
   cSubP->expirationTime        = sub.hasField(CSUB_EXPIRATION)?       getNumberFieldAsDoubleF(sub, CSUB_EXPIRATION)       : 0;
   cSubP->lastNotificationTime  = sub.hasField(CSUB_LASTNOTIFICATION)? getNumberFieldAsDoubleF(sub, CSUB_LASTNOTIFICATION) : -1;
-  cSubP->status                = sub.hasField(CSUB_STATUS)?           getStringFieldF(sub, CSUB_STATUS)                   : "active";
+  cSubP->status                = sub.hasField(CSUB_STATUS)?           getStringFieldF(&sub, CSUB_STATUS)                  : "active";
   cSubP->blacklist             = sub.hasField(CSUB_BLACKLIST)?        getBoolFieldF(sub, CSUB_BLACKLIST)                  : false;
   cSubP->lastFailure           = sub.hasField(CSUB_LASTFAILURE)?      getNumberFieldAsDoubleF(sub, CSUB_LASTFAILURE)      : -1;
   cSubP->lastSuccess           = sub.hasField(CSUB_LASTSUCCESS)?      getNumberFieldAsDoubleF(sub, CSUB_LASTSUCCESS)      : -1;
@@ -183,7 +183,7 @@ int mongoSubCacheItemInsert(const char* tenant, const BSONObj& sub)
   //
   // Note that the URL of the notification is stored outside the httpInfo object in mongo
   //
-  cSubP->httpInfo.fill(sub);
+  cSubP->httpInfo.fill(&sub);
 
 
   //
@@ -197,7 +197,7 @@ int mongoSubCacheItemInsert(const char* tenant, const BSONObj& sub)
     {
       std::string errorString;
 
-      cSubP->expression.q = getStringFieldF(expression, CSUB_EXPR_Q);
+      cSubP->expression.q = getStringFieldF(&expression, CSUB_EXPR_Q);
       if (cSubP->expression.q != "")
       {
         if (!cSubP->expression.stringFilter.parse(cSubP->expression.q.c_str(), &errorString))
@@ -214,7 +214,7 @@ int mongoSubCacheItemInsert(const char* tenant, const BSONObj& sub)
     {
       std::string errorString;
 
-      cSubP->expression.mq = getStringFieldF(expression, CSUB_EXPR_MQ);
+      cSubP->expression.mq = getStringFieldF(&expression, CSUB_EXPR_MQ);
       if (cSubP->expression.mq != "")
       {
         if (!cSubP->expression.mdStringFilter.parse(cSubP->expression.mq.c_str(), &errorString))
@@ -229,17 +229,17 @@ int mongoSubCacheItemInsert(const char* tenant, const BSONObj& sub)
 
     if (expression.hasField(CSUB_EXPR_GEOM))
     {
-      cSubP->expression.geometry = getStringFieldF(expression, CSUB_EXPR_GEOM);
+      cSubP->expression.geometry = getStringFieldF(&expression, CSUB_EXPR_GEOM);
     }
 
     if (expression.hasField(CSUB_EXPR_COORDS))
     {
-      cSubP->expression.coords = getStringFieldF(expression, CSUB_EXPR_COORDS);
+      cSubP->expression.coords = getStringFieldF(&expression, CSUB_EXPR_COORDS);
     }
 
     if (expression.hasField(CSUB_EXPR_GEOREL))
     {
-      cSubP->expression.georel = getStringFieldF(expression, CSUB_EXPR_GEOREL);
+      cSubP->expression.georel = getStringFieldF(&expression, CSUB_EXPR_GEOREL);
     }
   }
 
@@ -258,15 +258,15 @@ int mongoSubCacheItemInsert(const char* tenant, const BSONObj& sub)
       continue;
     }
 
-    std::string id            = getStringFieldF(entity, ENT_ENTITY_ID);
-    std::string isPattern     = entity.hasField(CSUB_ENTITY_ISPATTERN)? getStringFieldF(entity, CSUB_ENTITY_ISPATTERN) : "false";
+    std::string id            = getStringFieldF(&entity, ENT_ENTITY_ID);
+    std::string isPattern     = entity.hasField(CSUB_ENTITY_ISPATTERN)? getStringFieldF(&entity, CSUB_ENTITY_ISPATTERN) : "false";
     if (isPattern.empty() && id.empty())
     {
       id = ".*";
       isPattern = "true";
     }
 
-    std::string type          = entity.hasField(CSUB_ENTITY_TYPE)?      getStringFieldF(entity, CSUB_ENTITY_TYPE)      : "";
+    std::string type          = entity.hasField(CSUB_ENTITY_TYPE)?      getStringFieldF(&entity, CSUB_ENTITY_TYPE)      : "";
     bool        isTypePattern = entity.hasField(CSUB_ENTITY_ISTYPEPATTERN)? getBoolFieldF(entity, CSUB_ENTITY_ISTYPEPATTERN) : false;
     EntityInfo* eiP           = new EntityInfo(id, type, isPattern, isTypePattern);
 
@@ -384,15 +384,15 @@ int mongoSubCacheItemInsert
       continue;
     }
 
-    std::string id            = getStringFieldF(entity, ENT_ENTITY_ID);
-    std::string isPattern     = entity.hasField(CSUB_ENTITY_ISPATTERN)? getStringFieldF(entity, CSUB_ENTITY_ISPATTERN) : "false";
+    std::string id            = getStringFieldF(&entity, ENT_ENTITY_ID);
+    std::string isPattern     = entity.hasField(CSUB_ENTITY_ISPATTERN)? getStringFieldF(&entity, CSUB_ENTITY_ISPATTERN) : "false";
     if (isPattern.empty() && id.empty())
     {
       id = ".*";
       isPattern = "true";
     }
 
-    std::string type          = entity.hasField(CSUB_ENTITY_TYPE)?      getStringFieldF(entity, CSUB_ENTITY_TYPE)      : "";
+    std::string type          = entity.hasField(CSUB_ENTITY_TYPE)?      getStringFieldF(&entity, CSUB_ENTITY_TYPE)      : "";
     bool        isTypePattern = entity.hasField(CSUB_ENTITY_ISTYPEPATTERN)? getBoolFieldF(entity, CSUB_ENTITY_ISTYPEPATTERN) : false;
     EntityInfo* eiP           = new EntityInfo(id, type, isPattern, isTypePattern);
 
@@ -442,7 +442,7 @@ int mongoSubCacheItemInsert
   //
   // Note that the URL of the notification is stored outside the httpInfo object in mongo
   //
-  cSubP->httpInfo.fill(sub);
+  cSubP->httpInfo.fill(&sub);
 
 
   //

--- a/src/lib/mongoBackend/mongoUpdateContextAvailabilitySubscription.cpp
+++ b/src/lib/mongoBackend/mongoUpdateContextAvailabilitySubscription.cpp
@@ -163,7 +163,7 @@ HttpStatusCode mongoUpdateContextAvailabilitySubscription
   }
 
   /* Reference is not updatable, so it is appended directly */
-  newSub.append(CASUB_REFERENCE, getStringFieldF(sub, CASUB_REFERENCE));
+  newSub.append(CASUB_REFERENCE, getStringFieldF(&sub, CASUB_REFERENCE));
 
   int count = sub.hasField(CASUB_COUNT) ? getIntFieldF(sub, CASUB_COUNT) : 0;
 
@@ -208,7 +208,7 @@ HttpStatusCode mongoUpdateContextAvailabilitySubscription
   processAvailabilitySubscription(requestP->entityIdVector,
                                   requestP->attributeList,
                                   requestP->subscriptionId.get(),
-                                  getStringFieldF(sub, CASUB_REFERENCE),
+                                  getStringFieldF(&sub, CASUB_REFERENCE),
                                   NGSI_V1_LEGACY,
                                   tenant,
                                   fiwareCorrelator);

--- a/src/lib/mongoBackend/mongoUpdateSubscription.cpp
+++ b/src/lib/mongoBackend/mongoUpdateSubscription.cpp
@@ -98,7 +98,7 @@ static void setHttpInfo(const SubscriptionUpdate& subUp, const BSONObj& subOrig,
   else
   {
     // 'reference' is a mandatory field and 'custom' has a clear mapping to false in the case of missing field
-    std::string reference = getStringFieldF(subOrig, CSUB_REFERENCE);
+    std::string reference = getStringFieldF(&subOrig, CSUB_REFERENCE);
     bool        custom    = subOrig.hasField(CSUB_CUSTOM) ? getBoolFieldF(subOrig, CSUB_CUSTOM) : false;
 
     b->append(CSUB_REFERENCE, reference);
@@ -109,7 +109,7 @@ static void setHttpInfo(const SubscriptionUpdate& subUp, const BSONObj& subOrig,
 
     if (subOrig.hasField(CSUB_METHOD))
     {
-      std::string method = getStringFieldF(subOrig, CSUB_METHOD);
+      std::string method = getStringFieldF(&subOrig, CSUB_METHOD);
 
       b->append(CSUB_METHOD, method);
       LM_T(LmtMongo, ("Subscription method: %s", method.c_str()));
@@ -133,7 +133,7 @@ static void setHttpInfo(const SubscriptionUpdate& subUp, const BSONObj& subOrig,
 
     if (subOrig.hasField(CSUB_PAYLOAD))
     {
-      std::string payload = getStringFieldF(subOrig, CSUB_PAYLOAD);
+      std::string payload = getStringFieldF(&subOrig, CSUB_PAYLOAD);
 
       b->append(CSUB_PAYLOAD, payload);
       LM_T(LmtMongo, ("Subscription payload: %s", payload.c_str()));
@@ -181,7 +181,7 @@ static void setDescription(const SubscriptionUpdate& subUp, const BSONObj& subOr
   {
     if (subOrig.hasField(CSUB_DESCRIPTION))
     {
-      std::string description = getStringFieldF(subOrig, CSUB_DESCRIPTION);
+      std::string description = getStringFieldF(&subOrig, CSUB_DESCRIPTION);
 
       b->append(CSUB_DESCRIPTION, description);
       LM_T(LmtMongo, ("Subscription description: %s", description.c_str()));
@@ -205,7 +205,7 @@ static void setStatus(const SubscriptionUpdate& subUp, const BSONObj& subOrig, B
   {
     if (subOrig.hasField(CSUB_STATUS))
     {
-      std::string status = getStringFieldF(subOrig, CSUB_STATUS);
+      std::string status = getStringFieldF(&subOrig, CSUB_STATUS);
 
       b->append(CSUB_STATUS, status);
       LM_T(LmtMongo, ("Subscription status: %s", status.c_str()));
@@ -296,9 +296,9 @@ static void setCondsAndInitialNotifyNgsiv1
   for (unsigned int ix = 0; ix < ents.size(); ++ix)
   {
     BSONObj     ent       = ents[ix].embeddedObject();
-    std::string id        = getStringFieldF(ent, CSUB_ENTITY_ID);
-    std::string type      = ent.hasField(CSUB_ENTITY_TYPE)? getStringFieldF(ent, CSUB_ENTITY_TYPE) : "";
-    std::string isPattern = getStringFieldF(ent, CSUB_ENTITY_ISPATTERN);
+    std::string id        = getStringFieldF(&ent, CSUB_ENTITY_ID);
+    std::string type      = ent.hasField(CSUB_ENTITY_TYPE)? getStringFieldF(&ent, CSUB_ENTITY_TYPE) : "";
+    std::string isPattern = getStringFieldF(&ent, CSUB_ENTITY_ISPATTERN);
     EntID       en;
 
     if (isFalse(isPattern))
@@ -384,7 +384,7 @@ static void setCondsAndInitialNotify
     }
     else
     {
-      status = subOrig.hasField(CSUB_STATUS)? getStringFieldF(subOrig, CSUB_STATUS) : STATUS_ACTIVE;
+      status = subOrig.hasField(CSUB_STATUS)? getStringFieldF(&subOrig, CSUB_STATUS) : STATUS_ACTIVE;
     }
 
     if (subUp.notificationProvided)
@@ -396,7 +396,7 @@ static void setCondsAndInitialNotify
     }
     else
     {
-      httpInfo.fill(subOrig);
+      httpInfo.fill(&subOrig);
       blacklist = subOrig.hasField(CSUB_BLACKLIST)? getBoolFieldF(subOrig, CSUB_BLACKLIST) : false;
       setStringVectorF(subOrig, CSUB_ATTRS, &notifAttributesV);
 
@@ -412,7 +412,7 @@ static void setCondsAndInitialNotify
     }
     else if (subOrig.hasField(CSUB_FORMAT))
     {
-      attrsFormat = stringToRenderFormat(getStringFieldF(subOrig, CSUB_FORMAT));
+      attrsFormat = stringToRenderFormat(getStringFieldF(&subOrig, CSUB_FORMAT));
     }
 
     if (subUp.fromNgsiv1)
@@ -626,7 +626,7 @@ static void setFormat(const SubscriptionUpdate& subUp, const BSONObj& subOrig, B
   }
   else
   {
-    std::string format = getStringFieldF(subOrig, CSUB_FORMAT);
+    std::string format = getStringFieldF(&subOrig, CSUB_FORMAT);
 
     b->append(CSUB_FORMAT, format);
     LM_T(LmtMongo, ("Subscription format: %s", format.c_str()));
@@ -769,18 +769,18 @@ void updateInCache
 
   if (doc.hasField(CSUB_FORMAT))
   {
-    renderFormat = stringToRenderFormat(getStringFieldF(doc, CSUB_FORMAT));
+    renderFormat = stringToRenderFormat(getStringFieldF(&doc, CSUB_FORMAT));
   }
 
   if (doc.hasField(CSUB_EXPR))
   {
     BSONObj expr = getObjectFieldF(doc, CSUB_EXPR);
 
-    q      = expr.hasField(CSUB_EXPR_Q)?      getStringFieldF(expr, CSUB_EXPR_Q)      : "";
-    mq     = expr.hasField(CSUB_EXPR_MQ)?     getStringFieldF(expr, CSUB_EXPR_MQ)     : "";
-    geom   = expr.hasField(CSUB_EXPR_GEOM)?   getStringFieldF(expr, CSUB_EXPR_GEOM)   : "";
-    coords = expr.hasField(CSUB_EXPR_COORDS)? getStringFieldF(expr, CSUB_EXPR_COORDS) : "";
-    georel = expr.hasField(CSUB_EXPR_GEOREL)? getStringFieldF(expr, CSUB_EXPR_GEOREL) : "";
+    q      = expr.hasField(CSUB_EXPR_Q)?      getStringFieldF(&expr, CSUB_EXPR_Q)      : "";
+    mq     = expr.hasField(CSUB_EXPR_MQ)?     getStringFieldF(&expr, CSUB_EXPR_MQ)     : "";
+    geom   = expr.hasField(CSUB_EXPR_GEOM)?   getStringFieldF(&expr, CSUB_EXPR_GEOM)   : "";
+    coords = expr.hasField(CSUB_EXPR_COORDS)? getStringFieldF(&expr, CSUB_EXPR_COORDS) : "";
+    georel = expr.hasField(CSUB_EXPR_GEOREL)? getStringFieldF(&expr, CSUB_EXPR_GEOREL) : "";
   }
 
 
@@ -792,7 +792,7 @@ void updateInCache
                                           lastFailure,
                                           lastSuccess,
                                           doc.hasField(CSUB_EXPIRATION)? getNumberFieldAsDoubleF(doc, CSUB_EXPIRATION) : 0,
-                                          doc.hasField(CSUB_STATUS)? getStringFieldF(doc, CSUB_STATUS) : STATUS_ACTIVE,
+                                          doc.hasField(CSUB_STATUS)? getStringFieldF(&doc, CSUB_STATUS) : STATUS_ACTIVE,
                                           q,
                                           mq,
                                           geom,

--- a/src/lib/mongoBackend/safeMongo.cpp
+++ b/src/lib/mongoBackend/safeMongo.cpp
@@ -108,25 +108,25 @@ BSONArray getArrayField(const BSONObj& b, const char* field, const char* caller,
 *
 * getStringField -
 */
-const char* getStringField(const BSONObj& b, const char* field, const char* caller, int line)
+const char* getStringField(const BSONObj* bP, const char* field, const char* caller, int line)
 {
-  if (b.hasField(field) && b.getField(field).type() == mongo::String)
-    return b.getStringField(field);
+  if (bP->hasField(field) && bP->getField(field).type() == mongo::String)
+    return bP->getStringField(field);
 
 
   // Detect error
-  if (!b.hasField(field))
+  if (!bP->hasField(field))
   {
     LM_E(("Runtime Error (string field '%s' is missing in BSONObj <%s> from caller %s:%d)",
           field,
-          b.toString().c_str(),
+          bP->toString().c_str(),
           caller,
           line));
   }
   else
   {
     LM_E(("Runtime Error (field '%s' was supposed to be a string but type=%d in BSONObj <%s> from caller %s:%d)",
-          field, b.getField(field).type(), b.toString().c_str(), caller, line));
+          field, bP->getField(field).type(), bP->toString().c_str(), caller, line));
   }
 
   return "";

--- a/src/lib/mongoBackend/safeMongo.h
+++ b/src/lib/mongoBackend/safeMongo.h
@@ -89,10 +89,10 @@ extern mongo::BSONArray getArrayField
 */
 extern const char* getStringField
 (
-  const mongo::BSONObj&  b,
-  const char*            field,
-  const char*            caller = "<none>",
-  int                    line   = 0
+  const mongo::BSONObj* bP,
+  const char*           field,
+  const char*           caller = "<none>",
+  int                   line   = 0
 );
 
 

--- a/src/lib/ngsi/ContextElementResponse.cpp
+++ b/src/lib/ngsi/ContextElementResponse.cpp
@@ -144,17 +144,18 @@ ContextElementResponse::ContextElementResponse
   // Entity
   BSONObj id = getFieldF(entityDoc, "_id").embeddedObject();
 
-  std::string entityId   = getStringFieldF(id, ENT_ENTITY_ID);
-  std::string entityType = id.hasField(ENT_ENTITY_TYPE) ? getStringFieldF(id, ENT_ENTITY_TYPE) : "";
+  std::string entityId   = getStringFieldF(&id, ENT_ENTITY_ID);
+  std::string entityType = id.hasField(ENT_ENTITY_TYPE) ? getStringFieldF(&id, ENT_ENTITY_TYPE) : "";
 
   contextElement.entityId.fill(entityId, entityType, "false");
-  contextElement.entityId.servicePath = id.hasField(ENT_SERVICE_PATH) ? getStringFieldF(id, ENT_SERVICE_PATH) : "";
+  contextElement.entityId.servicePath = id.hasField(ENT_SERVICE_PATH) ? getStringFieldF(&id, ENT_SERVICE_PATH) : "";
 
   /* Get the location attribute (if it exists) */
   std::string locAttr;
   if (entityDoc.hasElement(ENT_LOCATION))
   {
-    locAttr = getStringFieldF(getObjectFieldF(entityDoc, ENT_LOCATION), ENT_LOCATION_ATTRNAME);
+    BSONObj objField = getObjectFieldF(entityDoc, ENT_LOCATION);
+    locAttr = getStringFieldF(&objField, ENT_LOCATION_ATTRNAME);
   }
 
 
@@ -186,7 +187,7 @@ ContextElementResponse::ContextElementResponse
     eqForDot(aName);
 
     ca.name = aName;
-    ca.type = getStringFieldF(attr, ENT_ATTRS_TYPE);
+    ca.type = getStringFieldF(&attr, ENT_ATTRS_TYPE);
 
     // Skip attribute if the attribute is in the list (or attrL is empty or includes "*")
     if (!includedAttribute(&ca, attrL))
@@ -205,7 +206,7 @@ ContextElementResponse::ContextElementResponse
       switch(getFieldF(attr, ENT_ATTRS_VALUE).type())
       {
       case String:
-        ca.stringValue = getStringFieldF(attr, ENT_ATTRS_VALUE);
+        ca.stringValue = getStringFieldF(&attr, ENT_ATTRS_VALUE);
         if (!includeEmpty && ca.stringValue.length() == 0)
         {
           continue;
@@ -284,13 +285,14 @@ ContextElementResponse::ContextElementResponse
       mds.getFieldNames(mdsSet);
       for (std::set<std::string>::iterator i = mdsSet.begin(); i != mdsSet.end(); ++i)
       {
-        char* currentMd = (char*) i->c_str();
-        char  mdName[512];
+        char*   currentMd = (char*) i->c_str();
+        BSONObj mdObj     = getObjectFieldF(mds, currentMd); 
+        char    mdName[512];
 
         strncpy(mdName, currentMd, sizeof(mdName));
         eqForDot(mdName);
 
-        Metadata*   mdP = new Metadata(mdName, getObjectFieldF(mds, currentMd));
+        Metadata* mdP = new Metadata((const char*) mdName, &mdObj);
         caP->metadataVector.push_back(mdP);
       }
     }

--- a/src/lib/ngsi/Metadata.cpp
+++ b/src/lib/ngsi/Metadata.cpp
@@ -186,16 +186,16 @@ Metadata::Metadata(const std::string& _name, const std::string& _type, bool _val
 *
 * Metadata::Metadata -
 */
-Metadata::Metadata(const std::string& _name, const BSONObj& mdB)
+Metadata::Metadata(const char* _name, BSONObj* mdB)
 {
   name            = _name;
-  type            = mdB.hasField(ENT_ATTRS_MD_TYPE) ? getStringFieldF(mdB, ENT_ATTRS_MD_TYPE) : "";
+  type            = mdB->hasField(ENT_ATTRS_MD_TYPE) ? getStringFieldF(mdB, ENT_ATTRS_MD_TYPE) : "";
   typeGiven       = (type == "")? false : true;
   compoundValueP  = NULL;
-  createdAt       = mdB.hasField("createdAt") ? getNumberFieldF(mdB, "createdAt") : 0;
-  modifiedAt      = mdB.hasField("modifiedAt") ? getNumberFieldF(mdB, "modifiedAt") : 0;
+  createdAt       = mdB->hasField("createdAt")  ? getNumberFieldF(*mdB, "createdAt") : 0;
+  modifiedAt      = mdB->hasField("modifiedAt") ? getNumberFieldF(*mdB, "modifiedAt") : 0;
 
-  BSONType bsonType = getFieldF(mdB, ENT_ATTRS_MD_VALUE).type();
+  BSONType bsonType = getFieldF(*mdB, ENT_ATTRS_MD_VALUE).type();
   switch (bsonType)
   {
   case String:
@@ -205,17 +205,17 @@ Metadata::Metadata(const std::string& _name, const BSONObj& mdB)
 
   case NumberInt:
     valueType   = orion::ValueTypeNumber;
-    numberValue = (double) getIntFieldF(mdB, ENT_ATTRS_MD_VALUE);
+    numberValue = (double) getIntFieldF(*mdB, ENT_ATTRS_MD_VALUE);
     break;
 
   case NumberDouble:
     valueType   = orion::ValueTypeNumber;
-    numberValue = getNumberFieldF(mdB, ENT_ATTRS_MD_VALUE);
+    numberValue = getNumberFieldF(*mdB, ENT_ATTRS_MD_VALUE);
     break;
 
   case Bool:
     valueType = orion::ValueTypeBoolean;
-    boolValue = getBoolFieldF(mdB, ENT_ATTRS_MD_VALUE);
+    boolValue = getBoolFieldF(*mdB, ENT_ATTRS_MD_VALUE);
     break;
 
   case jstNULL:
@@ -226,7 +226,7 @@ Metadata::Metadata(const std::string& _name, const BSONObj& mdB)
   case Array:
     valueType      = orion::ValueTypeObject;
     compoundValueP = new orion::CompoundValueNode();
-    compoundObjectResponse(compoundValueP, getFieldF(mdB, ENT_ATTRS_VALUE));
+    compoundObjectResponse(compoundValueP, getFieldF(*mdB, ENT_ATTRS_VALUE));
     compoundValueP->container = compoundValueP;
     compoundValueP->name      = "value";
     compoundValueP->valueType = (bsonType == Object)? orion::ValueTypeObject : orion::ValueTypeVector;
@@ -234,7 +234,7 @@ Metadata::Metadata(const std::string& _name, const BSONObj& mdB)
 
   default:
     valueType = orion::ValueTypeNotGiven;
-    LM_E(("Runtime Error (unknown metadata value type in DB: %d, using ValueTypeNotGiven)", getFieldF(mdB, ENT_ATTRS_MD_VALUE).type()));
+    LM_E(("Runtime Error (unknown metadata value type in DB: %d, using ValueTypeNotGiven)", getFieldF(*mdB, ENT_ATTRS_MD_VALUE).type()));
     break;
   }
 }

--- a/src/lib/ngsi/Metadata.h
+++ b/src/lib/ngsi/Metadata.h
@@ -89,7 +89,7 @@ typedef struct Metadata
   Metadata(const std::string& _name, const std::string& _type, const std::string& _value);
   Metadata(const std::string& _name, const std::string& _type, double _value);
   Metadata(const std::string& _name, const std::string& _type, bool _value);
-  Metadata(const std::string& _name, const mongo::BSONObj& mdB);
+  Metadata(const char* _name, mongo::BSONObj* mdB);
   ~Metadata();
 
   std::string  render(bool comma);

--- a/src/lib/orionld/mongoBackend/mongoLdRegistrationAux.cpp
+++ b/src/lib/orionld/mongoBackend/mongoLdRegistrationAux.cpp
@@ -57,12 +57,12 @@ void mongoSetLdPropertyV(ngsiv2::Registration* reg, const mongo::BSONObj& r)
   for (unsigned int ix = 0; ix < dbPropertyV.size(); ++ix)
   {
     mongo::BSONObj  pobj = dbPropertyV[ix].embeddedObject();
-    std::string     type = getStringFieldF(pobj, REG_ATTRS_TYPE);
+    std::string     type = getStringFieldF(&pobj, REG_ATTRS_TYPE);
     std::string     propName;
 
     if (type == REG_PROPERTIES_TYPE)
     {
-      propName = getStringFieldF(pobj, REG_PROPERTIES_NAME);
+      propName = getStringFieldF(&pobj, REG_PROPERTIES_NAME);
 
       if (propName != "")
       {
@@ -86,12 +86,12 @@ void mongoSetLdRelationshipV(ngsiv2::Registration* reg, const mongo::BSONObj& r)
   for (unsigned int ix = 0; ix < dbRelationshipV.size(); ++ix)
   {
     mongo::BSONObj  robj = dbRelationshipV[ix].embeddedObject();
-    std::string     type = getStringFieldF(robj, REG_ATTRS_TYPE);
+    std::string     type = getStringFieldF(&robj, REG_ATTRS_TYPE);
     std::string     relName;
 
     if (type == REG_RELATIONSHIPS_TYPE)
     {
-      relName = getStringFieldF(robj, REG_RELATIONSHIPS_NAME);
+      relName = getStringFieldF(&robj, REG_RELATIONSHIPS_NAME);
 
       if (relName != "")
       {
@@ -108,9 +108,9 @@ void mongoSetLdRelationshipV(ngsiv2::Registration* reg, const mongo::BSONObj& r)
 *
 * mongoSetLdRegistrationId -
 */
-void mongoSetLdRegistrationId(ngsiv2::Registration* reg, const mongo::BSONObj& r)
+void mongoSetLdRegistrationId(ngsiv2::Registration* reg, mongo::BSONObj* bobjP)
 {
-  reg->id = getStringFieldF(r, "_id");
+  reg->id = getStringFieldF(bobjP, "_id");
 }
 
 
@@ -119,9 +119,9 @@ void mongoSetLdRegistrationId(ngsiv2::Registration* reg, const mongo::BSONObj& r
 *
 * mongoSetLdName -
 */
-void mongoSetLdName(ngsiv2::Registration* reg, const mongo::BSONObj& r)
+void mongoSetLdName(ngsiv2::Registration* reg, mongo::BSONObj* bobjP)
 {
-  reg->name = r.hasField(REG_NAME) ? getStringFieldF(r, REG_NAME) : "";
+  reg->name = bobjP->hasField(REG_NAME) ? getStringFieldF(bobjP, REG_NAME) : "";
 }
 
 

--- a/src/lib/orionld/mongoBackend/mongoLdRegistrationAux.h
+++ b/src/lib/orionld/mongoBackend/mongoLdRegistrationAux.h
@@ -37,8 +37,8 @@
 */
 extern void mongoSetLdPropertyV(ngsiv2::Registration* reg, const mongo::BSONObj& r);
 extern void mongoSetLdRelationshipV(ngsiv2::Registration* reg, const mongo::BSONObj& r);
-extern void mongoSetLdRegistrationId(ngsiv2::Registration* reg, const mongo::BSONObj& r);
-extern void mongoSetLdName(ngsiv2::Registration* reg, const mongo::BSONObj& r);
+extern void mongoSetLdRegistrationId(ngsiv2::Registration* reg, mongo::BSONObj* bobjP);
+extern void mongoSetLdName(ngsiv2::Registration* reg, mongo::BSONObj* bobjP);
 extern void mongoSetExpiration(ngsiv2::Registration* regP, const mongo::BSONObj& r);
 extern void mongoSetLdObservationInterval(ngsiv2::Registration* reg, const mongo::BSONObj& r);
 extern void mongoSetLdManagementInterval(ngsiv2::Registration* reg, const mongo::BSONObj& r);

--- a/src/lib/orionld/mongoBackend/mongoLdRegistrationGet.cpp
+++ b/src/lib/orionld/mongoBackend/mongoLdRegistrationGet.cpp
@@ -108,9 +108,9 @@ bool mongoLdRegistrationGet
       return true;
     }
 
-    mongoSetLdRegistrationId(regP, bob);
-    mongoSetLdName(regP, bob);
-    mongoSetDescription(regP, bob);
+    mongoSetLdRegistrationId(regP, &bob);
+    mongoSetLdName(regP, &bob);
+    mongoSetDescription(regP, &bob);
 
     if (mongoSetDataProvided(regP, bob, false) == false)
     {
@@ -124,7 +124,7 @@ bool mongoLdRegistrationGet
     mongoSetLdObservationInterval(regP, bob);
     mongoSetLdManagementInterval(regP, bob);
     mongoSetExpiration(regP, bob);
-    mongoSetStatus(regP, bob);
+    mongoSetStatus(regP, &bob);
 
     mongoSetLdTimestamp(&regP->createdAt, "createdAt", bob);
     mongoSetLdTimestamp(&regP->modifiedAt, "modifiedAt", bob);

--- a/src/lib/orionld/mongoBackend/mongoLdRegistrationsGet.cpp
+++ b/src/lib/orionld/mongoBackend/mongoLdRegistrationsGet.cpp
@@ -285,9 +285,9 @@ bool mongoLdRegistrationsGet
     //        An aux function should be created for this to avoid the copied code.
     //
 
-    mongoSetLdRegistrationId(&reg, bob);
-    mongoSetLdName(&reg, bob);
-    mongoSetDescription(&reg, bob);
+    mongoSetLdRegistrationId(&reg, &bob);
+    mongoSetLdName(&reg, &bob);
+    mongoSetDescription(&reg, &bob);
 
     if (mongoSetDataProvided(&reg, bob, false) == false)
     {
@@ -301,7 +301,7 @@ bool mongoLdRegistrationsGet
     mongoSetLdObservationInterval(&reg, bob);
     mongoSetLdManagementInterval(&reg, bob);
     mongoSetExpires(&reg, bob);
-    mongoSetStatus(&reg, bob);
+    mongoSetStatus(&reg, &bob);
 
     mongoSetLdTimestamp(&reg.createdAt, "createdAt", bob);
     mongoSetLdTimestamp(&reg.modifiedAt, "modifiedAt", bob);

--- a/test/unittests/mongoBackend/mongoUpdateContext_2_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_2_test.cpp
@@ -3999,7 +3999,7 @@ TEST(mongoUpdateContextRequest, createMdNativeTypes)
     BSONObj mdObj2 = mds.getField("MD2").embeddedObject();
     BSONObj mdObj3 = mds.getField("MD3").embeddedObject();
     BSONObj mdObj4 = mds.getField("MD4").embeddedObject();
-    
+
     EXPECT_STREQ("T", getStringField(&mdObj1, "type"));
     EXPECT_STREQ("s", getStringField(&mdObj1, "value"));
     EXPECT_STREQ("T", getStringField(&mdObj2, "type"));

--- a/test/unittests/mongoBackend/mongoUpdateContext_2_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_2_test.cpp
@@ -1951,12 +1951,17 @@ TEST(mongoUpdateContextRequest, appendCreateEntWithMd)
     ASSERT_EQ(2, mdNames.size());
     EXPECT_TRUE(findAttr(mdNames, "MD1"));
     EXPECT_TRUE(findAttr(mdNames, "MD2"));
+
     EXPECT_TRUE(mds.hasField("MD1"));
-    EXPECT_STREQ("TMD1", getStringField(mds.getField("MD1").embeddedObject(), "type"));
-    EXPECT_STREQ("MD1val", getStringField(mds.getField("MD1").embeddedObject(), "value"));
     EXPECT_TRUE(mds.hasField("MD2"));
-    EXPECT_STREQ("TMD2", getStringField(mds.getField("MD2").embeddedObject(), "type"));
-    EXPECT_STREQ("MD2val", getStringField(mds.getField("MD2").embeddedObject(), "value"));
+
+    BSONObj mdObj1 = mds.getField("MD1").embeddedObject();
+    BSONObj mdObj2 = mds.getField("MD2").embeddedObject();
+
+    EXPECT_STREQ("TMD1", getStringField(&mdObj1, "type"));
+    EXPECT_STREQ("MD1val", getStringField(&mdObj1, "value"));
+    EXPECT_STREQ("TMD2", getStringField(&mdObj2, "type"));
+    EXPECT_STREQ("MD2val", getStringField(&mdObj2, "value"));
 
     utExit();
 }
@@ -2046,12 +2051,17 @@ TEST(mongoUpdateContextRequest, appendMdAllExisting)
     ASSERT_EQ(2, mdNames.size());
     EXPECT_TRUE(findAttr(mdNames, "MD1"));
     EXPECT_TRUE(findAttr(mdNames, "MD2"));
+
     EXPECT_TRUE(mds.hasField("MD1"));
-    EXPECT_STREQ("TMD1", getStringField(mds.getField("MD1").embeddedObject(), "type"));
-    EXPECT_STREQ("new_val", getStringField(mds.getField("MD1").embeddedObject(), "value"));
     EXPECT_TRUE(mds.hasField("MD2"));
-    EXPECT_STREQ("TMD2", getStringField(mds.getField("MD2").embeddedObject(), "type"));
-    EXPECT_STREQ("MD2val", getStringField(mds.getField("MD2").embeddedObject(), "value"));
+
+    BSONObj mdObj1 = mds.getField("MD1").embeddedObject();
+    BSONObj mdObj2 = mds.getField("MD2").embeddedObject();
+
+    EXPECT_STREQ("TMD1", getStringField(&mdObj1, "type"));
+    EXPECT_STREQ("new_val", getStringField(&mdObj1, "value"));
+    EXPECT_STREQ("TMD2", getStringField(&mdObj2, "type"));
+    EXPECT_STREQ("MD2val", getStringField(&mdObj2, "value"));
 
     utExit();
 }
@@ -2141,12 +2151,17 @@ TEST(mongoUpdateContextRequest, updateMdAllExisting)
     ASSERT_EQ(2, mdNames.size());
     EXPECT_TRUE(findAttr(mdNames, "MD1"));
     EXPECT_TRUE(findAttr(mdNames, "MD2"));
+
     EXPECT_TRUE(mds.hasField("MD1"));
-    EXPECT_STREQ("TMD1", getStringField(mds.getField("MD1").embeddedObject(), "type"));
-    EXPECT_STREQ("new_val", getStringField(mds.getField("MD1").embeddedObject(), "value"));
     EXPECT_TRUE(mds.hasField("MD2"));
-    EXPECT_STREQ("TMD2", getStringField(mds.getField("MD2").embeddedObject(), "type"));
-    EXPECT_STREQ("MD2val", getStringField(mds.getField("MD2").embeddedObject(), "value"));
+
+    BSONObj mdObj1 = mds.getField("MD1").embeddedObject();
+    BSONObj mdObj2 = mds.getField("MD2").embeddedObject();
+
+    EXPECT_STREQ("TMD1", getStringField(&mdObj1, "type"));
+    EXPECT_STREQ("new_val", getStringField(&mdObj1, "value"));
+    EXPECT_STREQ("TMD2", getStringField(&mdObj2, "type"));
+    EXPECT_STREQ("MD2val", getStringField(&mdObj2, "value"));
 
     utExit();
 }
@@ -2237,15 +2252,21 @@ TEST(mongoUpdateContextRequest, appendMdAllNew)
     EXPECT_TRUE(findAttr(mdNames, "MD1"));
     EXPECT_TRUE(findAttr(mdNames, "MD2"));
     EXPECT_TRUE(findAttr(mdNames, "MD3"));
+
     EXPECT_TRUE(mds.hasField("MD1"));
-    EXPECT_STREQ("TMD1", getStringField(mds.getField("MD1").embeddedObject(), "type"));
-    EXPECT_STREQ("MD1val", getStringField(mds.getField("MD1").embeddedObject(), "value"));
     EXPECT_TRUE(mds.hasField("MD2"));
-    EXPECT_STREQ("TMD2", getStringField(mds.getField("MD2").embeddedObject(), "type"));
-    EXPECT_STREQ("MD2val", getStringField(mds.getField("MD2").embeddedObject(), "value"));
     EXPECT_TRUE(mds.hasField("MD3"));
-    EXPECT_STREQ("TMD3", getStringField(mds.getField("MD3").embeddedObject(), "type"));
-    EXPECT_STREQ("new_val3", getStringField(mds.getField("MD3").embeddedObject(), "value"));
+
+    BSONObj mdObj1 = mds.getField("MD1").embeddedObject();
+    BSONObj mdObj2 = mds.getField("MD2").embeddedObject();
+    BSONObj mdObj3 = mds.getField("MD3").embeddedObject();
+
+    EXPECT_STREQ("TMD1",     getStringField(&mdObj1, "type"));
+    EXPECT_STREQ("MD1val",   getStringField(&mdObj1, "value"));
+    EXPECT_STREQ("TMD2",     getStringField(&mdObj2, "type"));
+    EXPECT_STREQ("MD2val",   getStringField(&mdObj2, "value"));
+    EXPECT_STREQ("TMD3",     getStringField(&mdObj3, "type"));
+    EXPECT_STREQ("new_val3", getStringField(&mdObj3, "value"));
 
     utExit();
 }
@@ -2336,15 +2357,21 @@ TEST(mongoUpdateContextRequest, updateMdAllNew)
     EXPECT_TRUE(findAttr(mdNames, "MD1"));
     EXPECT_TRUE(findAttr(mdNames, "MD2"));
     EXPECT_TRUE(findAttr(mdNames, "MD3"));
+
     EXPECT_TRUE(mds.hasField("MD1"));
-    EXPECT_STREQ("TMD1", getStringField(mds.getField("MD1").embeddedObject(), "type"));
-    EXPECT_STREQ("MD1val", getStringField(mds.getField("MD1").embeddedObject(), "value"));
     EXPECT_TRUE(mds.hasField("MD2"));
-    EXPECT_STREQ("TMD2", getStringField(mds.getField("MD2").embeddedObject(), "type"));
-    EXPECT_STREQ("MD2val", getStringField(mds.getField("MD2").embeddedObject(), "value"));
     EXPECT_TRUE(mds.hasField("MD3"));
-    EXPECT_STREQ("TMD3", getStringField(mds.getField("MD3").embeddedObject(), "type"));
-    EXPECT_STREQ("new_val3", getStringField(mds.getField("MD3").embeddedObject(), "value"));
+
+    BSONObj mdObj1 = mds.getField("MD1").embeddedObject();
+    BSONObj mdObj2 = mds.getField("MD2").embeddedObject();
+    BSONObj mdObj3 = mds.getField("MD3").embeddedObject();
+
+    EXPECT_STREQ("TMD1", getStringField(&mdObj1, "type"));
+    EXPECT_STREQ("MD1val", getStringField(&mdObj1, "value"));
+    EXPECT_STREQ("TMD2", getStringField(&mdObj2, "type"));
+    EXPECT_STREQ("MD2val", getStringField(&mdObj2, "value"));
+    EXPECT_STREQ("TMD3", getStringField(&mdObj3, "type"));
+    EXPECT_STREQ("new_val3", getStringField(&mdObj3, "value"));
 
     utExit();
 }
@@ -2440,15 +2467,21 @@ TEST(mongoUpdateContextRequest, appendMdSomeNew)
     EXPECT_TRUE(findAttr(mdNames, "MD1"));
     EXPECT_TRUE(findAttr(mdNames, "MD2"));
     EXPECT_TRUE(findAttr(mdNames, "MD3"));
+
     EXPECT_TRUE(mds.hasField("MD1"));
-    EXPECT_STREQ("TMD1", getStringField(mds.getField("MD1").embeddedObject(), "type"));
-    EXPECT_STREQ("MD1val", getStringField(mds.getField("MD1").embeddedObject(), "value"));
     EXPECT_TRUE(mds.hasField("MD2"));
-    EXPECT_STREQ("TMD2", getStringField(mds.getField("MD2").embeddedObject(), "type"));
-    EXPECT_STREQ("new_val2", getStringField(mds.getField("MD2").embeddedObject(), "value"));
     EXPECT_TRUE(mds.hasField("MD3"));
-    EXPECT_STREQ("TMD3", getStringField(mds.getField("MD3").embeddedObject(), "type"));
-    EXPECT_STREQ("new_val3", getStringField(mds.getField("MD3").embeddedObject(), "value"));
+
+    BSONObj mdObj1 = mds.getField("MD1").embeddedObject();
+    BSONObj mdObj2 = mds.getField("MD2").embeddedObject();
+    BSONObj mdObj3 = mds.getField("MD3").embeddedObject();
+
+    EXPECT_STREQ("TMD1",     getStringField(&mdObj1, "type"));
+    EXPECT_STREQ("MD1val",   getStringField(&mdObj1, "value"));
+    EXPECT_STREQ("TMD2",     getStringField(&mdObj2, "type"));
+    EXPECT_STREQ("new_val2", getStringField(&mdObj2, "value"));
+    EXPECT_STREQ("TMD3",     getStringField(&mdObj3, "type"));
+    EXPECT_STREQ("new_val3", getStringField(&mdObj3, "value"));
 
     utExit();
 }
@@ -2544,15 +2577,21 @@ TEST(mongoUpdateContextRequest, updateMdSomeNew)
     EXPECT_TRUE(findAttr(mdNames, "MD1"));
     EXPECT_TRUE(findAttr(mdNames, "MD2"));
     EXPECT_TRUE(findAttr(mdNames, "MD3"));
+
     EXPECT_TRUE(mds.hasField("MD1"));
-    EXPECT_STREQ("TMD1", getStringField(mds.getField("MD1").embeddedObject(), "type"));
-    EXPECT_STREQ("MD1val", getStringField(mds.getField("MD1").embeddedObject(), "value"));
     EXPECT_TRUE(mds.hasField("MD2"));
-    EXPECT_STREQ("TMD2", getStringField(mds.getField("MD2").embeddedObject(), "type"));
-    EXPECT_STREQ("new_val2", getStringField(mds.getField("MD2").embeddedObject(), "value"));
     EXPECT_TRUE(mds.hasField("MD3"));
-    EXPECT_STREQ("TMD3", getStringField(mds.getField("MD3").embeddedObject(), "type"));
-    EXPECT_STREQ("new_val3", getStringField(mds.getField("MD3").embeddedObject(), "value"));
+
+    BSONObj mdObj1 = mds.getField("MD1").embeddedObject();
+    BSONObj mdObj2 = mds.getField("MD2").embeddedObject();
+    BSONObj mdObj3 = mds.getField("MD3").embeddedObject();
+
+    EXPECT_STREQ("TMD1",     getStringField(&mdObj1, "type"));
+    EXPECT_STREQ("MD1val",   getStringField(&mdObj1, "value"));
+    EXPECT_STREQ("TMD2",     getStringField(&mdObj2, "type"));
+    EXPECT_STREQ("new_val2", getStringField(&mdObj2, "value"));
+    EXPECT_STREQ("TMD3",     getStringField(&mdObj3, "type"));
+    EXPECT_STREQ("new_val3", getStringField(&mdObj3, "value"));
 
     utExit();
 }
@@ -2642,12 +2681,17 @@ TEST(mongoUpdateContextRequest, appendValueAndMd)
     ASSERT_EQ(2, mdNames.size());
     EXPECT_TRUE(findAttr(mdNames, "MD1"));
     EXPECT_TRUE(findAttr(mdNames, "MD2"));
+
     EXPECT_TRUE(mds.hasField("MD1"));
-    EXPECT_STREQ("TMD1", getStringField(mds.getField("MD1").embeddedObject(), "type"));
-    EXPECT_STREQ("new_val", getStringField(mds.getField("MD1").embeddedObject(), "value"));
     EXPECT_TRUE(mds.hasField("MD2"));
-    EXPECT_STREQ("TMD2", getStringField(mds.getField("MD2").embeddedObject(), "type"));
-    EXPECT_STREQ("MD2val", getStringField(mds.getField("MD2").embeddedObject(), "value"));
+
+    BSONObj mdObj1 = mds.getField("MD1").embeddedObject();
+    BSONObj mdObj2 = mds.getField("MD2").embeddedObject();
+
+    EXPECT_STREQ("TMD1",    getStringField(&mdObj1, "type"));
+    EXPECT_STREQ("new_val", getStringField(&mdObj1, "value"));
+    EXPECT_STREQ("TMD2",    getStringField(&mdObj2, "type"));
+    EXPECT_STREQ("MD2val",  getStringField(&mdObj2, "value"));
 
     utExit();
 }
@@ -2737,12 +2781,17 @@ TEST(mongoUpdateContextRequest, updateValueAndMd)
     ASSERT_EQ(2, mdNames.size());
     EXPECT_TRUE(findAttr(mdNames, "MD1"));
     EXPECT_TRUE(findAttr(mdNames, "MD2"));
+
     EXPECT_TRUE(mds.hasField("MD1"));
-    EXPECT_STREQ("TMD1", getStringField(mds.getField("MD1").embeddedObject(), "type"));
-    EXPECT_STREQ("new_val", getStringField(mds.getField("MD1").embeddedObject(), "value"));
     EXPECT_TRUE(mds.hasField("MD2"));
-    EXPECT_STREQ("TMD2", getStringField(mds.getField("MD2").embeddedObject(), "type"));
-    EXPECT_STREQ("MD2val", getStringField(mds.getField("MD2").embeddedObject(), "value"));
+
+    BSONObj mdObj1 = mds.getField("MD1").embeddedObject();
+    BSONObj mdObj2 = mds.getField("MD2").embeddedObject();
+
+    EXPECT_STREQ("TMD1", getStringField(&mdObj1, "type"));
+    EXPECT_STREQ("new_val", getStringField(&mdObj1, "value"));
+    EXPECT_STREQ("TMD2", getStringField(&mdObj2, "type"));
+    EXPECT_STREQ("MD2val", getStringField(&mdObj2, "value"));
 
     utExit();
 }
@@ -2833,12 +2882,17 @@ TEST(mongoUpdateContextRequest, appendMdNoActualChanges)
     ASSERT_EQ(2, mdNames.size());
     EXPECT_TRUE(findAttr(mdNames, "MD1"));
     EXPECT_TRUE(findAttr(mdNames, "MD2"));
+
     EXPECT_TRUE(mds.hasField("MD1"));
-    EXPECT_STREQ("TMD1", getStringField(mds.getField("MD1").embeddedObject(), "type"));
-    EXPECT_STREQ("MD1val", getStringField(mds.getField("MD1").embeddedObject(), "value"));
     EXPECT_TRUE(mds.hasField("MD2"));
-    EXPECT_STREQ("TMD2", getStringField(mds.getField("MD2").embeddedObject(), "type"));
-    EXPECT_STREQ("MD2val", getStringField(mds.getField("MD2").embeddedObject(), "value"));
+
+    BSONObj mdObj1 = mds.getField("MD1").embeddedObject();
+    BSONObj mdObj2 = mds.getField("MD2").embeddedObject();
+
+    EXPECT_STREQ("TMD1",   getStringField(&mdObj1, "type"));
+    EXPECT_STREQ("MD1val", getStringField(&mdObj1, "value"));
+    EXPECT_STREQ("TMD2",   getStringField(&mdObj2, "type"));
+    EXPECT_STREQ("MD2val", getStringField(&mdObj2, "value"));
 
     utExit();
 }
@@ -2928,12 +2982,17 @@ TEST(mongoUpdateContextRequest, updateMdNoActualChanges)
     ASSERT_EQ(2, mdNames.size());
     EXPECT_TRUE(findAttr(mdNames, "MD1"));
     EXPECT_TRUE(findAttr(mdNames, "MD2"));
+
     EXPECT_TRUE(mds.hasField("MD1"));
-    EXPECT_STREQ("TMD1", getStringField(mds.getField("MD1").embeddedObject(), "type"));
-    EXPECT_STREQ("MD1val", getStringField(mds.getField("MD1").embeddedObject(), "value"));
     EXPECT_TRUE(mds.hasField("MD2"));
-    EXPECT_STREQ("TMD2", getStringField(mds.getField("MD2").embeddedObject(), "type"));
-    EXPECT_STREQ("MD2val", getStringField(mds.getField("MD2").embeddedObject(), "value"));
+
+    BSONObj mdObj1 = mds.getField("MD1").embeddedObject();
+    BSONObj mdObj2 = mds.getField("MD2").embeddedObject();
+
+    EXPECT_STREQ("TMD1",   getStringField(&mdObj1, "type"));
+    EXPECT_STREQ("MD1val", getStringField(&mdObj1, "value"));
+    EXPECT_STREQ("TMD2",   getStringField(&mdObj2, "type"));
+    EXPECT_STREQ("MD2val", getStringField(&mdObj2, "value"));
 
     utExit();
 }
@@ -3930,17 +3989,25 @@ TEST(mongoUpdateContextRequest, createMdNativeTypes)
     EXPECT_TRUE(findAttr(mdNames, "MD2"));
     EXPECT_TRUE(findAttr(mdNames, "MD3"));
     EXPECT_TRUE(findAttr(mdNames, "MD4"));
+
     EXPECT_TRUE(mds.hasField("MD1"));
-    EXPECT_STREQ("T", getStringField(mds.getField("MD1").embeddedObject(), "type"));
-    EXPECT_STREQ("s", getStringField(mds.getField("MD1").embeddedObject(), "value"));
     EXPECT_TRUE(mds.hasField("MD2"));
-    EXPECT_STREQ("T", getStringField(mds.getField("MD2").embeddedObject(), "type"));
-    EXPECT_EQ(55.5, mds.getField("MD2").embeddedObject().getField("value").Number());
     EXPECT_TRUE(mds.hasField("MD3"));
-    EXPECT_STREQ("T", getStringField(mds.getField("MD3").embeddedObject(), "type"));
-    EXPECT_FALSE(mds.getField("MD3").embeddedObject().getBoolField("value"));
     EXPECT_TRUE(mds.hasField("MD4"));
-    EXPECT_STREQ("T", getStringField(mds.getField("MD4").embeddedObject(), "type"));
+
+    BSONObj mdObj1 = mds.getField("MD1").embeddedObject();
+    BSONObj mdObj2 = mds.getField("MD2").embeddedObject();
+    BSONObj mdObj3 = mds.getField("MD3").embeddedObject();
+    BSONObj mdObj4 = mds.getField("MD4").embeddedObject();
+    
+    EXPECT_STREQ("T", getStringField(&mdObj1, "type"));
+    EXPECT_STREQ("s", getStringField(&mdObj1, "value"));
+    EXPECT_STREQ("T", getStringField(&mdObj2, "type"));
+    EXPECT_EQ(55.5, mds.getField("MD2").embeddedObject().getField("value").Number());
+    EXPECT_STREQ("T", getStringField(&mdObj3, "type"));
+    EXPECT_FALSE(mdObj3.getBoolField("value"));
+
+    EXPECT_STREQ("T", getStringField(&mdObj4, "type"));
     EXPECT_TRUE(mds.getField("MD4").embeddedObject().getField("value").isNull());
 
     /* Note "_id.type: {$exists: false}" is a way for querying for entities without type */
@@ -4064,17 +4131,24 @@ TEST(mongoUpdateContextRequest, updateMdNativeTypes)
     EXPECT_TRUE(findAttr(mdNames, "MD2"));
     EXPECT_TRUE(findAttr(mdNames, "MD3"));
     EXPECT_TRUE(findAttr(mdNames, "MD4"));
+
     EXPECT_TRUE(mds.hasField("MD1"));
-    EXPECT_STREQ("T", getStringField(mds.getField("MD1").embeddedObject(), "type"));
-    EXPECT_STREQ("ss", getStringField(mds.getField("MD1").embeddedObject(), "value"));
     EXPECT_TRUE(mds.hasField("MD2"));
-    EXPECT_STREQ("T", getStringField(mds.getField("MD2").embeddedObject(), "type"));
-    EXPECT_EQ(44.4, mds.getField("MD2").embeddedObject().getField("value").Number());
     EXPECT_TRUE(mds.hasField("MD3"));
-    EXPECT_STREQ("T", getStringField(mds.getField("MD3").embeddedObject(), "type"));
-    EXPECT_TRUE(mds.getField("MD3").embeddedObject().getBoolField("value"));
     EXPECT_TRUE(mds.hasField("MD4"));
-    EXPECT_STREQ("T", getStringField(mds.getField("MD4").embeddedObject(), "type"));
+
+    BSONObj mdObj1 = mds.getField("MD1").embeddedObject();
+    BSONObj mdObj2 = mds.getField("MD2").embeddedObject();
+    BSONObj mdObj3 = mds.getField("MD3").embeddedObject();
+    BSONObj mdObj4 = mds.getField("MD4").embeddedObject();
+
+    EXPECT_STREQ("T", getStringField(&mdObj1, "type"));
+    EXPECT_STREQ("ss", getStringField(&mdObj1, "value"));
+    EXPECT_STREQ("T", getStringField(&mdObj2, "type"));
+    EXPECT_EQ(44.4, mds.getField("MD2").embeddedObject().getField("value").Number());
+    EXPECT_STREQ("T", getStringField(&mdObj3, "type"));
+    EXPECT_TRUE(mds.getField("MD3").embeddedObject().getBoolField("value"));
+    EXPECT_STREQ("T", getStringField(&mdObj4, "type"));
     EXPECT_TRUE(mds.getField("MD4").embeddedObject().getField("value").isNull());
 
     utExit();
@@ -4162,17 +4236,24 @@ TEST(mongoUpdateContextRequest, preservingMdNativeTypes)
     EXPECT_TRUE(findAttr(mdNames, "MD2"));
     EXPECT_TRUE(findAttr(mdNames, "MD3"));
     EXPECT_TRUE(findAttr(mdNames, "MD4"));
+
     EXPECT_TRUE(mds.hasField("MD1"));
-    EXPECT_STREQ("T", getStringField(mds.getField("MD1").embeddedObject(), "type"));
-    EXPECT_STREQ("s", getStringField(mds.getField("MD1").embeddedObject(), "value"));
     EXPECT_TRUE(mds.hasField("MD2"));
-    EXPECT_STREQ("T", getStringField(mds.getField("MD2").embeddedObject(), "type"));
-    EXPECT_EQ(55.5, mds.getField("MD2").embeddedObject().getField("value").Number());
+
+    BSONObj mdObj1 = mds.getField("MD1").embeddedObject();
+    BSONObj mdObj2 = mds.getField("MD2").embeddedObject();
+    BSONObj mdObj3 = mds.getField("MD3").embeddedObject();
+    BSONObj mdObj4 = mds.getField("MD4").embeddedObject();
+
+    EXPECT_STREQ("T", getStringField(&mdObj1, "type"));
+    EXPECT_STREQ("s", getStringField(&mdObj1, "value"));
+    EXPECT_STREQ("T", getStringField(&mdObj2, "type"));
+    EXPECT_EQ(55.5, mdObj2.getField("value").Number());
     EXPECT_TRUE(mds.hasField("MD3"));
-    EXPECT_STREQ("T", getStringField(mds.getField("MD3").embeddedObject(), "type"));
-    EXPECT_FALSE(mds.getField("MD3").embeddedObject().getBoolField("value"));
+    EXPECT_STREQ("T", getStringField(&mdObj3, "type"));
+    EXPECT_FALSE(mdObj3.getBoolField("value"));
     EXPECT_TRUE(mds.hasField("MD4"));
-    EXPECT_STREQ("T", getStringField(mds.getField("MD4").embeddedObject(), "type"));
+    EXPECT_STREQ("T", getStringField(&mdObj4, "type"));
     EXPECT_TRUE(mds.getField("MD4").embeddedObject().getField("value").isNull());
 
     utExit();

--- a/test/unittests/mongoBackend/mongoUpdateContext_test.cpp
+++ b/test/unittests/mongoBackend/mongoUpdateContext_test.cpp
@@ -4804,12 +4804,17 @@ TEST(mongoUpdateContextRequest, createEntityMd)
     ASSERT_EQ(2, mdNames.size());
     EXPECT_TRUE(findAttr(mdNames, "MD1"));
     EXPECT_TRUE(findAttr(mdNames, "MD2"));
+
     EXPECT_TRUE(mds.hasField("MD1"));
-    EXPECT_STREQ("TMD1", getStringField(mds.getField("MD1").embeddedObject(), "type"));
-    EXPECT_STREQ("MD1val", getStringField(mds.getField("MD1").embeddedObject(), "value"));
     EXPECT_TRUE(mds.hasField("MD2"));
-    EXPECT_STREQ("TMD2", getStringField(mds.getField("MD2").embeddedObject(), "type"));
-    EXPECT_STREQ("MD2val", getStringField(mds.getField("MD2").embeddedObject(), "value"));
+
+    BSONObj mdObj1 = mds.getField("MD1").embeddedObject();
+    BSONObj mdObj2 = mds.getField("MD2").embeddedObject();
+
+    EXPECT_STREQ("TMD1",   getStringField(&mdObj1, "type"));
+    EXPECT_STREQ("MD1val", getStringField(&mdObj1, "value"));
+    EXPECT_STREQ("TMD2",   getStringField(&mdObj2, "type"));
+    EXPECT_STREQ("MD2val", getStringField(&mdObj2, "value"));
 
     /* Note "_id.type: {$exists: false}" is a way for querying for entities without type */
     ent = connection->findOne(ENTITIES_COLL, BSON("_id.id" << "E1" << "_id.type" << BSON("$exists" << false)));

--- a/test/unittests/testInit.cpp
+++ b/test/unittests/testInit.cpp
@@ -22,6 +22,7 @@
 *
 * Author: Fermin Galan
 */
+#include "mongo/client/dbclient.h"
 #include "unittests/testInit.h"
 
 #include "logMsg/logMsg.h"
@@ -45,6 +46,17 @@ using mongo::DBClientBase;
 */
 extern DBClientBase* mongoInitialConnectionGetForUnitTest();
 extern void          setMongoConnectionForUnitTest(DBClientBase* _connection);
+
+
+
+/* ****************************************************************************
+*
+* C_STR_FIELD -
+*/
+const char* C_STR_FIELD(mongo::BSONObj bob, std::string f)
+{
+  return getStringField(&bob, f.c_str());
+}
 
 
 

--- a/test/unittests/testInit.cpp
+++ b/test/unittests/testInit.cpp
@@ -22,13 +22,14 @@
 *
 * Author: Fermin Galan
 */
+#include <string>
+
 #include "mongo/client/dbclient.h"
 #include "unittests/testInit.h"
 
 #include "logMsg/logMsg.h"
 
 #include "mongoBackend/MongoGlobal.h"
-#include "mongo/client/dbclient.h"
 
 
 

--- a/test/unittests/testInit.h
+++ b/test/unittests/testInit.h
@@ -25,6 +25,8 @@
 *
 * Author: Fermin Galan
 */
+#include "mongo/client/dbclient.h"
+
 #include "ngsi9/NotifyContextAvailabilityRequest.h"
 #include "ngsi10/NotifyContextRequest.h"
 #include "mongoBackend/safeMongo.h"
@@ -47,7 +49,13 @@
 #define RES_CER_STATUS(i)       res.contextElementResponseVector[i]->statusCode
 #define RES_CER_ATTR(i, j)      res.contextElementResponseVector[i]->contextElement.contextAttributeVector[j]
 
-#define C_STR_FIELD(b, f)       getStringField(b, f)
+
+
+/* ****************************************************************************
+*
+* C_STR_FIELD -
+*/
+extern const char* C_STR_FIELD(mongo::BSONObj bob, std::string f);
 
 
 

--- a/test/unittests/testInit.h
+++ b/test/unittests/testInit.h
@@ -25,6 +25,8 @@
 *
 * Author: Fermin Galan
 */
+#include <string>
+
 #include "mongo/client/dbclient.h"
 
 #include "ngsi9/NotifyContextAvailabilityRequest.h"


### PR DESCRIPTION
Hoping to gain some performance by avoiding making copies:
* getStringField now takes a BSONObj pointer as input parameter, not a C++ reference
* HttpInfo::fill, same same
