### PR TITLE
Fixed issue #892 - or at least a very first draft

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
 * Issue #885  Batch Ops responds with a corrupted payload body if Accept: application/ld+json - fix respond with application/json
 * Issue #280  Performace: saving all DB collection paths ONCE in a tenant-struct instead of creating them before each and every use
+* Issue #892  Broker able to receive and act upon NGSI-LD notifications - very first implementation - needs further testing

--- a/src/app/orionld/orionldRestServices.cpp
+++ b/src/app/orionld/orionldRestServices.cpp
@@ -23,6 +23,7 @@
 * Author: Ken Zangelin
 */
 #include "orionld/serviceRoutines/orionldPostEntities.h"
+#include "orionld/serviceRoutines/orionldPostNotify.h"
 #include "orionld/serviceRoutines/orionldPostEntity.h"
 #include "orionld/serviceRoutines/orionldPostSubscriptions.h"
 #include "orionld/serviceRoutines/orionldPostRegistrations.h"
@@ -104,6 +105,7 @@ static OrionLdRestServiceSimplified postServiceV[] =
 {
   { "/ngsi-ld/v1/entities/*/attrs",                orionldPostEntity           },
   { "/ngsi-ld/v1/entities",                        orionldPostEntities         },
+  { "/ngsi-ld/ex/v1/notify",                       orionldPostNotify           },
   { "/ngsi-ld/v1/entityOperations/create",         orionldPostBatchCreate      },
   { "/ngsi-ld/v1/entityOperations/upsert",         orionldPostBatchUpsert      },
   { "/ngsi-ld/v1/entityOperations/update",         orionldPostBatchUpdate      },

--- a/src/lib/orionld/mongoCppLegacy/mongoCppLegacyTenantsGet.cpp
+++ b/src/lib/orionld/mongoCppLegacy/mongoCppLegacyTenantsGet.cpp
@@ -74,24 +74,10 @@ bool mongoCppLegacyTenantsGet(void)
       mongo::BSONObj  db   = dbV[ix].Obj();
       char*           name = mongoCppLegacyDbStringFieldGet(&db, "name");
 
-      LM_TMP(("TENANT: Got a mongo database named '%s'", name));
       if (strncmp(name, dbName, dbNameLen) == 0)
       {
-        // The prefix matches, now EOS or '-'
-        LM_TMP(("TENANT: first letter after prefix is: '%c' (0x%x)", name[dbNameLen], name[dbNameLen]));
-        if (name[dbNameLen] == 0)  // the base
-        {
-          LM_TMP(("TENANT: it's the base: '%s'", name));
-        }
-        else if (name[dbNameLen] != '-')  // not a valid tenant (orionld, for example)
-        {
-          LM_TMP(("TENANT: it's not a DB for the broker (no hyphen after dbPrefix): '%s'", name));
-        }
-        else if (name[dbNameLen + 1] == 0)
-        {
-          LM_TMP(("TENANT: invalid database name (hyphen there but no tenant): '%s'", name));
-        }
-        else
+        // The prefix matches, now '-' + tenant
+        if ((name[dbNameLen] == '-') && (name[dbNameLen + 1] != 0))
         {
           char* tenantName = &name[dbNameLen + 1];
 

--- a/src/lib/orionld/serviceRoutines/CMakeLists.txt
+++ b/src/lib/orionld/serviceRoutines/CMakeLists.txt
@@ -62,6 +62,7 @@ SET (SOURCES
     orionldPostTemporalEntities.cpp
     orionldPostContexts.cpp
     orionldDeleteContext.cpp
+    orionldPostNotify.cpp
 )
 
 # Include directories

--- a/src/lib/orionld/serviceRoutines/orionldNotify.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldNotify.cpp
@@ -125,7 +125,7 @@ static void responseTreat(OrionldNotificationInfo* niP, char* buf, int bufLen)
 
 // -----------------------------------------------------------------------------
 //
-// orionldNotify -
+// orionldNotify - SHOULD BE MOVED to another directory/library
 //
 // This function assumes that the vector orionldState.notificationInfo is
 // correctly filled in.

--- a/src/lib/orionld/serviceRoutines/orionldPostNotify.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostNotify.cpp
@@ -1,0 +1,79 @@
+/*
+*
+ Copyright 2021 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+#include "logMsg/logMsg.h"                                     // LM_*
+#include "logMsg/traceLevels.h"                                // Lmt*
+
+extern "C"
+{
+#include "kjson/KjNode.h"                                      // KjNode
+#include "kjson/kjLookup.h"                                    // kjLookup
+#include "kjson/kjClone.h"                                     // kjClone
+}
+
+#include "common/globals.h"                                    // parse8601Time
+#include "rest/ConnectionInfo.h"                               // ConnectionInfo
+
+#include "orionld/common/orionldState.h"                       // orionldState
+#include "orionld/common/orionldErrorResponse.h"               // orionldErrorResponseCreate
+#include "orionld/serviceRoutines/orionldPostBatchUpsert.h"    // orionldPostBatchUpsert
+#include "orionld/serviceRoutines/orionldPostNotify.h"         // Own interface
+
+
+
+// ----------------------------------------------------------------------------
+//
+// orionldPostNotify -
+//
+bool orionldPostNotify(ConnectionInfo* ciP)
+{
+  KjNode* dataArray = kjLookup(orionldState.requestTree, "data");
+
+  if (dataArray == NULL)
+  {
+    LM_W(("Invalid Notification (the 'data' member is missing)"));
+    orionldErrorResponseCreate(OrionldBadRequestData, "Invalid Notification", "The 'data' member is missing");
+    orionldState.httpStatusCode = SccBadRequest;
+    return false;
+  }
+
+  if (dataArray->type != KjArray)
+  {
+    LM_W(("Invalid Notification (the 'data' member is present but it is not a GSON Array - it is a JSON %s)", kjValueType(dataArray->type)));
+    orionldErrorResponseCreate(OrionldBadRequestData, "Invalid Notification", "The 'data' member is present but it is not an array");
+    orionldState.httpStatusCode = SccBadRequest;
+    return false;
+  }
+
+  //
+  // All good - letting BATCH UPSERT (update, not replace) take care of the request
+  // For this to work, I simply have to call the service routine, after:
+  // * Setting the "incoming tree" to point to the value of the "data" array
+  // * Setting the URI param "option" to "update"
+  //
+  orionldState.requestTree            = dataArray;
+  orionldState.uriParamOptions.update = true;
+
+  return orionldPostBatchUpsert(ciP);
+}

--- a/src/lib/orionld/serviceRoutines/orionldPostNotify.h
+++ b/src/lib/orionld/serviceRoutines/orionldPostNotify.h
@@ -1,0 +1,38 @@
+#ifndef SRC_LIB_ORIONLD_SERVICEROUTINES_ORIONLDPOSTNOTIFY_H_
+#define SRC_LIB_ORIONLD_SERVICEROUTINES_ORIONLDPOSTNOTIFY_H_
+
+/*
+*
+* Copyright 2018 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+#include "rest/ConnectionInfo.h"           // ConnectionInfo
+
+
+
+// ----------------------------------------------------------------------------
+//
+// orionldPostNotify -
+//
+extern bool orionldPostNotify(ConnectionInfo* ciP);
+
+#endif  // SRC_LIB_ORIONLD_SERVICEROUTINES_ORIONLDPOSTNOTIFY_H_

--- a/test/functionalTest/cases/0000_ngsild/ngsild_notify.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_notify.test
@@ -1,0 +1,190 @@
+# Copyright 2021 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Having one broker subscribe to another broker, and keep a copy of the entities incoming via notification
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+dbInit CP1
+brokerStart CB
+brokerStart CP1
+
+--SHELL--
+
+#
+# This is a test of the NGSI-LD /notify endpoint
+#
+# 01. Make CP1 subscribe to changes in E1 on CB
+# 02. Create entity E1 in the main broker - CB
+# 03. Query CP1 for Ei - see the same entity as in CB
+# 04. Modify E1 in CB
+# 05. Query CP1 for Ei - see the change propagated
+#
+
+
+echo "01. Make CP1 subscribe to changes in E1 on CB"
+echo "============================================="
+payload='{
+  "id": "urn:ngsi-ld:subscriptions:copy-e1",
+  "type": "Subscription",
+  "name": "notification on E1",
+  "entities": [
+    {
+      "id": "urn:ngsi-ld:entities:E1",
+      "type": "T1"
+    }
+  ],
+  "notification": {
+    "endpoint": {
+      "uri": "http://127.0.0.1:'${CP1_PORT}'/ngsi-ld/ex/v1/notify"
+    }
+  }
+}'
+orionCurl --url /ngsi-ld/v1/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo "02. Create entity E1 in the main broker - CB"
+echo "============================================"
+payload='{
+  "id": "urn:ngsi-ld:entities:E1",
+  "type": "T1",
+  "P1": {
+    "type": "Property",
+    "value": 1
+  },
+  "R1": {
+    "type": "Relationship",
+    "object": "urn:ngsi-ld:entities:E2"
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "03. Query CP1 for Ei - see the same entity as in CB"
+echo "==================================================="
+orionCurl --url /ngsi-ld/v1/entities?type=T1 --port $CP1_PORT
+echo
+echo
+
+
+echo "04. Modify E1 in CB"
+echo "==================="
+payload='{
+  "value": 2
+}'
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entities:E1/attrs/P1 -X PATCH --payload "$payload"
+echo
+echo
+
+
+echo "05. Query CP1 for Ei - see the change propagated"
+echo "================================================"
+orionCurl --url /ngsi-ld/v1/entities?type=T1 --port $CP1_PORT
+echo
+echo
+
+
+--REGEXPECT--
+01. Make CP1 subscribe to changes in E1 on CB
+=============================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:subscriptions:copy-e1
+Date: REGEX(.*)
+
+
+
+02. Create entity E1 in the main broker - CB
+============================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:entities:E1
+Date: REGEX(.*)
+
+
+
+03. Query CP1 for Ei - see the same entity as in CB
+===================================================
+HTTP/1.1 200 OK
+Content-Length: 145
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+[
+    {
+        "P1": {
+            "type": "Property",
+            "value": 1
+        },
+        "R1": {
+            "object": "urn:ngsi-ld:entities:E2",
+            "type": "Relationship"
+        },
+        "id": "urn:ngsi-ld:entities:E1",
+        "type": "T1"
+    }
+]
+
+
+04. Modify E1 in CB
+===================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+05. Query CP1 for Ei - see the change propagated
+================================================
+HTTP/1.1 200 OK
+Content-Length: 145
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+[
+    {
+        "P1": {
+            "type": "Property",
+            "value": 2
+        },
+        "R1": {
+            "object": "urn:ngsi-ld:entities:E2",
+            "type": "Relationship"
+        },
+        "id": "urn:ngsi-ld:entities:E1",
+        "type": "T1"
+    }
+]
+
+
+--TEARDOWN--
+brokerStop CB
+brokerStop CP1
+dbDrop CB
+dbDrop CP1


### PR DESCRIPTION
Orion-LD is now able to receive NGSI-LD notifications, and act upon the notifications by creating/updating entities.
The entities in the "data" field of a notification are treated as a BATCH UPSERT, with the "update" flag set.

It works, at least in a very simple case, but further tests need to be performed.
Possibly also the feature to include a different tenant for the notifications might be implemented and will also have to be tersted in such case.
