### PR TITLE
getNumber with pointer not C++ reference

### DIFF
--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -193,7 +193,7 @@ static bool equalMetadataValues(const BSONObj& md1, const BSONObj& md2)
       */
 
     case mongo::NumberDouble:
-      if (getNumberFieldF(md1, ENT_ATTRS_MD_TYPE) != getNumberFieldF(md2, ENT_ATTRS_MD_TYPE))
+      if (getNumberFieldF(&md1, ENT_ATTRS_MD_TYPE) != getNumberFieldF(&md2, ENT_ATTRS_MD_TYPE))
       {
         return false;
       }
@@ -249,7 +249,7 @@ static bool equalMetadataValues(const BSONObj& md1, const BSONObj& md2)
     */
 
   case mongo::NumberDouble:
-    return getNumberFieldF(md1, ENT_ATTRS_MD_VALUE) == getNumberFieldF(md2, ENT_ATTRS_MD_VALUE);
+    return getNumberFieldF(&md1, ENT_ATTRS_MD_VALUE) == getNumberFieldF(&md2, ENT_ATTRS_MD_VALUE);
 
   case mongo::Bool:
     return getBoolFieldF(&md1, ENT_ATTRS_MD_VALUE) == getBoolFieldF(&md2, ENT_ATTRS_MD_VALUE);
@@ -334,7 +334,7 @@ static bool attrValueChanges(const BSONObj& attr, ContextAttribute* caP, ApiVers
     return true;
 
   case mongo::NumberDouble:
-    return caP->valueType != orion::ValueTypeNumber || caP->numberValue != getNumberFieldF(attr, ENT_ATTRS_VALUE);
+    return caP->valueType != orion::ValueTypeNumber || caP->numberValue != getNumberFieldF(&attr, ENT_ATTRS_VALUE);
 
   case mongo::Bool:
     return caP->valueType != orion::ValueTypeBoolean || caP->boolValue != getBoolFieldF(&attr, ENT_ATTRS_VALUE);
@@ -495,7 +495,7 @@ static bool mergeAttrInfo(const BSONObj& attr, ContextAttribute* caP, BSONObj* m
       break;
 
     case mongo::NumberDouble:
-      ab.append(ENT_ATTRS_VALUE, getNumberFieldF(attr, ENT_ATTRS_VALUE));
+      ab.append(ENT_ATTRS_VALUE, getNumberFieldF(&attr, ENT_ATTRS_VALUE));
       break;
 
     case mongo::Bool:
@@ -595,7 +595,7 @@ static bool mergeAttrInfo(const BSONObj& attr, ContextAttribute* caP, BSONObj* m
   /* 4. Add creation date */
   if (attr.hasField(ENT_ATTRS_CREATION_DATE))
   {
-    ab.append(ENT_ATTRS_CREATION_DATE, getNumberFieldAsDoubleF(attr, ENT_ATTRS_CREATION_DATE));
+    ab.append(ENT_ATTRS_CREATION_DATE, getNumberFieldAsDoubleF(&attr, ENT_ATTRS_CREATION_DATE));
   }
 
   /* Was it an actual update? */
@@ -649,7 +649,7 @@ static bool mergeAttrInfo(const BSONObj& attr, ContextAttribute* caP, BSONObj* m
      * in database by a CB instance previous to the support of creation and modification dates */
     if (attr.hasField(ENT_ATTRS_MODIFICATION_DATE))
     {
-      ab.append(ENT_ATTRS_MODIFICATION_DATE, getNumberFieldAsDoubleF(attr, ENT_ATTRS_MODIFICATION_DATE));
+      ab.append(ENT_ATTRS_MODIFICATION_DATE, getNumberFieldAsDoubleF(&attr, ENT_ATTRS_MODIFICATION_DATE));
     }
   }
 
@@ -1557,8 +1557,8 @@ static bool addTriggeredSubscriptions_noCache
       //
       // NOTE: renderFormatString: NGSIv1 JSON is 'default' (for old db-content)
       //
-      double            throttling         = sub.hasField(CSUB_THROTTLING)?       getNumberFieldAsDoubleF(sub, CSUB_THROTTLING)       : -1;
-      double            lastNotification   = sub.hasField(CSUB_LASTNOTIFICATION)? getNumberFieldAsDoubleF(sub, CSUB_LASTNOTIFICATION) : -1;
+      double            throttling         = sub.hasField(CSUB_THROTTLING)?       getNumberFieldAsDoubleF(&sub, CSUB_THROTTLING)       : -1;
+      double            lastNotification   = sub.hasField(CSUB_LASTNOTIFICATION)? getNumberFieldAsDoubleF(&sub, CSUB_LASTNOTIFICATION) : -1;
       const char*       renderFormatString = sub.hasField(CSUB_FORMAT)? getStringFieldF(&sub, CSUB_FORMAT) : "legacy";
       RenderFormat      renderFormat       = stringToRenderFormat(renderFormatString);
       ngsiv2::HttpInfo  httpInfo;
@@ -3411,8 +3411,8 @@ static void updateEntity
 
   // The hasField() check is needed as the entity could have been created with very old Orion version not
   // supporting modification/creation dates
-  notifyCerP->contextElement.entityId.creDate = r.hasField(ENT_CREATION_DATE)     ? getNumberFieldAsDoubleF(r, ENT_CREATION_DATE)     : -1;
-  notifyCerP->contextElement.entityId.modDate = r.hasField(ENT_MODIFICATION_DATE) ? getNumberFieldAsDoubleF(r, ENT_MODIFICATION_DATE) : -1;
+  notifyCerP->contextElement.entityId.creDate = r.hasField(ENT_CREATION_DATE)     ? getNumberFieldAsDoubleF(&r, ENT_CREATION_DATE)     : -1;
+  notifyCerP->contextElement.entityId.modDate = r.hasField(ENT_MODIFICATION_DATE) ? getNumberFieldAsDoubleF(&r, ENT_MODIFICATION_DATE) : -1;
 
   // The logic to detect notification loops is to check that the correlator in the request differs from the last one seen for the entity and,
   // in addition, the request was sent due to a custom notification

--- a/src/lib/mongoBackend/mongoGetSubscriptions.cpp
+++ b/src/lib/mongoBackend/mongoGetSubscriptions.cpp
@@ -175,12 +175,12 @@ static void setNotification(Subscription* subP, const BSONObj& r, const std::str
 
   ngsiv2::Notification* nP = &subP->notification;
 
-  subP->throttling      = r.hasField(CSUB_THROTTLING)?       getNumberFieldAsDoubleF(r, CSUB_THROTTLING)       : -1;
-  nP->lastNotification  = r.hasField(CSUB_LASTNOTIFICATION)? getNumberFieldAsDoubleF(r, CSUB_LASTNOTIFICATION) : -1;
-  nP->timesSent         = r.hasField(CSUB_COUNT)?            getIntOrLongFieldAsLongF(r, CSUB_COUNT)           : -1;
-  nP->blacklist         = r.hasField(CSUB_BLACKLIST)?        getBoolFieldF(&r, CSUB_BLACKLIST)                 : false;
-  nP->lastFailure       = r.hasField(CSUB_LASTFAILURE)?      getNumberFieldAsDoubleF(r, CSUB_LASTFAILURE)      : -1;
-  nP->lastSuccess       = r.hasField(CSUB_LASTSUCCESS)?      getNumberFieldAsDoubleF(r, CSUB_LASTSUCCESS)      : -1;
+  subP->throttling      = r.hasField(CSUB_THROTTLING)?       getNumberFieldAsDoubleF(&r, CSUB_THROTTLING)       : -1;
+  nP->lastNotification  = r.hasField(CSUB_LASTNOTIFICATION)? getNumberFieldAsDoubleF(&r, CSUB_LASTNOTIFICATION) : -1;
+  nP->timesSent         = r.hasField(CSUB_COUNT)?            getIntOrLongFieldAsLongF(&r, CSUB_COUNT)           : -1;
+  nP->blacklist         = r.hasField(CSUB_BLACKLIST)?        getBoolFieldF(&r, CSUB_BLACKLIST)                  : false;
+  nP->lastFailure       = r.hasField(CSUB_LASTFAILURE)?      getNumberFieldAsDoubleF(&r, CSUB_LASTFAILURE)      : -1;
+  nP->lastSuccess       = r.hasField(CSUB_LASTSUCCESS)?      getNumberFieldAsDoubleF(&r, CSUB_LASTSUCCESS)      : -1;
 
   // Attributes format
   subP->attrsFormat = r.hasField(CSUB_FORMAT)? stringToRenderFormat(getStringFieldF(&r, CSUB_FORMAT)) : NGSI_V1_LEGACY;
@@ -234,7 +234,7 @@ static void setNotification(Subscription* subP, const BSONObj& r, const std::str
 */
 static void setStatus(Subscription* s, const BSONObj& r)
 {
-  s->expires = r.hasField(CSUB_EXPIRATION)? getNumberFieldAsDoubleF(r, CSUB_EXPIRATION) : -1;
+  s->expires = r.hasField(CSUB_EXPIRATION)? getNumberFieldAsDoubleF(&r, CSUB_EXPIRATION) : -1;
 
   //
   // Status
@@ -323,7 +323,7 @@ static void setMimeType(Subscription* s, const BSONObj* rP)
 */
 static void setTimeInterval(Subscription* s, const BSONObj& r)
 {
-  s->timeInterval = (int) (r.hasField("timeInterval") ? getIntOrLongFieldAsLongF(r, "timeInterval") : -1);
+  s->timeInterval = (int) (r.hasField("timeInterval") ? getIntOrLongFieldAsLongF(&r, "timeInterval") : -1);
 }
 
 #endif

--- a/src/lib/mongoBackend/mongoRegistrationAux.cpp
+++ b/src/lib/mongoBackend/mongoRegistrationAux.cpp
@@ -232,7 +232,7 @@ bool mongoSetDataProvided(ngsiv2::Registration* regP, const mongo::BSONObj& r, b
 */
 void mongoSetExpires(ngsiv2::Registration* regP, const mongo::BSONObj& r)
 {
-  regP->expires = (r.hasField(REG_EXPIRATION))? getNumberFieldAsDoubleF(r, REG_EXPIRATION) : -1;
+  regP->expires = (r.hasField(REG_EXPIRATION))? getNumberFieldAsDoubleF(&r, REG_EXPIRATION) : -1;
 }
 
 

--- a/src/lib/mongoBackend/mongoSubCache.cpp
+++ b/src/lib/mongoBackend/mongoSubCache.cpp
@@ -167,13 +167,13 @@ int mongoSubCacheItemInsert(const char* tenant, const BSONObj& sub)
   cSubP->tenant                = (tenant[0] == 0)? strdup("") : strdup(tenant);  // FIXME: strdup("") ... really?
   cSubP->servicePath           = strdup(sub.hasField(CSUB_SERVICE_PATH)? getStringFieldF(&sub, CSUB_SERVICE_PATH) : "/");
   cSubP->renderFormat          = renderFormat;
-  cSubP->throttling            = sub.hasField(CSUB_THROTTLING)?       getNumberFieldAsDoubleF(sub, CSUB_THROTTLING)       : -1;
-  cSubP->expirationTime        = sub.hasField(CSUB_EXPIRATION)?       getNumberFieldAsDoubleF(sub, CSUB_EXPIRATION)       : 0;
-  cSubP->lastNotificationTime  = sub.hasField(CSUB_LASTNOTIFICATION)? getNumberFieldAsDoubleF(sub, CSUB_LASTNOTIFICATION) : -1;
-  cSubP->status                = sub.hasField(CSUB_STATUS)?           getStringFieldF(&sub, CSUB_STATUS)                  : "active";
-  cSubP->blacklist             = sub.hasField(CSUB_BLACKLIST)?        getBoolFieldF(&sub, CSUB_BLACKLIST)                 : false;
-  cSubP->lastFailure           = sub.hasField(CSUB_LASTFAILURE)?      getNumberFieldAsDoubleF(sub, CSUB_LASTFAILURE)      : -1;
-  cSubP->lastSuccess           = sub.hasField(CSUB_LASTSUCCESS)?      getNumberFieldAsDoubleF(sub, CSUB_LASTSUCCESS)      : -1;
+  cSubP->throttling            = sub.hasField(CSUB_THROTTLING)?       getNumberFieldAsDoubleF(&sub, CSUB_THROTTLING)       : -1;
+  cSubP->expirationTime        = sub.hasField(CSUB_EXPIRATION)?       getNumberFieldAsDoubleF(&sub, CSUB_EXPIRATION)       : 0;
+  cSubP->lastNotificationTime  = sub.hasField(CSUB_LASTNOTIFICATION)? getNumberFieldAsDoubleF(&sub, CSUB_LASTNOTIFICATION) : -1;
+  cSubP->status                = sub.hasField(CSUB_STATUS)?           getStringFieldF(&sub, CSUB_STATUS)                   : "active";
+  cSubP->blacklist             = sub.hasField(CSUB_BLACKLIST)?        getBoolFieldF(&sub, CSUB_BLACKLIST)                  : false;
+  cSubP->lastFailure           = sub.hasField(CSUB_LASTFAILURE)?      getNumberFieldAsDoubleF(&sub, CSUB_LASTFAILURE)      : -1;
+  cSubP->lastSuccess           = sub.hasField(CSUB_LASTSUCCESS)?      getNumberFieldAsDoubleF(&sub, CSUB_LASTSUCCESS)      : -1;
   cSubP->count                 = 0;
   cSubP->next                  = NULL;
 
@@ -417,14 +417,14 @@ int mongoSubCacheItemInsert
     // if the database objuect contains lastNotificationTime,
     // then use the value from the database
     //
-    lastNotificationTime = getNumberFieldAsDoubleF(sub, CSUB_LASTNOTIFICATION);
+    lastNotificationTime = getNumberFieldAsDoubleF(&sub, CSUB_LASTNOTIFICATION);
   }
 
   cSubP->tenant                = (tenant[0] == 0)? NULL : strdup(tenant);
   cSubP->subscriptionId        = strdup(subscriptionId);
   cSubP->servicePath           = strdup(servicePath);
   cSubP->renderFormat          = renderFormat;
-  cSubP->throttling            = sub.hasField(CSUB_THROTTLING)?       getNumberFieldAsDoubleF(sub, CSUB_THROTTLING) : -1;
+  cSubP->throttling            = sub.hasField(CSUB_THROTTLING)?       getNumberFieldAsDoubleF(&sub, CSUB_THROTTLING) : -1;
   cSubP->expirationTime        = expirationTime;
   cSubP->lastNotificationTime  = lastNotificationTime;
   cSubP->count                 = 0;

--- a/src/lib/mongoBackend/mongoUpdateContextAvailabilitySubscription.cpp
+++ b/src/lib/mongoBackend/mongoUpdateContextAvailabilitySubscription.cpp
@@ -152,7 +152,7 @@ HttpStatusCode mongoUpdateContextAvailabilitySubscription
   /* Duration (optional) */
   if (requestP->duration.isEmpty())
   {
-    newSub.append(CASUB_EXPIRATION, getIntOrLongFieldAsLongF(sub, CASUB_EXPIRATION));
+    newSub.append(CASUB_EXPIRATION, getIntOrLongFieldAsLongF(&sub, CASUB_EXPIRATION));
   }
   else
   {

--- a/src/lib/mongoBackend/mongoUpdateSubscription.cpp
+++ b/src/lib/mongoBackend/mongoUpdateSubscription.cpp
@@ -75,7 +75,7 @@ static void setExpiration(const SubscriptionUpdate& subUp, const BSONObj& subOri
   {
     if (subOrig.hasField(CSUB_EXPIRATION))
     {
-      double expires = getNumberFieldAsDoubleF(subOrig, CSUB_EXPIRATION);
+      double expires = getNumberFieldAsDoubleF(&subOrig, CSUB_EXPIRATION);
 
       b->append(CSUB_EXPIRATION, expires);
       LM_T(LmtMongo, ("Subscription expiration: %f", expires));
@@ -157,7 +157,7 @@ static void setThrottling(const SubscriptionUpdate& subUp, const BSONObj& subOri
   {
     if (subOrig.hasField(CSUB_THROTTLING))
     {
-      double throttling = getNumberFieldAsDoubleF(subOrig, CSUB_THROTTLING);
+      double throttling = getNumberFieldAsDoubleF(&subOrig, CSUB_THROTTLING);
 
       b->append(CSUB_THROTTLING, throttling);
       LM_T(LmtMongo, ("Subscription throttling: %f", throttling));
@@ -475,7 +475,7 @@ static void setCount(long long inc, const BSONObj& subOrig, BSONObjBuilder* b)
 {
   if (subOrig.hasField(CSUB_COUNT))
   {
-    long long count = getIntOrLongFieldAsLongF(subOrig, CSUB_COUNT);
+    long long count = getIntOrLongFieldAsLongF(&subOrig, CSUB_COUNT);
     setCount(count + inc, b);
   }
   else
@@ -514,7 +514,7 @@ static void setLastNotification(const BSONObj& subOrig, CachedSubscription* subC
     return;
   }
 
-  double lastNotification = getNumberFieldAsDoubleF(subOrig, CSUB_LASTNOTIFICATION);
+  double lastNotification = getNumberFieldAsDoubleF(&subOrig, CSUB_LASTNOTIFICATION);
 
   //
   // Compare with 'lastNotificationTime', that might come from the sub-cache.
@@ -536,7 +536,7 @@ static void setLastNotification(const BSONObj& subOrig, CachedSubscription* subC
 */
 static double setLastFailure(const BSONObj& subOrig, CachedSubscription* subCacheP, BSONObjBuilder* b)
 {
-  double lastFailure = subOrig.hasField(CSUB_LASTFAILURE)? getNumberFieldAsDoubleF(subOrig, CSUB_LASTFAILURE) : 0;
+  double lastFailure = subOrig.hasField(CSUB_LASTFAILURE)? getNumberFieldAsDoubleF(&subOrig, CSUB_LASTFAILURE) : 0;
 
   //
   // Compare with 'lastFailure' from the sub-cache.
@@ -560,7 +560,7 @@ static double setLastFailure(const BSONObj& subOrig, CachedSubscription* subCach
 */
 static double setLastSuccess(const BSONObj& subOrig, CachedSubscription* subCacheP, BSONObjBuilder* b)
 {
-  double lastSuccess = getNumberFieldAsDoubleF(subOrig, CSUB_LASTSUCCESS);
+  double lastSuccess = getNumberFieldAsDoubleF(&subOrig, CSUB_LASTSUCCESS);
 
   //
   // Compare with 'lastSuccess' from the sub-cache.
@@ -791,7 +791,7 @@ void updateInCache
                                           lastNotification,
                                           lastFailure,
                                           lastSuccess,
-                                          doc.hasField(CSUB_EXPIRATION)? getNumberFieldAsDoubleF(doc, CSUB_EXPIRATION) : 0,
+                                          doc.hasField(CSUB_EXPIRATION)? getNumberFieldAsDoubleF(&doc, CSUB_EXPIRATION) : 0,
                                           doc.hasField(CSUB_STATUS)? getStringFieldF(&doc, CSUB_STATUS) : STATUS_ACTIVE,
                                           q,
                                           mq,

--- a/src/lib/mongoBackend/safeMongo.cpp
+++ b/src/lib/mongoBackend/safeMongo.cpp
@@ -138,23 +138,23 @@ const char* getStringField(const BSONObj* bP, const char* field, const char* cal
 *
 * getNumberField -
 */
-double getNumberField(const BSONObj& b, const char* field, const char* caller, int line)
+double getNumberField(const BSONObj* bP, const char* field, const char* caller, int line)
 {
-  if (b.hasField(field) && b.getField(field).type() == mongo::NumberDouble)
+  if (bP->hasField(field) && bP->getField(field).type() == mongo::NumberDouble)
   {
-    return b.getField(field).Number();
+    return bP->getField(field).Number();
   }
 
   // Detect error
-  if (!b.hasField(field))
+  if (!bP->hasField(field))
   {
     LM_E(("Runtime Error (double field '%s' is missing in BSONObj <%s> from caller %s:%d)",
-          field, b.toString().c_str(), caller, line));
+          field, bP->toString().c_str(), caller, line));
   }
   else
   {
     LM_E(("Runtime Error (field '%s' was supposed to be an double but type=%d in BSONObj <%s> from caller %s:%d)",
-          field, b.getField(field).type(), b.toString().c_str(), caller, line));
+          field, bP->getField(field).type(), bP->toString().c_str(), caller, line));
   }
 
   return -1;
@@ -192,62 +192,34 @@ int getIntField(const BSONObj* bP, const char* field, const char* caller, int li
 
 /* ****************************************************************************
 *
-* getLongField -
-*/
-long long getLongField(const BSONObj& b, const char* field, const char* caller, int line)
-{
-  if (b.hasField(field) && (b.getField(field).type() == mongo::NumberLong))
-  {
-    return b.getField(field).Long();
-  }
-
-  // Detect error
-  if (!b.hasField(field))
-  {
-    LM_E(("Runtime Error (long field '%s' is missing in BSONObj <%s> from caller %s:%d)",
-          field, b.toString().c_str(), caller, line));
-  }
-  else
-  {
-    LM_E(("Runtime Error (field '%s' was supposed to be a long but type=%d in BSONObj <%s> from caller %s:%d)",
-          field, b.getField(field).type(), b.toString().c_str(), caller, line));
-  }
-
-  return -1;
-}
-
-
-
-/* ****************************************************************************
-*
 * getIntOrLongFieldAsLong -
 */
-long long getIntOrLongFieldAsLong(const BSONObj& b, const char* field, const char* caller, int line)
+long long getIntOrLongFieldAsLong(const BSONObj* bP, const char* field, const char* caller, int line)
 {
-  if (b.hasField(field))
+  if (bP->hasField(field))
   {
-    if (b.getField(field).type() == mongo::NumberLong)
+    if (bP->getField(field).type() == mongo::NumberLong)
     {
-      return b.getField(field).Long();
+      return bP->getField(field).Long();
     }
-    else if (b.getField(field).type() == mongo::NumberInt)
+    else if (bP->getField(field).type() == mongo::NumberInt)
     {
-      return b.getField(field).Int();
+      return bP->getField(field).Int();
     }
-    else if (b.getField(field).type() == mongo::NumberDouble)
-      return (long long) b.getField(field).Double();
+    else if (bP->getField(field).type() == mongo::NumberDouble)
+      return (long long) bP->getField(field).Double();
   }
 
   // Detect error
-  if (!b.hasField(field))
+  if (!bP->hasField(field))
   {
     LM_E(("Runtime Error (int/long field '%s' is missing in BSONObj <%s> from caller %s:%d)",
-          field, b.toString().c_str(), caller, line));
+          field, bP->toString().c_str(), caller, line));
   }
   else
   {
     LM_E(("Runtime Error (field '%s' was supposed to be int or long but type=%d in BSONObj <%s> from caller %s:%d)",
-          field, b.getField(field).type(), b.toString().c_str(), caller, line));
+          field, bP->getField(field).type(), bP->toString().c_str(), caller, line));
   }
 
   return -1;
@@ -286,25 +258,25 @@ bool getBoolField(const BSONObj* bP, const char* field, const char* caller, int 
 *
 * getNumberFieldAsDouble -
 */
-double getNumberFieldAsDouble(const BSONObj& b, const char* field, const char* caller, int line)
+double getNumberFieldAsDouble(const BSONObj* bP, const char* field, const char* caller, int line)
 {
   double retVal = -1;
 
-  if (b.hasField(field))
+  if (bP->hasField(field))
   {
-    if      (b.getField(field).type() == mongo::NumberDouble)      retVal = b.getField(field).Double();
-    else if (b.getField(field).type() == mongo::NumberLong)        retVal = b.getField(field).Long();
-    else if (b.getField(field).type() == mongo::NumberInt)         retVal = b.getField(field).Int();
+    if      (bP->getField(field).type() == mongo::NumberDouble)      retVal = bP->getField(field).Double();
+    else if (bP->getField(field).type() == mongo::NumberLong)        retVal = bP->getField(field).Long();
+    else if (bP->getField(field).type() == mongo::NumberInt)         retVal = bP->getField(field).Int();
     else
       LM_E(("Runtime Error (field '%s' was supposed to be a Number (double/int/long) but the type is '%s' (type as integer: %d) in BSONObj <%s> from caller %s:%d)",
-            field, mongoTypeName(b.getField(field).type()), b.getField(field).type(), b.toString().c_str(), caller, line));
+            field, mongoTypeName(bP->getField(field).type()), bP->getField(field).type(), bP->toString().c_str(), caller, line));
 
     return retVal;
   }
 
   LM_E(("Runtime Error (double/int/long field '%s' is missing in BSONObj <%s> from caller %s:%d)",
         field,
-        b.toString().c_str(),
+        bP->toString().c_str(),
         caller,
         line));
 

--- a/src/lib/mongoBackend/safeMongo.h
+++ b/src/lib/mongoBackend/safeMongo.h
@@ -45,7 +45,6 @@
 #define getStringFieldF(b, field)           getStringField(b, field, __FUNCTION__, __LINE__)
 #define getNumberFieldF(b, field)           getNumberField(b, field, __FUNCTION__, __LINE__)
 #define getIntFieldF(b, field)              getIntField(b, field, __FUNCTION__, __LINE__)
-#define getLongFieldF(b, field)             getLongField(b, field, __FUNCTION__, __LINE__)
 #define getIntOrLongFieldAsLongF(b, field)  getIntOrLongFieldAsLong(b, field, __FUNCTION__, __LINE__)
 #define getNumberFieldAsDoubleF(b, field)   getNumberFieldAsDouble(b, field, __FUNCTION__, __LINE__)
 #define getBoolFieldF(b, field)             getBoolField(b, field, __FUNCTION__, __LINE__)
@@ -103,7 +102,7 @@ extern const char* getStringField
 */
 extern double getNumberField
 (
-  const mongo::BSONObj&  b,
+  const mongo::BSONObj*  bP,
   const char*            field,
   const char*            caller,
   int                    line
@@ -127,25 +126,11 @@ extern int getIntField
 
 /* ****************************************************************************
 *
-* getLongField -
-*/
-extern long long getLongField
-(
-  const mongo::BSONObj&  b,
-  const char*            field,
-  const char*            caller = "<none>",
-  int                    line   = 0
-);
-
-
-
-/* ****************************************************************************
-*
 * getIntOrLongFieldAsLong -
 */
 extern long long getIntOrLongFieldAsLong
 (
-  const mongo::BSONObj&  b,
+  const mongo::BSONObj*  bP,
   const char*            field,
   const char*            caller = "<none>",
   int                    line   = 0
@@ -159,7 +144,7 @@ extern long long getIntOrLongFieldAsLong
 */
 extern double getNumberFieldAsDouble
 (
-  const mongo::BSONObj&  b,
+  const mongo::BSONObj*  bP,
   const char*            field,
   const char*            caller = "<none>",
   int                    line   = 0

--- a/src/lib/ngsi/ContextElementResponse.cpp
+++ b/src/lib/ngsi/ContextElementResponse.cpp
@@ -215,7 +215,7 @@ ContextElementResponse::ContextElementResponse
         break;
 
       case NumberDouble:
-        ca.numberValue = getNumberFieldF(attr, ENT_ATTRS_VALUE);
+        ca.numberValue = getNumberFieldF(&attr, ENT_ATTRS_VALUE);
         caP = new ContextAttribute(ca.name, ca.type, ca.numberValue);
         break;
 
@@ -300,12 +300,12 @@ ContextElementResponse::ContextElementResponse
     /* Set creDate and modDate at attribute level */
     if (attr.hasField(ENT_ATTRS_CREATION_DATE))
     {
-      caP->creDate = getNumberFieldAsDoubleF(attr, ENT_ATTRS_CREATION_DATE);
+      caP->creDate = getNumberFieldAsDoubleF(&attr, ENT_ATTRS_CREATION_DATE);
     }
 
     if (attr.hasField(ENT_ATTRS_MODIFICATION_DATE))
     {
-      caP->modDate = getNumberFieldAsDoubleF(attr, ENT_ATTRS_MODIFICATION_DATE);
+      caP->modDate = getNumberFieldAsDoubleF(&attr, ENT_ATTRS_MODIFICATION_DATE);
     }
 
     contextElement.contextAttributeVector.push_back(caP);
@@ -314,12 +314,12 @@ ContextElementResponse::ContextElementResponse
   /* Set creDate and modDate at entity level */
   if (entityDoc.hasField(ENT_CREATION_DATE))
   {
-    contextElement.entityId.creDate = getNumberFieldAsDoubleF(entityDoc, ENT_CREATION_DATE);
+    contextElement.entityId.creDate = getNumberFieldAsDoubleF(&entityDoc, ENT_CREATION_DATE);
   }
 
   if (entityDoc.hasField(ENT_MODIFICATION_DATE))
   {
-    contextElement.entityId.modDate = getNumberFieldAsDoubleF(entityDoc, ENT_MODIFICATION_DATE);
+    contextElement.entityId.modDate = getNumberFieldAsDoubleF(&entityDoc, ENT_MODIFICATION_DATE);
   }
 }
 

--- a/src/lib/ngsi/Metadata.cpp
+++ b/src/lib/ngsi/Metadata.cpp
@@ -192,8 +192,8 @@ Metadata::Metadata(const char* _name, BSONObj* mdB)
   type            = mdB->hasField(ENT_ATTRS_MD_TYPE) ? getStringFieldF(mdB, ENT_ATTRS_MD_TYPE) : "";
   typeGiven       = (type == "")? false : true;
   compoundValueP  = NULL;
-  createdAt       = mdB->hasField("createdAt")  ? getNumberFieldF(*mdB, "createdAt") : 0;
-  modifiedAt      = mdB->hasField("modifiedAt") ? getNumberFieldF(*mdB, "modifiedAt") : 0;
+  createdAt       = mdB->hasField("createdAt")  ? getNumberFieldF(mdB, "createdAt") : 0;
+  modifiedAt      = mdB->hasField("modifiedAt") ? getNumberFieldF(mdB, "modifiedAt") : 0;
 
   BSONType bsonType = getFieldF(*mdB, ENT_ATTRS_MD_VALUE).type();
   switch (bsonType)
@@ -210,7 +210,7 @@ Metadata::Metadata(const char* _name, BSONObj* mdB)
 
   case NumberDouble:
     valueType   = orion::ValueTypeNumber;
-    numberValue = getNumberFieldF(*mdB, ENT_ATTRS_MD_VALUE);
+    numberValue = getNumberFieldF(mdB, ENT_ATTRS_MD_VALUE);
     break;
 
   case Bool:

--- a/src/lib/orionld/mongoBackend/mongoLdRegistrationAux.cpp
+++ b/src/lib/orionld/mongoBackend/mongoLdRegistrationAux.cpp
@@ -132,7 +132,7 @@ void mongoSetLdName(ngsiv2::Registration* reg, mongo::BSONObj* bobjP)
 */
 void mongoSetExpiration(ngsiv2::Registration* regP, const mongo::BSONObj& r)
 {
-  regP->expires = (r.hasField(REG_EXPIRATION))? getNumberFieldAsDoubleF(r, REG_EXPIRATION) : -1;
+  regP->expires = (r.hasField(REG_EXPIRATION))? getNumberFieldAsDoubleF(&r, REG_EXPIRATION) : -1;
 }
 
 
@@ -147,8 +147,8 @@ void mongoSetLdObservationInterval(ngsiv2::Registration* reg, const mongo::BSONO
   {
     mongo::BSONObj obj              = getObjectFieldF(r, REG_OBSERVATION_INTERVAL);
 
-    reg->observationInterval.start  = getNumberFieldAsDoubleF(obj, REG_INTERVAL_START);
-    reg->observationInterval.end    = obj.hasField(REG_INTERVAL_END) ? getNumberFieldAsDoubleF(obj, REG_INTERVAL_END) : -1;
+    reg->observationInterval.start  = getNumberFieldAsDoubleF(&obj, REG_INTERVAL_START);
+    reg->observationInterval.end    = obj.hasField(REG_INTERVAL_END) ? getNumberFieldAsDoubleF(&obj, REG_INTERVAL_END) : -1;
   }
   else
   {
@@ -169,8 +169,8 @@ void mongoSetLdManagementInterval(ngsiv2::Registration* reg, const mongo::BSONOb
   {
     mongo::BSONObj obj             = getObjectFieldF(r, REG_MANAGEMENT_INTERVAL);
 
-    reg->managementInterval.start  = getNumberFieldAsDoubleF(obj, REG_INTERVAL_START);
-    reg->managementInterval.end    = obj.hasField(REG_INTERVAL_END) ? getNumberFieldAsDoubleF(obj, REG_INTERVAL_END) : -1;
+    reg->managementInterval.start  = getNumberFieldAsDoubleF(&obj, REG_INTERVAL_START);
+    reg->managementInterval.end    = obj.hasField(REG_INTERVAL_END) ? getNumberFieldAsDoubleF(&obj, REG_INTERVAL_END) : -1;
   }
   else
   {
@@ -188,7 +188,7 @@ void mongoSetLdManagementInterval(ngsiv2::Registration* reg, const mongo::BSONOb
 void mongoSetLdTimestamp(double* timestampP, const char* name, const mongo::BSONObj& bobj)
 {
   if (bobj.hasField(name))
-    *timestampP = getNumberFieldAsDoubleF(bobj, name);
+    *timestampP = getNumberFieldAsDoubleF(&bobj, name);
   else
     *timestampP = -1;
 }


### PR DESCRIPTION
getLong/Number/IntOrLong-Field functions now get a pointer to its BSONObj instead of as a C++ reference