### PR TITLE
hardening/getObjectField-with-pointer-not-reference

### DIFF
--- a/src/lib/apiTypesV2/HttpInfo.cpp
+++ b/src/lib/apiTypesV2/HttpInfo.cpp
@@ -142,7 +142,7 @@ void HttpInfo::fill(const BSONObj* boP)
 
   if (boP->hasField("notifierInfo"))
   {
-    BSONObj ni = getObjectFieldF(*boP, "notifierInfo");
+    BSONObj ni = getObjectFieldF(boP, "notifierInfo");
 
     for (BSONObj::iterator iter = ni.begin(); iter.more();)
     {
@@ -172,7 +172,7 @@ void HttpInfo::fill(const BSONObj* boP)
     // qs
     if (boP->hasField(CSUB_QS))
     {
-      BSONObj qs = getObjectFieldF(*boP, CSUB_QS);
+      BSONObj qs = getObjectFieldF(boP, CSUB_QS);
 
       for (BSONObj::iterator i = qs.begin(); i.more();)
       {
@@ -188,7 +188,7 @@ void HttpInfo::fill(const BSONObj* boP)
     // headers
     if (boP->hasField(CSUB_HEADERS))
     {
-      BSONObj headers = getObjectFieldF(*boP, CSUB_HEADERS);
+      BSONObj headers = getObjectFieldF(boP, CSUB_HEADERS);
 
       for (BSONObj::iterator i = headers.begin(); i.more();)
       {

--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -293,8 +293,8 @@ static bool equalMetadata(const BSONObj& md1, const BSONObj& md2)
       return false;
     }
 
-    BSONObj md1Item = getObjectFieldF(md1, currentMd);
-    BSONObj md2Item = getObjectFieldF(md2, currentMd);
+    BSONObj md1Item = getObjectFieldF(&md1, currentMd);
+    BSONObj md2Item = getObjectFieldF(&md2, currentMd);
 
     if (!equalMetadataValues(md1Item, md2Item))
     {
@@ -487,7 +487,7 @@ static bool mergeAttrInfo(const BSONObj& attr, ContextAttribute* caP, BSONObj* m
     switch (getFieldF(attr, ENT_ATTRS_VALUE).type())
     {
     case mongo::Object:
-      ab.append(ENT_ATTRS_VALUE, getObjectFieldF(attr, ENT_ATTRS_VALUE));
+      ab.append(ENT_ATTRS_VALUE, getObjectFieldF(&attr, ENT_ATTRS_VALUE));
       break;
 
     case mongo::Array:
@@ -566,7 +566,7 @@ static bool mergeAttrInfo(const BSONObj& attr, ContextAttribute* caP, BSONObj* m
     for (std::set<std::string>::iterator i = mdsSet.begin(); i != mdsSet.end(); ++i)
     {
       const char*  currentMd = i->c_str();
-      BSONObj      mdItem    = getObjectFieldF(md, currentMd);
+      BSONObj      mdItem    = getObjectFieldF(&md, currentMd);
       Metadata     md(currentMd, &mdItem);
 
       mdSize++;
@@ -805,7 +805,7 @@ static bool updateAttribute
     }
 
     BSONObj newAttr;
-    BSONObj attr = getObjectFieldF(attrs, effectiveName);
+    BSONObj attr = getObjectFieldF(&attrs, effectiveName);
 
     *actualUpdate = mergeAttrInfo(attr, caP, &newAttr, apiVersion);
     if (*actualUpdate)
@@ -1586,7 +1586,7 @@ static bool addTriggeredSubscriptions_noCache
 
       if (sub.hasField(CSUB_EXPR))
       {
-        BSONObj expr = getObjectFieldF(sub, CSUB_EXPR);
+        BSONObj expr = getObjectFieldF(&sub, CSUB_EXPR);
 
         std::string q        = expr.hasField(CSUB_EXPR_Q)      ? getStringFieldF(&expr, CSUB_EXPR_Q)      : "";
         std::string mq       = expr.hasField(CSUB_EXPR_MQ)     ? getStringFieldF(&expr, CSUB_EXPR_MQ)     : "";
@@ -3320,7 +3320,7 @@ static void updateEntity
   const std::string  typeString        = "_id." ENT_ENTITY_TYPE;
   const std::string  servicePathString = "_id." ENT_SERVICE_PATH;
 
-  BSONObj            idField           = getObjectFieldF(r, "_id");
+  BSONObj            idField           = getObjectFieldF(&r, "_id");
 
   std::string        entityId          = getStringFieldF(&idField, ENT_ENTITY_ID);
   std::string        entityType        = getStringFieldF(&idField, ENT_ENTITY_TYPE);
@@ -3342,7 +3342,7 @@ static void updateEntity
    * the request one of the BSON objects could be empty (it use to be the $unset one). In addition, for
    * APPEND and DELETE updates we use two arrays to push/pull attributes in the attrsNames vector */
 
-  BSONObj           attrs     = getObjectFieldF(r, ENT_ATTRS);
+  BSONObj           attrs     = getObjectFieldF(&r, ENT_ATTRS);
   BSONObjBuilder    toSet;
   BSONObjBuilder    toUnset;
   BSONArrayBuilder  toPush;
@@ -3361,10 +3361,10 @@ static void updateEntity
 
   if (r.hasField(ENT_LOCATION))
   {
-    BSONObj loc    = getObjectFieldF(r, ENT_LOCATION);
+    BSONObj loc    = getObjectFieldF(&r, ENT_LOCATION);
 
     locAttr        = getStringFieldF(&loc, ENT_LOCATION_ATTRNAME);
-    currentGeoJson = getObjectFieldF(loc, ENT_LOCATION_COORDS);
+    currentGeoJson = getObjectFieldF(&loc, ENT_LOCATION_COORDS);
   }
 
   /* Is the entity using date expiration? In that case, we fill the currentdateExpiration attribute with that information.

--- a/src/lib/mongoBackend/location.cpp
+++ b/src/lib/mongoBackend/location.cpp
@@ -158,7 +158,9 @@ static bool getGeoJson
 
     // Autocast doesn't make sense in this context
     caP->valueBson(bo, "", false);
-    geoJson->appendElements(getObjectFieldF(bo.obj(), ENT_ATTRS_VALUE));
+
+    mongo::BSONObj boObj = bo.obj();
+    geoJson->appendElements(getObjectFieldF(&boObj, ENT_ATTRS_VALUE));
 
     return true;
   }

--- a/src/lib/mongoBackend/mongoGetSubscriptions.cpp
+++ b/src/lib/mongoBackend/mongoGetSubscriptions.cpp
@@ -136,7 +136,7 @@ static void setSubject(Subscription* s, const BSONObj& r)
 
   if (r.hasField(CSUB_EXPR))
   {
-    mongo::BSONObj expression = getObjectFieldF(r, CSUB_EXPR);
+    mongo::BSONObj expression = getObjectFieldF(&r, CSUB_EXPR);
 
     const char*  q           = getStringFieldF(&expression, CSUB_EXPR_Q);
     const char*  mq          = getStringFieldF(&expression, CSUB_EXPR_MQ);

--- a/src/lib/mongoBackend/mongoQueryTypes.cpp
+++ b/src/lib/mongoBackend/mongoQueryTypes.cpp
@@ -124,15 +124,15 @@ static void getAttributeTypes
 
     /* Previous versions of this function used a simpler approach:
      *
-     *   BSONObj attrs = getObjectFieldF(r, ENT_ATTRS);
-     *   BSONObj attr  = getObjectFieldF(attrs, attrName);
+     *   BSONObj attrs = getObjectFieldF(&r, ENT_ATTRS);
+     *   BSONObj attr  = getObjectFieldF(&attrs, attrName);
      *   attrTypes->push_back(getStringFieldF(attr, ENT_ATTRS_TYPE));
      *
      * However, it doesn't work when the attribute uses metadata ID
      *
      */
 
-    BSONObj                attrs = getObjectFieldF(r, ENT_ATTRS);
+    BSONObj                attrs = getObjectFieldF(&r, ENT_ATTRS);
     std::set<std::string>  attrsSet;
 
     attrs.getFieldNames(attrsSet);
@@ -150,7 +150,7 @@ static void getAttributeTypes
 
       if (strncmp(currentAttr, attrName.c_str(), cmpLen) == 0)
       {
-        BSONObj attr = getObjectFieldF(attrs, currentAttr);
+        BSONObj attr = getObjectFieldF(&attrs, currentAttr);
         attrTypes->push_back(getStringFieldF(&attr, ENT_ATTRS_TYPE));
       }
     }
@@ -216,7 +216,7 @@ static unsigned int countCmd(const std::string& tenant, const BSONArray& pipelin
   if (result.hasField("cursor"))
   {
     // abcense of "count" field in the "firtBatch" array means "zero result"
-    resultsArray = getFieldF(getObjectFieldF(result, "cursor"), "firstBatch").Array();
+    resultsArray = getFieldF(getObjectFieldF(&result, "cursor"), "firstBatch").Array();
     if ((resultsArray.size() > 0) && (resultsArray[0].embeddedObject().hasField("count")))
     {
       BSONObj bo = resultsArray[0].embeddedObject();
@@ -339,7 +339,7 @@ HttpStatusCode mongoEntityTypesValues
 
   if (result.hasField("cursor"))
   {
-    resultsArray = getFieldF(getObjectFieldF(result, "cursor"), "firstBatch").Array();
+    resultsArray = getFieldF(getObjectFieldF(&result, "cursor"), "firstBatch").Array();
   }
 
   if (resultsArray.size() == 0)
@@ -515,7 +515,7 @@ HttpStatusCode mongoEntityTypes
 
   if (result.hasField("cursor"))
   {
-    resultsArray = getFieldF(getObjectFieldF(result, "cursor"), "firstBatch").Array();
+    resultsArray = getFieldF(getObjectFieldF(&result, "cursor"), "firstBatch").Array();
   }
 
   // Early return if no element was found
@@ -704,7 +704,7 @@ HttpStatusCode mongoAttributesForEntityType
 
   if (result.hasField("cursor"))
   {
-    resultsArray = getFieldF(getObjectFieldF(result, "cursor"), "firstBatch").Array();
+    resultsArray = getFieldF(getObjectFieldF(&result, "cursor"), "firstBatch").Array();
   }
 
   responseP->entityType.count = countEntities(tenant, servicePathV, entityType);

--- a/src/lib/mongoBackend/mongoSubCache.cpp
+++ b/src/lib/mongoBackend/mongoSubCache.cpp
@@ -191,7 +191,7 @@ int mongoSubCacheItemInsert(const char* tenant, const BSONObj& sub)
   //
   if (sub.hasField(CSUB_EXPR))
   {
-    BSONObj expression = getObjectFieldF(sub, CSUB_EXPR);
+    BSONObj expression = getObjectFieldF(&sub, CSUB_EXPR);
 
     if (expression.hasField(CSUB_EXPR_Q))
     {

--- a/src/lib/mongoBackend/mongoUpdateSubscription.cpp
+++ b/src/lib/mongoBackend/mongoUpdateSubscription.cpp
@@ -117,7 +117,7 @@ static void setHttpInfo(const SubscriptionUpdate& subUp, const BSONObj& subOrig,
 
     if (subOrig.hasField(CSUB_HEADERS))
     {
-      BSONObj headers = getObjectFieldF(subOrig, CSUB_HEADERS);
+      BSONObj headers = getObjectFieldF(&subOrig, CSUB_HEADERS);
 
       b->append(CSUB_HEADERS, headers);
       LM_T(LmtMongo, ("Subscription headers: %s", headers.toString().c_str()));
@@ -125,7 +125,7 @@ static void setHttpInfo(const SubscriptionUpdate& subUp, const BSONObj& subOrig,
 
     if (subOrig.hasField(CSUB_QS))
     {
-      BSONObj qs = getObjectFieldF(subOrig, CSUB_QS);
+      BSONObj qs = getObjectFieldF(&subOrig, CSUB_QS);
 
       b->append(CSUB_QS, qs);
       LM_T(LmtMongo, ("Subscription qs: %s", qs.toString().c_str()));
@@ -603,7 +603,7 @@ static void setExpression(const SubscriptionUpdate& subUp, const BSONObj& subOri
 
     if (subOrig.hasField(CSUB_EXPR))
     {
-      expression = getObjectFieldF(subOrig, CSUB_EXPR);
+      expression = getObjectFieldF(&subOrig, CSUB_EXPR);
     }
     else
     {
@@ -782,7 +782,7 @@ void updateInCache
 
   if (doc.hasField(CSUB_EXPR))
   {
-    BSONObj expr = getObjectFieldF(doc, CSUB_EXPR);
+    BSONObj expr = getObjectFieldF(&doc, CSUB_EXPR);
 
     q      = expr.hasField(CSUB_EXPR_Q)?      getStringFieldF(&expr, CSUB_EXPR_Q)      : "";
     mq     = expr.hasField(CSUB_EXPR_MQ)?     getStringFieldF(&expr, CSUB_EXPR_MQ)     : "";

--- a/src/lib/mongoBackend/safeMongo.cpp
+++ b/src/lib/mongoBackend/safeMongo.cpp
@@ -53,21 +53,21 @@ using mongo::AssertionException;
 *
 * getObjectField -
 */
-BSONObj getObjectField(const BSONObj& b, const char* field, const char* caller, int line)
+BSONObj getObjectField(const BSONObj* bP, const char* field, const char* caller, int line)
 {
-  if (b.hasField(field) && b.getField(field).type() == mongo::Object)
-    return b.getObjectField(field);
+  if (bP->hasField(field) && bP->getField(field).type() == mongo::Object)
+    return bP->getObjectField(field);
 
   // Detect error
-  if (!b.hasField(field))
+  if (!bP->hasField(field))
   {
     LM_E(("Runtime Error (object field '%s' is missing in BSONObj <%s> from caller %s:%d)",
-          field, b.toString().c_str(), caller, line));
+          field, bP->toString().c_str(), caller, line));
   }
   else
   {
     LM_E(("Runtime Error (field '%s' was supposed to be an object but type=%d in BSONObj <%s> from caller %s:%d)",
-          field, b.getField(field).type(), b.toString().c_str(), caller, line));
+          field, bP->getField(field).type(), bP->toString().c_str(), caller, line));
   }
 
   return BSONObj();

--- a/src/lib/mongoBackend/safeMongo.h
+++ b/src/lib/mongoBackend/safeMongo.h
@@ -59,7 +59,7 @@
 */
 extern mongo::BSONObj getObjectField
 (
-  const mongo::BSONObj&  b,
+  const mongo::BSONObj*  bP,
   const char*            field,
   const char*            caller = "<none>",
   int                    line   = 0

--- a/src/lib/ngsi/ContextElementResponse.cpp
+++ b/src/lib/ngsi/ContextElementResponse.cpp
@@ -57,7 +57,7 @@ ContextElementResponse::ContextElementResponse()
 
 /* ****************************************************************************
 *
-* ContextElementResponse::ContextElementResponse - 
+* ContextElementResponse::ContextElementResponse -
 */
 ContextElementResponse::ContextElementResponse(EntityId* eP, ContextAttribute* aP)
 {
@@ -75,7 +75,7 @@ ContextElementResponse::ContextElementResponse(EntityId* eP, ContextAttribute* a
 
 /* ****************************************************************************
 *
-* ContextElementResponse::ContextElementResponse - 
+* ContextElementResponse::ContextElementResponse -
 */
 ContextElementResponse::ContextElementResponse(ContextElementResponse* cerP)
 {
@@ -154,7 +154,7 @@ ContextElementResponse::ContextElementResponse
   std::string locAttr;
   if (entityDoc.hasElement(ENT_LOCATION))
   {
-    BSONObj objField = getObjectFieldF(entityDoc, ENT_LOCATION);
+    BSONObj objField = getObjectFieldF(&entityDoc, ENT_LOCATION);
     locAttr = getStringFieldF(&objField, ENT_LOCATION_ATTRNAME);
   }
 
@@ -163,14 +163,14 @@ ContextElementResponse::ContextElementResponse
   // Attribute vector
   // FIXME P5: constructor for BSONObj could be added to ContextAttributeVector/ContextAttribute classes, to make building more modular
   //
-  BSONObj                attrs = getObjectFieldF(entityDoc, ENT_ATTRS);
+  BSONObj                attrs = getObjectFieldF(&entityDoc, ENT_ATTRS);
   std::set<std::string>  attrNames;
 
   attrs.getFieldNames(attrNames);
   for (std::set<std::string>::iterator i = attrNames.begin(); i != attrNames.end(); ++i)
   {
     const char*        attrName = i->c_str();
-    BSONObj            attr     = getObjectFieldF(attrs, attrName);
+    BSONObj            attr     = getObjectFieldF(&attrs, attrName);
     ContextAttribute*  caP      = NULL;
     ContextAttribute   ca;
     char               aName[512];
@@ -279,14 +279,14 @@ ContextElementResponse::ContextElementResponse
     /* Setting custom metadata (if any) */
     if (attr.hasField(ENT_ATTRS_MD))
     {
-      BSONObj                mds = getObjectFieldF(attr, ENT_ATTRS_MD);
+      BSONObj                mds = getObjectFieldF(&attr, ENT_ATTRS_MD);
       std::set<std::string>  mdsSet;
 
       mds.getFieldNames(mdsSet);
       for (std::set<std::string>::iterator i = mdsSet.begin(); i != mdsSet.end(); ++i)
       {
         char*   currentMd = (char*) i->c_str();
-        BSONObj mdObj     = getObjectFieldF(mds, currentMd); 
+        BSONObj mdObj     = getObjectFieldF(&mds, currentMd);
         char    mdName[512];
 
         strncpy(mdName, currentMd, sizeof(mdName));
@@ -340,7 +340,7 @@ ContextElementResponse::ContextElementResponse(ContextElement* ceP, bool useDefa
 
 /* ****************************************************************************
 *
-* ContextElementResponse::render - 
+* ContextElementResponse::render -
 */
 std::string ContextElementResponse::render
 (
@@ -365,7 +365,7 @@ std::string ContextElementResponse::render
 
 /* ****************************************************************************
 *
-* ContextElementResponse::toJson - 
+* ContextElementResponse::toJson -
 */
 std::string ContextElementResponse::toJson
 (
@@ -386,7 +386,7 @@ std::string ContextElementResponse::toJson
 
 /* ****************************************************************************
 *
-* ContextElementResponse::release - 
+* ContextElementResponse::release -
 */
 void ContextElementResponse::release(void)
 {
@@ -398,7 +398,7 @@ void ContextElementResponse::release(void)
 
 /* ****************************************************************************
 *
-* ContextElementResponse::check - 
+* ContextElementResponse::check -
 */
 std::string ContextElementResponse::check
 (
@@ -427,7 +427,7 @@ std::string ContextElementResponse::check
 
 /* ****************************************************************************
 *
-* ContextElementResponse::fill - 
+* ContextElementResponse::fill -
 */
 void ContextElementResponse::fill(QueryContextResponse* qcrP, const std::string& entityId, const std::string& entityType)
 {
@@ -453,7 +453,7 @@ void ContextElementResponse::fill(QueryContextResponse* qcrP, const std::string&
   //
   // FIXME P7: If more than one context element is found, we simply select the first one.
   //           A better approach would be to change this convop to return a vector of responses.
-  //           Adding a call to alarmMgr::badInput - with this I mean that the user that sends the 
+  //           Adding a call to alarmMgr::badInput - with this I mean that the user that sends the
   //           query needs to avoid using this conv op to make any queries that can give more than
   //           one unique context element :-).
   //           This FIXME is related to github issue #588 and (probably) #650.
@@ -476,7 +476,7 @@ void ContextElementResponse::fill(QueryContextResponse* qcrP, const std::string&
 
 /* ****************************************************************************
 *
-* ContextElementResponse::fill - 
+* ContextElementResponse::fill -
 */
 void ContextElementResponse::fill(ContextElementResponse* cerP)
 {
@@ -488,7 +488,7 @@ void ContextElementResponse::fill(ContextElementResponse* cerP)
 
 /* ****************************************************************************
 *
-* ContextElementResponse::clone - 
+* ContextElementResponse::clone -
 */
 ContextElementResponse* ContextElementResponse::clone(void)
 {

--- a/src/lib/orionld/mongoBackend/mongoLdRegistrationAux.cpp
+++ b/src/lib/orionld/mongoBackend/mongoLdRegistrationAux.cpp
@@ -145,7 +145,7 @@ void mongoSetLdObservationInterval(ngsiv2::Registration* reg, const mongo::BSONO
 {
   if (r.hasField(REG_OBSERVATION_INTERVAL))
   {
-    mongo::BSONObj obj              = getObjectFieldF(r, REG_OBSERVATION_INTERVAL);
+    mongo::BSONObj obj              = getObjectFieldF(&r, REG_OBSERVATION_INTERVAL);
 
     reg->observationInterval.start  = getNumberFieldAsDoubleF(&obj, REG_INTERVAL_START);
     reg->observationInterval.end    = obj.hasField(REG_INTERVAL_END) ? getNumberFieldAsDoubleF(&obj, REG_INTERVAL_END) : -1;
@@ -167,7 +167,7 @@ void mongoSetLdManagementInterval(ngsiv2::Registration* reg, const mongo::BSONOb
 {
   if (r.hasField(REG_MANAGEMENT_INTERVAL))
   {
-    mongo::BSONObj obj             = getObjectFieldF(r, REG_MANAGEMENT_INTERVAL);
+    mongo::BSONObj obj             = getObjectFieldF(&r, REG_MANAGEMENT_INTERVAL);
 
     reg->managementInterval.start  = getNumberFieldAsDoubleF(&obj, REG_INTERVAL_START);
     reg->managementInterval.end    = obj.hasField(REG_INTERVAL_END) ? getNumberFieldAsDoubleF(&obj, REG_INTERVAL_END) : -1;
@@ -206,7 +206,7 @@ bool mongoSetLdTimeInterval(OrionldGeoLocation* geoLocationP, const char* name, 
 {
   if (bobj.hasField(name))
   {
-    mongo::BSONObj   locBobj   = getObjectFieldF(bobj, name);
+    mongo::BSONObj   locBobj   = getObjectFieldF(&bobj, name);
     KjNode*          tree      = mongoCppLegacyDataToKjTree(&locBobj, false, titleP, detailP);
 
     for (KjNode* nodeP = tree->value.firstChildP; nodeP != NULL; nodeP = nodeP->next)
@@ -237,7 +237,7 @@ bool mongoSetLdProperties(ngsiv2::Registration* regP, const char* name, const mo
 {
   if (bobj.hasField(name))
   {
-    mongo::BSONObj  propertiesObj = getObjectFieldF(bobj, name);
+    mongo::BSONObj  propertiesObj = getObjectFieldF(&bobj, name);
 
     regP->properties = mongoCppLegacyDataToKjTree(&propertiesObj, false, titleP, detailP);
 


### PR DESCRIPTION
Performance:
* the getObjectField function now gets a pointer to its BSONObj instead of as a C++ reference
- Still need to make the returned BSONObj an out-parameter (as a C pointer), to avoid more copies