### PR TITLE
Hardening/get array field with pointer not reference

### DIFF
--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -491,7 +491,7 @@ static bool mergeAttrInfo(const BSONObj& attr, ContextAttribute* caP, BSONObj* m
       break;
 
     case mongo::Array:
-      ab.appendArray(ENT_ATTRS_VALUE, getArrayFieldF(attr, ENT_ATTRS_VALUE));
+      ab.appendArray(ENT_ATTRS_VALUE, getArrayFieldF(&attr, ENT_ATTRS_VALUE));
       break;
 
     case mongo::NumberDouble:

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -491,7 +491,11 @@ static bool mergeAttrInfo(const BSONObj& attr, ContextAttribute* caP, BSONObj* m
       break;
 
     case mongo::Array:
-      ab.appendArray(ENT_ATTRS_VALUE, getArrayFieldF(&attr, ENT_ATTRS_VALUE));
+    {
+      BSONArray array;
+      if (getArrayField(&array, &attr, ENT_ATTRS_VALUE, __FILE__, __LINE__) == true)
+        ab.appendArray(ENT_ATTRS_VALUE, array);
+    }
       break;
 
     case mongo::NumberDouble:

--- a/src/lib/mongoBackend/mongoUpdateSubscription.cpp
+++ b/src/lib/mongoBackend/mongoUpdateSubscription.cpp
@@ -231,7 +231,7 @@ static void setEntities(const SubscriptionUpdate& subUp, const BSONObj& subOrig,
   }
   else
   {
-    BSONArray entities = getArrayFieldF(subOrig, CSUB_ENTITIES);
+    BSONArray entities = getArrayFieldF(&subOrig, CSUB_ENTITIES);
 
     b->append(CSUB_ENTITIES, entities);
     LM_T(LmtMongo, ("Subscription entities: %s", entities.toString().c_str()));
@@ -252,7 +252,7 @@ static void setAttrs(const SubscriptionUpdate& subUp, const BSONObj& subOrig, BS
   }
   else
   {
-    BSONArray attrs = getArrayFieldF(subOrig, CSUB_ATTRS);
+    BSONArray attrs = getArrayFieldF(&subOrig, CSUB_ATTRS);
 
     b->append(CSUB_ATTRS, attrs);
     LM_T(LmtMongo, ("Subscription attrs: %s", attrs.toString().c_str()));
@@ -458,7 +458,7 @@ static void setCondsAndInitialNotify
   }
   else
   {
-    BSONArray conds = getArrayFieldF(subOrig, CSUB_CONDITIONS);
+    BSONArray conds = getArrayFieldF(&subOrig, CSUB_CONDITIONS);
 
     b->append(CSUB_CONDITIONS, conds);
     LM_T(LmtMongo, ("Subscription conditions: %s", conds.toString().c_str()));
@@ -676,7 +676,7 @@ static void setMetadata(const SubscriptionUpdate& subUp, const BSONObj& subOrig,
 
     if (subOrig.hasField(CSUB_METADATA))
     {
-      metadata = getArrayFieldF(subOrig, CSUB_METADATA);
+      metadata = getArrayFieldF(&subOrig, CSUB_METADATA);
     }
 
     b->append(CSUB_METADATA, metadata);

--- a/src/lib/mongoBackend/mongoUpdateSubscription.cpp
+++ b/src/lib/mongoBackend/mongoUpdateSubscription.cpp
@@ -231,10 +231,13 @@ static void setEntities(const SubscriptionUpdate& subUp, const BSONObj& subOrig,
   }
   else
   {
-    BSONArray entities = getArrayFieldF(&subOrig, CSUB_ENTITIES);
-
+    //
+    // Ignoring bool response from getArrayField
+    // If not found, an empty array is added to 'b'
+    //
+    BSONArray entities;
+    getArrayField(&entities, &subOrig, CSUB_ENTITIES, __FILE__, __LINE__);
     b->append(CSUB_ENTITIES, entities);
-    LM_T(LmtMongo, ("Subscription entities: %s", entities.toString().c_str()));
   }
 }
 
@@ -252,10 +255,13 @@ static void setAttrs(const SubscriptionUpdate& subUp, const BSONObj& subOrig, BS
   }
   else
   {
-    BSONArray attrs = getArrayFieldF(&subOrig, CSUB_ATTRS);
-
+    //
+    // Ignoring bool response from getArrayField
+    // If not found, an empty array is added to 'b'
+    //
+    BSONArray attrs;
+    getArrayField(&attrs, &subOrig, CSUB_ATTRS, __FILE__, __LINE__);
     b->append(CSUB_ATTRS, attrs);
-    LM_T(LmtMongo, ("Subscription attrs: %s", attrs.toString().c_str()));
   }
 }
 
@@ -458,10 +464,13 @@ static void setCondsAndInitialNotify
   }
   else
   {
-    BSONArray conds = getArrayFieldF(&subOrig, CSUB_CONDITIONS);
-
+    //
+    // Ignoring bool response from getArrayField
+    // If not found, an empty array is added to 'b'
+    //
+    BSONArray conds;
+    getArrayField(&conds, &subOrig, CSUB_CONDITIONS, __FILE__, __LINE__);
     b->append(CSUB_CONDITIONS, conds);
-    LM_T(LmtMongo, ("Subscription conditions: %s", conds.toString().c_str()));
   }
 }
 
@@ -672,15 +681,14 @@ static void setMetadata(const SubscriptionUpdate& subUp, const BSONObj& subOrig,
     // Note that if subOrig doesn't have CSUB_METADATA (e.g. old subscription in the DB created before
     // this feature) BSONArray constructor ensures an empty array
     //
+
+    //
+    // Ignoring bool response from getArrayField
+    // If not found, an empty array is added to 'b'
+    //
     BSONArray metadata;
-
-    if (subOrig.hasField(CSUB_METADATA))
-    {
-      metadata = getArrayFieldF(&subOrig, CSUB_METADATA);
-    }
-
+    getArrayField(&metadata, &subOrig, CSUB_METADATA, __FILE__, __LINE__);
     b->append(CSUB_METADATA, metadata);
-    LM_T(LmtMongo, ("Subscription metadata: %s", metadata.toString().c_str()));
   }
 }
 

--- a/src/lib/mongoBackend/safeMongo.cpp
+++ b/src/lib/mongoBackend/safeMongo.cpp
@@ -79,24 +79,24 @@ BSONObj getObjectField(const BSONObj& b, const char* field, const char* caller, 
 *
 * getArrayField -
 */
-BSONArray getArrayField(const BSONObj& b, const char* field, const char* caller, int line)
+BSONArray getArrayField(const BSONObj* bP, const char* field, const char* caller, int line)
 {
-  if (b.hasField(field) && b.getField(field).type() == mongo::Array)
+  if (bP->hasField(field) && bP->getField(field).type() == mongo::Array)
   {
     // See http://stackoverflow.com/questions/36307126/getting-bsonarray-from-bsonelement-in-an-direct-way
-    return (BSONArray) b.getObjectField(field);
+    return (BSONArray) bP->getObjectField(field);
   }
 
   // Detect error
-  if (!b.hasField(field))
+  if (!bP->hasField(field))
   {
     LM_E(("Runtime Error (object field '%s' is missing in BSONObj <%s> from caller %s:%d)",
-          field, b.toString().c_str(), caller, line));
+          field, bP->toString().c_str(), caller, line));
   }
   else
   {
     LM_E(("Runtime Error (field '%s' was supposed to be an array but type=%d in BSONObj <%s> from caller %s:%d)",
-          field, b.getField(field).type(), b.toString().c_str(), caller, line));
+          field, bP->getField(field).type(), bP->toString().c_str(), caller, line));
   }
 
   return BSONArray();

--- a/src/lib/mongoBackend/safeMongo.h
+++ b/src/lib/mongoBackend/safeMongo.h
@@ -74,7 +74,7 @@ extern mongo::BSONObj getObjectField
 */
 extern mongo::BSONArray getArrayField
 (
-  const mongo::BSONObj&  b,
+  const mongo::BSONObj*  bP,
   const char*            field,
   const char*            caller = "<none>",
   int                    line   = 0

--- a/src/lib/mongoBackend/safeMongo.h
+++ b/src/lib/mongoBackend/safeMongo.h
@@ -41,7 +41,6 @@
 * Some macros to make the usage of these functions prettier
 */
 #define getObjectFieldF(b, field)           getObjectField(b, field, __FUNCTION__, __LINE__)
-#define getArrayFieldF(b, field)            getArrayField(b, field, __FUNCTION__, __LINE__)
 #define getStringFieldF(b, field)           getStringField(b, field, __FUNCTION__, __LINE__)
 #define getNumberFieldF(b, field)           getNumberField(b, field, __FUNCTION__, __LINE__)
 #define getIntFieldF(b, field)              getIntField(b, field, __FUNCTION__, __LINE__)
@@ -72,8 +71,9 @@ extern mongo::BSONObj getObjectField
 *
 * getArrayField -
 */
-extern mongo::BSONArray getArrayField
+extern bool getArrayField
 (
+  mongo::BSONArray*      outArrayP,
   const mongo::BSONObj*  bP,
   const char*            field,
   const char*            caller = "<none>",


### PR DESCRIPTION
Performance:
* Fixed getArrayField (minimized copies and calls to new/delete + constructor/destructor):
  * No longer returning a BSONObk on the stack (a pointer is sent as out-parameter)
  * No longer accepting an BSONObj& as in-parameter - it's instead a C pointer