### PR TITLE
Performance/superfluous has field

### DIFF
--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -1571,11 +1571,13 @@ static bool addTriggeredSubscriptions_noCache
       //
       // NOTE: renderFormatString: NGSIv1 JSON is 'default' (for old db-content)
       //
-      double            throttling         = sub.hasField(CSUB_THROTTLING)?       getNumberFieldAsDoubleF(&sub, CSUB_THROTTLING)       : -1;
-      double            lastNotification   = sub.hasField(CSUB_LASTNOTIFICATION)? getNumberFieldAsDoubleF(&sub, CSUB_LASTNOTIFICATION) : -1;
-      const char*       renderFormatString = sub.hasField(CSUB_FORMAT)? getStringFieldF(&sub, CSUB_FORMAT) : "legacy";
+      double            throttling         = getNumberFieldAsDoubleF(&sub, CSUB_THROTTLING);
+      double            lastNotification   = getNumberFieldAsDoubleF(&sub, CSUB_LASTNOTIFICATION);
+      const char*       renderFmt          = getStringFieldF(&sub, CSUB_FORMAT);
+      const char*       renderFormatString = (renderFmt[0] == 0)? "legacy" : renderFmt;
       RenderFormat      renderFormat       = stringToRenderFormat(renderFormatString);
       ngsiv2::HttpInfo  httpInfo;
+
 
       httpInfo.fill(&sub);
 
@@ -1587,7 +1589,7 @@ static bool addTriggeredSubscriptions_noCache
                                                                "",
                                                                "");
 
-      trigs->blacklist = sub.hasField(CSUB_BLACKLIST)? getBoolFieldF(&sub, CSUB_BLACKLIST) : false;
+      trigs->blacklist = getBoolFieldF(&sub, CSUB_BLACKLIST);
 
       if (sub.hasField(CSUB_METADATA))
         setStringVectorF(&sub, CSUB_METADATA, &trigs->metadata);
@@ -1597,11 +1599,11 @@ static bool addTriggeredSubscriptions_noCache
         BSONObj expr;
         getObjectFieldF(&expr, &sub, CSUB_EXPR);
 
-        std::string q        = expr.hasField(CSUB_EXPR_Q)      ? getStringFieldF(&expr, CSUB_EXPR_Q)      : "";
-        std::string mq       = expr.hasField(CSUB_EXPR_MQ)     ? getStringFieldF(&expr, CSUB_EXPR_MQ)     : "";
-        std::string georel   = expr.hasField(CSUB_EXPR_GEOREL) ? getStringFieldF(&expr, CSUB_EXPR_GEOREL) : "";
-        std::string geometry = expr.hasField(CSUB_EXPR_GEOM)   ? getStringFieldF(&expr, CSUB_EXPR_GEOM)   : "";
-        std::string coords   = expr.hasField(CSUB_EXPR_COORDS) ? getStringFieldF(&expr, CSUB_EXPR_COORDS) : "";
+        std::string q        = getStringFieldF(&expr, CSUB_EXPR_Q);
+        std::string mq       = getStringFieldF(&expr, CSUB_EXPR_MQ);
+        std::string georel   = getStringFieldF(&expr, CSUB_EXPR_GEOREL);
+        std::string geometry = getStringFieldF(&expr, CSUB_EXPR_GEOM);
+        std::string coords   = getStringFieldF(&expr, CSUB_EXPR_COORDS);
 
         trigs->fillExpression(georel, geometry, coords);
 
@@ -3428,8 +3430,8 @@ static void updateEntity
 
   // The hasField() check is needed as the entity could have been created with very old Orion version not
   // supporting modification/creation dates
-  notifyCerP->contextElement.entityId.creDate = r.hasField(ENT_CREATION_DATE)     ? getNumberFieldAsDoubleF(&r, ENT_CREATION_DATE)     : -1;
-  notifyCerP->contextElement.entityId.modDate = r.hasField(ENT_MODIFICATION_DATE) ? getNumberFieldAsDoubleF(&r, ENT_MODIFICATION_DATE) : -1;
+  notifyCerP->contextElement.entityId.creDate = getNumberFieldAsDoubleF(&r, ENT_CREATION_DATE);
+  notifyCerP->contextElement.entityId.modDate = getNumberFieldAsDoubleF(&r, ENT_MODIFICATION_DATE);
 
   // The logic to detect notification loops is to check that the correlator in the request differs from the last one seen for the entity and,
   // in addition, the request was sent due to a custom notification

--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -1647,7 +1647,7 @@ bool entitiesQuery
     docs++;
 
     LM_T(LmtMongo, ("retrieved document [%d]: '%s'", docs, r.toString().c_str()));
-    ContextElementResponse*  cer = new ContextElementResponse(r, attrL, includeEmpty, apiVersion);
+    ContextElementResponse*  cer = new ContextElementResponse(&r, attrL, includeEmpty, apiVersion);
 
     addDatesForAttrs(cer, metadataList.lookup(NGSI_MD_DATECREATED), metadataList.lookup(NGSI_MD_DATEMODIFIED));
 

--- a/src/lib/ngsi/ContextElementResponse.cpp
+++ b/src/lib/ngsi/ContextElementResponse.cpp
@@ -133,8 +133,8 @@ static bool includedAttribute(const ContextAttribute* attrP, const StringList& a
 */
 ContextElementResponse::ContextElementResponse
 (
-  const mongo::BSONObj&  entityDoc,
-  const StringList&   attrL,
+  const mongo::BSONObj*  entityDocP,
+  const StringList&      attrL,
   bool                   includeEmpty,
   ApiVersion             apiVersion
 )
@@ -142,7 +142,7 @@ ContextElementResponse::ContextElementResponse
   prune = false;
 
   // Entity
-  BSONObj id = getFieldF(&entityDoc, "_id").embeddedObject();
+  BSONObj id = getFieldF(entityDocP, "_id").embeddedObject();
 
   const char* entityId   = getStringFieldF(&id, ENT_ENTITY_ID);
   const char* entityType = id.hasField(ENT_ENTITY_TYPE) ? getStringFieldF(&id, ENT_ENTITY_TYPE) : "";
@@ -152,10 +152,10 @@ ContextElementResponse::ContextElementResponse
 
   /* Get the location attribute (if it exists) */
   std::string locAttr;
-  if (entityDoc.hasElement(ENT_LOCATION))
+  if (entityDocP->hasElement(ENT_LOCATION))
   {
     BSONObj objField;
-    getObjectFieldF(&objField, &entityDoc, ENT_LOCATION);
+    getObjectFieldF(&objField, entityDocP, ENT_LOCATION);
     locAttr = getStringFieldF(&objField, ENT_LOCATION_ATTRNAME);
   }
 
@@ -167,7 +167,7 @@ ContextElementResponse::ContextElementResponse
   BSONObj                attrs;
   std::set<std::string>  attrNames;
 
-  getObjectFieldF(&attrs, &entityDoc, ENT_ATTRS);
+  getObjectFieldF(&attrs, entityDocP, ENT_ATTRS);
   attrs.getFieldNames(attrNames);
   for (std::set<std::string>::iterator i = attrNames.begin(); i != attrNames.end(); ++i)
   {
@@ -318,14 +318,14 @@ ContextElementResponse::ContextElementResponse
   }
 
   /* Set creDate and modDate at entity level */
-  if (entityDoc.hasField(ENT_CREATION_DATE))
+  if (entityDocP->hasField(ENT_CREATION_DATE))
   {
-    contextElement.entityId.creDate = getNumberFieldAsDoubleF(&entityDoc, ENT_CREATION_DATE);
+    contextElement.entityId.creDate = getNumberFieldAsDoubleF(entityDocP, ENT_CREATION_DATE);
   }
 
-  if (entityDoc.hasField(ENT_MODIFICATION_DATE))
+  if (entityDocP->hasField(ENT_MODIFICATION_DATE))
   {
-    contextElement.entityId.modDate = getNumberFieldAsDoubleF(&entityDoc, ENT_MODIFICATION_DATE);
+    contextElement.entityId.modDate = getNumberFieldAsDoubleF(entityDocP, ENT_MODIFICATION_DATE);
   }
 }
 

--- a/src/lib/ngsi/ContextElementResponse.h
+++ b/src/lib/ngsi/ContextElementResponse.h
@@ -59,7 +59,7 @@ typedef struct ContextElementResponse
   ContextElementResponse();
   ContextElementResponse(EntityId* eP, ContextAttribute* aP);
   ContextElementResponse(ContextElementResponse* cerP);
-  ContextElementResponse(const mongo::BSONObj&  entityDoc,
+  ContextElementResponse(const mongo::BSONObj*  entityDocP,
                          const StringList&      attrL,
                          bool                   includeEmpty = true,
                          ApiVersion             apiVersion   = V1);


### PR DESCRIPTION
Performance:
* Removed all unnecessary calls to getField in MongoCommonUpdate.cpp
* ContextElementResponse constructor + updateEntity now take a pointer to a BSONObj, not a copy