### PR TITLE
Hardening/get int field with pointer not reference

### DIFF
--- a/src/lib/mongoBackend/mongoQueryTypes.cpp
+++ b/src/lib/mongoBackend/mongoQueryTypes.cpp
@@ -219,7 +219,8 @@ static unsigned int countCmd(const std::string& tenant, const BSONArray& pipelin
     resultsArray = getFieldF(getObjectFieldF(result, "cursor"), "firstBatch").Array();
     if ((resultsArray.size() > 0) && (resultsArray[0].embeddedObject().hasField("count")))
     {
-      return getIntFieldF(resultsArray[0].embeddedObject(), "count");
+      BSONObj bo = resultsArray[0].embeddedObject();
+      return getIntFieldF(&bo, "count");
     }
   }
   else

--- a/src/lib/mongoBackend/mongoUpdateContextAvailabilitySubscription.cpp
+++ b/src/lib/mongoBackend/mongoUpdateContextAvailabilitySubscription.cpp
@@ -165,12 +165,12 @@ HttpStatusCode mongoUpdateContextAvailabilitySubscription
   /* Reference is not updatable, so it is appended directly */
   newSub.append(CASUB_REFERENCE, getStringFieldF(&sub, CASUB_REFERENCE));
 
-  int count = sub.hasField(CASUB_COUNT) ? getIntFieldF(sub, CASUB_COUNT) : 0;
+  int count = sub.hasField(CASUB_COUNT) ? getIntFieldF(&sub, CASUB_COUNT) : 0;
 
   /* The hasField check is needed due to lastNotification/count could not be present in the original doc */
   if (sub.hasField(CASUB_LASTNOTIFICATION))
   {
-    newSub.append(CASUB_LASTNOTIFICATION, getIntFieldF(sub, CASUB_LASTNOTIFICATION));
+    newSub.append(CASUB_LASTNOTIFICATION, getIntFieldF(&sub, CASUB_LASTNOTIFICATION));
   }
 
   if (sub.hasField(CASUB_COUNT))

--- a/src/lib/mongoBackend/safeMongo.cpp
+++ b/src/lib/mongoBackend/safeMongo.cpp
@@ -166,23 +166,23 @@ double getNumberField(const BSONObj& b, const char* field, const char* caller, i
 *
 * getIntField -
 */
-int getIntField(const BSONObj& b, const char* field, const char* caller, int line)
+int getIntField(const BSONObj* bP, const char* field, const char* caller, int line)
 {
-  if (b.hasField(field) && b.getField(field).type() == mongo::NumberInt)
+  if (bP->hasField(field) && bP->getField(field).type() == mongo::NumberInt)
   {
-    return b.getIntField(field);
+    return bP->getIntField(field);
   }
 
   // Detect error
-  if (!b.hasField(field))
+  if (!bP->hasField(field))
   {
     LM_E(("Runtime Error (int field '%s' is missing in BSONObj <%s> from caller %s:%d)",
-          field, b.toString().c_str(), caller, line));
+          field, bP->toString().c_str(), caller, line));
   }
   else
   {
     LM_E(("Runtime Error (field '%s' was supposed to be an int but type=%d in BSONObj <%s> from caller %s:%d)",
-          field, b.getField(field).type(), b.toString().c_str(), caller, line));
+          field, bP->getField(field).type(), bP->toString().c_str(), caller, line));
   }
 
   return -1;

--- a/src/lib/mongoBackend/safeMongo.h
+++ b/src/lib/mongoBackend/safeMongo.h
@@ -117,7 +117,7 @@ extern double getNumberField
 */
 extern int getIntField
 (
-  const mongo::BSONObj&  b,
+  const mongo::BSONObj*  bP,
   const char*            field,
   const char*            caller = "<none>",
   int                    line   = 0

--- a/src/lib/ngsi/ContextElementResponse.cpp
+++ b/src/lib/ngsi/ContextElementResponse.cpp
@@ -220,7 +220,7 @@ ContextElementResponse::ContextElementResponse
         break;
 
       case NumberInt:
-        ca.numberValue = (double) getIntFieldF(attr, ENT_ATTRS_VALUE);
+        ca.numberValue = (double) getIntFieldF(&attr, ENT_ATTRS_VALUE);
         caP = new ContextAttribute(ca.name, ca.type, ca.numberValue);
         break;
 

--- a/src/lib/ngsi/Metadata.cpp
+++ b/src/lib/ngsi/Metadata.cpp
@@ -205,7 +205,7 @@ Metadata::Metadata(const char* _name, BSONObj* mdB)
 
   case NumberInt:
     valueType   = orion::ValueTypeNumber;
-    numberValue = (double) getIntFieldF(*mdB, ENT_ATTRS_MD_VALUE);
+    numberValue = (double) getIntFieldF(mdB, ENT_ATTRS_MD_VALUE);
     break;
 
   case NumberDouble:


### PR DESCRIPTION
Performance:
getIntField now take a pointer to a BSONObj and not a C++ reference