### PR TITLE
Implemented part of issue #926

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -11,3 +11,4 @@
 * Issue #280  HTTP header NGSILD-Tenant (not FIWARE-Service) in notifications on NGSI-LD subscriptions
 * Issue #922  Dynamic allocation of GeoProperties array
 * Issue #917  No notification when a compound value is updated without modification
+* Issue #926  GET local location of a cached context using URI params location and url - to be able to refresh it in the context cache

--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -136,6 +136,8 @@ typedef struct OrionldUriParams
   bool      prettyPrint;
   int       spaces;
   char*     subscriptionId;
+  bool      location;
+  char*     url;
 } OrionldUriParams;
 
 

--- a/src/lib/orionld/rest/OrionLdRestService.h
+++ b/src/lib/orionld/rest/OrionLdRestService.h
@@ -137,6 +137,9 @@ typedef struct OrionLdRestServiceSimplifiedVector
 #define ORIONLD_URIPARAM_PRETTYPRINT          (1 << 22)
 #define ORIONLD_URIPARAM_SPACES               (1 << 23)
 #define ORIONLD_URIPARAM_SUBSCRIPTION_ID      (1 << 24)
+#define ORIONLD_URIPARAM_LOCATION             (1 << 25)
+#define ORIONLD_URIPARAM_URL                  (1 << 27)
+
 
 
 // -----------------------------------------------------------------------------

--- a/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
@@ -436,6 +436,26 @@ static MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const
     orionldState.uriParams.subscriptionId  = (char*) value;
     orionldState.uriParams.mask           |= ORIONLD_URIPARAM_SUBSCRIPTION_ID;
   }
+  else if (SCOMPARE9(key, 'l', 'o', 'c', 'a', 't', 'i', 'o', 'n', 0))
+  {
+    if (strcmp(value, "true") == 0)
+      orionldState.uriParams.location = true;
+    else if (strcmp(value, "false") == 0)
+      orionldState.uriParams.location = false;
+    else
+    {
+      orionldErrorResponseCreate(OrionldBadRequestData, "Invalid value for uri parameter 'location'", value);
+      orionldState.httpStatusCode = 400;
+      return MHD_YES;
+    }
+
+    orionldState.uriParams.mask |= ORIONLD_URIPARAM_LOCATION;
+  }
+  else if (SCOMPARE4(key, 'u', 'r', 'l', 0))
+  {
+    orionldState.uriParams.url   = (char*) value;
+    orionldState.uriParams.mask |= ORIONLD_URIPARAM_URL;
+  }
   else
   {
     LM_W(("Bad Input (unknown URI parameter: '%s')", key));

--- a/src/lib/orionld/rest/orionldServiceInit.cpp
+++ b/src/lib/orionld/rest/orionldServiceInit.cpp
@@ -440,6 +440,7 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
   else if (serviceP->serviceRoutine == orionldGetDbIndexes)
   {
     serviceP->options  = 0;  // Tenant is Ignored
+
     serviceP->options |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
     serviceP->options |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
     serviceP->options |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED;
@@ -449,6 +450,8 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
     serviceP->options  = 0;  // Tenant is Ignored
 
     serviceP->uriParams |= ORIONLD_URIPARAM_DETAILS;
+    serviceP->uriParams |= ORIONLD_URIPARAM_LOCATION;
+    serviceP->uriParams |= ORIONLD_URIPARAM_URL;
 
     serviceP->options   |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
     serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;

--- a/test/functionalTest/cases/0000_ngsild/ngsild_context_location.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_context_location.test
@@ -1,0 +1,122 @@
+# Copyright 2021 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+GET the location of an @context
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+dbDrop orionld
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Create an entity with a context, only to put the context in the context cache
+# 02. GET the local location of the context from step 1 and save its URL
+# 03. DELETE the context from the cache
+# 04. Attempt to GET the context again - see 404 Not Found
+#
+
+echo "01. Create an entity with a context, only to put the context in the context cache"
+echo "================================================================================="
+payload='{
+  "id": "urn:ngsi-ld:entities:E1",
+  "type": "T",
+  "A3": {
+    "type": "Property",
+    "value": 1
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+echo
+echo
+
+
+echo "02. GET the local location of the context from step 1 and save its URL"
+echo "======================================================================"
+orionCurl --url '/ngsi-ld/v1/jsonldContexts?location=true&url=https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld'
+contextUrl=$(cat /tmp/httpHeaders.out | grep 'Location' | awk '{ print $2}')
+echo contextUrl: $contextUrl
+echo
+echo
+
+
+echo "03. DELETE the context from the cache"
+echo "====================================="
+orionCurl --url $contextUrl -X DELETE
+echo
+echo
+
+
+echo "04. Attempt to GET the context again - see 404 Not Found"
+echo "========================================================"
+orionCurl --url '/ngsi-ld/v1/jsonldContexts?location=true&url=https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld'
+echo
+echo
+
+
+--REGEXPECT--
+01. Create an entity with a context, only to put the context in the context cache
+=================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:entities:E1
+Date: REGEX(.*)
+
+
+
+02. GET the local location of the context from step 1 and save its URL
+======================================================================
+HTTP/1.1 200 OK
+Content-Length: 0
+Location: /ngsi-ld/v1/jsonldContexts/REGEX(.*)
+Date: REGEX(.*)
+
+contextUrl: /ngsi-ld/v1/jsonldContexts/REGEX(.*)
+
+
+03. DELETE the context from the cache
+=====================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+04. Attempt to GET the context again - see 404 Not Found
+========================================================
+HTTP/1.1 404 Not Found
+Content-Length: 176
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld",
+    "title": "Context Not Found",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/0000_ngsild/ngsild_context_location_errors.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_context_location_errors.test
@@ -1,0 +1,128 @@
+# Copyright 2021 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Error handling for GET the location of an @context
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+dbDrop orionld
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Attempt to GET a cached context with only 'location' URI param set
+# 02. Attempt to GET a cached context with only 'url' URI param set
+# 03. Attempt to GET a cached context with 'details' set
+# 04. Attempt to GET a cached context that doesn't exist
+#
+
+echo "01. Attempt to GET a cached context with only 'location' URI param set"
+echo "======================================================================"
+orionCurl --url '/ngsi-ld/v1/jsonldContexts?location=true'
+echo
+echo
+
+
+echo "02. Attempt to GET a cached context with only 'url' URI param set"
+echo "================================================================="
+orionCurl --url '/ngsi-ld/v1/jsonldContexts?url=https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld'
+echo
+echo
+
+
+echo "03. Attempt to GET a cached context with 'details' set"
+echo "======================================================"
+orionCurl --url '/ngsi-ld/v1/jsonldContexts?location=true&url=https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld&details=true'
+echo
+echo
+
+
+echo "04. Attempt to GET a cached context that doesn't exist"
+echo "======================================================"
+orionCurl --url '/ngsi-ld/v1/jsonldContexts?location=true&url=https://fiware.github.io/NGSI-LD_TestSuite/ldContext/nothing.jsonld'
+echo
+echo
+
+
+--REGEXPECT--
+01. Attempt to GET a cached context with only 'location' URI param set
+======================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 147
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "'location' present but 'url' missing",
+    "title": "Incompatible URI parameters",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+02. Attempt to GET a cached context with only 'url' URI param set
+=================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 147
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "'url' present but 'location' missing",
+    "title": "Incompatible URI parameters",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+03. Attempt to GET a cached context with 'details' set
+======================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 155
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "'location' and 'url' don't support 'details'",
+    "title": "Incompatible URI parameters",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+04. Attempt to GET a cached context that doesn't exist
+======================================================
+HTTP/1.1 404 Not Found
+Content-Length: 168
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/nothing.jsonld",
+    "title": "Context Not Found",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
Fixed part of issue #926

The broker now responds with the complete local URL (ending with the local ID) of a cached context in the `Location` header,
of the request `GET /ngsi-ld/v1/jsonldContexts?location=true&url=XXX`.

E.g., to DELETE the cached copy of the context http:a.b.c/context1.jsonld:
```
% curl "localhost:1026/jsonldContexts?location=true&url=http:a.b.c/context1.jsonld" --dump-header /tmp/hdrs
% url=$(cat /tmp/hdrs | grep Location | awk '{ print $2 }')
% curl localhost:1026$url -X DELETE
```
To delete the context from the cache, in order to refresh it, simply use the URL from the response Location header.
The context is then removed from the cache and will be re-downloaded when needed.