### PR TITLE
std::string to char pointer for four mongoUpdateContext params

### DIFF
--- a/src/lib/mongoBackend/mongoUpdateContext.cpp
+++ b/src/lib/mongoBackend/mongoUpdateContext.cpp
@@ -52,12 +52,12 @@ HttpStatusCode mongoUpdateContext
 (
   UpdateContextRequest*                 requestP,
   UpdateContextResponse*                responseP,
-  const std::string&                    tenant,
+  const char*                           tenant,
   const std::vector<std::string>&       servicePathV,
   std::map<std::string, std::string>&   uriParams,    // FIXME P7: we need this to implement "restriction-based" filters
-  const std::string&                    xauthToken,
-  const std::string&                    fiwareCorrelator,
-  const std::string&                    ngsiV2AttrsFormat,
+  const char*                           xauthToken,
+  const char*                           fiwareCorrelator,
+  const char*                           ngsiV2AttrsFormat,
   ApiVersion                            apiVersion,
   Ngsiv2Flavour                         ngsiv2Flavour
 )

--- a/src/lib/mongoBackend/mongoUpdateContext.h
+++ b/src/lib/mongoBackend/mongoUpdateContext.h
@@ -43,12 +43,12 @@ extern HttpStatusCode mongoUpdateContext
 (
   UpdateContextRequest*                 requestP,
   UpdateContextResponse*                responseP,
-  const std::string&                    tenant,
+  const char*                           tenant,
   const std::vector<std::string>&       servicePathV,
   std::map<std::string, std::string>&   uriParams,    // FIXME P7: we need this to implement "restriction-based" filters
-  const std::string&                    xauthToken,
-  const std::string&                    fiwareCorrelator,
-  const std::string&                    ngsiV2AttrsFormat,
+  const char*                           xauthToken,
+  const char*                           fiwareCorrelator,
+  const char*                           ngsiV2AttrsFormat,
   ApiVersion                            apiVersion       = V1,
   Ngsiv2Flavour                         ngsiv2Flavour    = NGSIV2_NO_FLAVOUR
 );

--- a/src/lib/orionld/serviceRoutines/orionldPatchAttribute.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchAttribute.cpp
@@ -849,9 +849,9 @@ bool orionldPatchAttribute(ConnectionInfo* ciP)
                                                    orionldState.tenant,
                                                    ciP->servicePathV,
                                                    ciP->uriParam,
-                                                   ciP->httpHeaders.xauthToken,
-                                                   ciP->httpHeaders.correlator,
-                                                   ciP->httpHeaders.ngsiv2AttrsFormat,
+                                                   ciP->httpHeaders.xauthToken.c_str(),
+                                                   ciP->httpHeaders.correlator.c_str(),
+                                                   ciP->httpHeaders.ngsiv2AttrsFormat.c_str(),
                                                    ciP->apiVersion,
                                                    NGSIV2_NO_FLAVOUR);
 

--- a/src/lib/orionld/serviceRoutines/orionldPatchEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchEntity.cpp
@@ -326,9 +326,9 @@ bool orionldPatchEntity(ConnectionInfo* ciP)
                                                      orionldState.tenant,
                                                      ciP->servicePathV,
                                                      ciP->uriParam,
-                                                     ciP->httpHeaders.xauthToken,
-                                                     ciP->httpHeaders.correlator,
-                                                     ciP->httpHeaders.ngsiv2AttrsFormat,
+                                                     ciP->httpHeaders.xauthToken.c_str(),
+                                                     ciP->httpHeaders.correlator.c_str(),
+                                                     ciP->httpHeaders.ngsiv2AttrsFormat.c_str(),
                                                      ciP->apiVersion,
                                                      NGSIV2_NO_FLAVOUR);
 

--- a/src/lib/orionld/serviceRoutines/orionldPostBatchCreate.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostBatchCreate.cpp
@@ -270,9 +270,9 @@ bool orionldPostBatchCreate(ConnectionInfo* ciP)
                                                      orionldState.tenant,
                                                      ciP->servicePathV,
                                                      ciP->uriParam,
-                                                     ciP->httpHeaders.xauthToken,
-                                                     ciP->httpHeaders.correlator,
-                                                     ciP->httpHeaders.ngsiv2AttrsFormat,
+                                                     ciP->httpHeaders.xauthToken.c_str(),
+                                                     ciP->httpHeaders.correlator.c_str(),
+                                                     ciP->httpHeaders.ngsiv2AttrsFormat.c_str(),
                                                      ciP->apiVersion,
                                                      NGSIV2_NO_FLAVOUR);
 

--- a/src/lib/orionld/serviceRoutines/orionldPostBatchUpdate.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostBatchUpdate.cpp
@@ -288,9 +288,9 @@ bool orionldPostBatchUpdate(ConnectionInfo* ciP)
                                                    orionldState.tenant,
                                                    ciP->servicePathV,
                                                    ciP->uriParam,
-                                                   ciP->httpHeaders.xauthToken,
-                                                   ciP->httpHeaders.correlator,
-                                                   ciP->httpHeaders.ngsiv2AttrsFormat,
+                                                   ciP->httpHeaders.xauthToken.c_str(),
+                                                   ciP->httpHeaders.correlator.c_str(),
+                                                   ciP->httpHeaders.ngsiv2AttrsFormat.c_str(),
                                                    ciP->apiVersion,
                                                    NGSIV2_NO_FLAVOUR);
 

--- a/src/lib/orionld/serviceRoutines/orionldPostBatchUpsert.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostBatchUpsert.cpp
@@ -387,9 +387,9 @@ bool orionldPostBatchUpsert(ConnectionInfo* ciP)
                                                    orionldState.tenant,
                                                    ciP->servicePathV,
                                                    ciP->uriParam,
-                                                   ciP->httpHeaders.xauthToken,
-                                                   ciP->httpHeaders.correlator,
-                                                   ciP->httpHeaders.ngsiv2AttrsFormat,
+                                                   ciP->httpHeaders.xauthToken.c_str(),
+                                                   ciP->httpHeaders.correlator.c_str(),
+                                                   ciP->httpHeaders.ngsiv2AttrsFormat.c_str(),
                                                    ciP->apiVersion,
                                                    NGSIV2_NO_FLAVOUR);
 

--- a/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
@@ -400,9 +400,9 @@ bool orionldPostEntities(ConnectionInfo* ciP)
                                                    orionldState.tenant,
                                                    ciP->servicePathV,
                                                    ciP->uriParam,
-                                                   ciP->httpHeaders.xauthToken,
-                                                   ciP->httpHeaders.correlator,
-                                                   ciP->httpHeaders.ngsiv2AttrsFormat,
+                                                   ciP->httpHeaders.xauthToken.c_str(),
+                                                   ciP->httpHeaders.correlator.c_str(),
+                                                   ciP->httpHeaders.ngsiv2AttrsFormat.c_str(),
                                                    ciP->apiVersion,
                                                    NGSIV2_NO_FLAVOUR);
 

--- a/src/lib/orionld/serviceRoutines/orionldPostEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntity.cpp
@@ -467,9 +467,9 @@ bool orionldPostEntity(ConnectionInfo* ciP)
                                 orionldState.tenant,
                                 ciP->servicePathV,
                                 ciP->uriParam,
-                                ciP->httpHeaders.xauthToken,
-                                ciP->httpHeaders.correlator,
-                                ciP->httpHeaders.ngsiv2AttrsFormat,
+                                ciP->httpHeaders.xauthToken.c_str(),
+                                ciP->httpHeaders.correlator.c_str(),
+                                ciP->httpHeaders.ngsiv2AttrsFormat.c_str(),
                                 ciP->apiVersion,
                                 NGSIV2_NO_FLAVOUR);
 

--- a/src/lib/serviceRoutines/postUpdateContext.cpp
+++ b/src/lib/serviceRoutines/postUpdateContext.cpp
@@ -494,12 +494,12 @@ std::string postUpdateContext
   HttpStatusCode httpStatusCode;
   TIMED_MONGO(httpStatusCode = mongoUpdateContext(upcrP,
                                                   upcrsP,
-                                                  ciP->tenant,
+                                                  ciP->tenant.c_str(),
                                                   ciP->servicePathV,
                                                   ciP->uriParam,
-                                                  ciP->httpHeaders.xauthToken,
-                                                  ciP->httpHeaders.correlator,
-                                                  ciP->httpHeaders.ngsiv2AttrsFormat,
+                                                  ciP->httpHeaders.xauthToken.c_str(),
+                                                  ciP->httpHeaders.correlator.c_str(),
+                                                  ciP->httpHeaders.ngsiv2AttrsFormat.c_str(),
                                                   ciP->apiVersion,
                                                   ngsiV2Flavour));
 


### PR DESCRIPTION
Performance:
Changed four `std::string&` params of mongoUpdateContext to `char*`