### PR TITLE
Finished issue #926

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -50,6 +50,13 @@ jobs:
         image: mongo:4.0
         ports:
           - 27017:27017
+      context-server:
+        image: wistefan/context-server:0.2.0
+        env:
+          MEMORY_ENABLED: true
+        ports:
+          - 7080:8080
+
     strategy:
       fail-fast: true
       matrix:

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -12,3 +12,6 @@
 * Issue #922  Dynamic allocation of GeoProperties array
 * Issue #917  No notification when a compound value is updated without modification
 * Issue #926  GET local location of a cached context using URI params location and url - to be able to refresh it in the context cache
+* Issue #926  DELETE /contexts/<contextId> now also accepts complete URL as "contextId"
+* Issue #926  DELETE /contexts/<contextId> able to reload contexts (URI param ?reload=true)
+

--- a/docker/Dockerfile-test
+++ b/docker/Dockerfile-test
@@ -2,7 +2,7 @@ FROM fiware/orion-ld-base
 
 ARG PATH_TO_SRC='/opt/orion/'
 
-RUN  apt-get install -y lcov
+RUN  apt-get install -y lcov docker
 
 COPY . ${PATH_TO_SRC}
 WORKDIR ${PATH_TO_SRC}

--- a/docker/Dockerfile-test
+++ b/docker/Dockerfile-test
@@ -2,7 +2,7 @@ FROM fiware/orion-ld-base
 
 ARG PATH_TO_SRC='/opt/orion/'
 
-RUN  apt-get install -y lcov docker
+RUN  apt-get install -y lcov
 
 COPY . ${PATH_TO_SRC}
 WORKDIR ${PATH_TO_SRC}

--- a/scripts/cServer.sh
+++ b/scripts/cServer.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Copyright 2021 Telefonica Investigacion y Desarrollo, S.A.U
+# 
+# This file is part of Orion Context Broker.
+#   
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the 
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+# 
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+set -e
+
+docker run --rm -d --name context-server -p 7080:8080  -e MEMORY_ENABLED=true -e LOGGERS_LEVELS_ROOT=TRACE wistefan/context-server
+
+timeout 30 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:7080/health)" != "200" ]]; do sleep 5; done' || false

--- a/src/lib/orionld/common/orionldRequestSend.cpp
+++ b/src/lib/orionld/common/orionldRequestSend.cpp
@@ -212,7 +212,6 @@ bool orionldRequestSend
 
   struct curl_slist* headers = NULL;
 
-
   if (contentType != NULL)  // then also payload and payloadLen is supplied
   {
     char contentTypeHeader[128];

--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -138,6 +138,7 @@ typedef struct OrionldUriParams
   char*     subscriptionId;
   bool      location;
   char*     url;
+  bool      reload;
 } OrionldUriParams;
 
 
@@ -308,6 +309,7 @@ typedef struct OrionldConnectionState
   KjNode*                 geoPropertyNode;     // Must point to the "value" of the GeoProperty (for Retrieve Entity only)
   bool                    geoPropertyMissing;  // The gro-property is really not present in the DB - must be NULL is the response (for Retrieve Entity only)
   KjNode*                 geoPropertyNodes;    // object with "entityId": { <GeoProperty value> }, one per entity (for Query Entities
+
 
   // Error Handling
   OrionldProblemDetails   pd;

--- a/src/lib/orionld/context/orionldContextFromUrl.cpp
+++ b/src/lib/orionld/context/orionldContextFromUrl.cpp
@@ -253,7 +253,7 @@ OrionldContext* orionldContextFromUrl(char* url, char* id, OrionldProblemDetails
   if (buffer == NULL)
   {
     // orionldContextDownload fills in pdP
-    LM_W(("Bad Input? (%s: %s)", pdP->title, pdP->detail));
+    LM_W(("Bad Input? (%s: %s). URL: %s", pdP->title, pdP->detail, url));
     return NULL;
   }
 

--- a/src/lib/orionld/rest/OrionLdRestService.h
+++ b/src/lib/orionld/rest/OrionLdRestService.h
@@ -139,6 +139,7 @@ typedef struct OrionLdRestServiceSimplifiedVector
 #define ORIONLD_URIPARAM_SUBSCRIPTION_ID      (1 << 24)
 #define ORIONLD_URIPARAM_LOCATION             (1 << 25)
 #define ORIONLD_URIPARAM_URL                  (1 << 27)
+#define ORIONLD_URIPARAM_RELOAD               (1 << 28)
 
 
 

--- a/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
@@ -456,6 +456,11 @@ static MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const
     orionldState.uriParams.url   = (char*) value;
     orionldState.uriParams.mask |= ORIONLD_URIPARAM_URL;
   }
+  else if (SCOMPARE7(key, 'r', 'e', 'l', 'o', 'a', 'd', 0))
+  {
+    orionldState.uriParams.reload = true;
+    orionldState.uriParams.mask  |= ORIONLD_URIPARAM_RELOAD;
+  }
   else
   {
     LM_W(("Bad Input (unknown URI parameter: '%s')", key));

--- a/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
@@ -695,8 +695,6 @@ bool uriParamSupport(uint32_t supported, uint32_t given, char** detailP)
 //   25. Cleanup
 //   26. DONE
 //
-//
-//
 MHD_Result orionldMhdConnectionTreat(ConnectionInfo* ciP)
 {
   bool     contextToBeCashed    = false;

--- a/src/lib/orionld/rest/orionldServiceInit.cpp
+++ b/src/lib/orionld/rest/orionldServiceInit.cpp
@@ -49,7 +49,6 @@ extern "C"
 #include "orionld/context/orionldContextInit.h"                      // orionldContextInit
 #include "orionld/rest/OrionLdRestService.h"                         // OrionLdRestService, ORION_LD_SERVICE_PREFIX_LEN
 #include "orionld/rest/temporaryErrorPayloads.h"                     // Temporary Error Payloads
-#include "orionld/rest/uriParamName.h"                               // uriParamName
 #include "orionld/serviceRoutines/orionldPostEntities.h"             // orionldPostEntities
 #include "orionld/serviceRoutines/orionldPostEntity.h"               // orionldPostEntity
 #include "orionld/serviceRoutines/orionldGetEntities.h"              // orionldGetEntities
@@ -83,6 +82,7 @@ extern "C"
 #include "orionld/serviceRoutines/orionldGetContexts.h"              // orionldGetContexts
 #include "orionld/serviceRoutines/orionldGetContext.h"               // orionldGetContext
 #include "orionld/serviceRoutines/orionldPostContexts.h"             // orionldPostContexts
+#include "orionld/serviceRoutines/orionldDeleteContext.h"            // orionldDeleteContext
 #include "orionld/serviceRoutines/orionldPostNotify.h"               // orionldPostNotify
 
 #include "orionld/troe/troePostEntities.h"                           // troePostEntities
@@ -471,6 +471,17 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
     serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
     serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED;
     serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_TYPE_CHECK;
+  }
+  else if (serviceP->serviceRoutine == orionldDeleteContext)
+  {
+    serviceP->options  = 0;  // Tenant is Ignored
+
+    serviceP->options   |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
+    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
+    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED;
+    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_TYPE_CHECK;
+
+    serviceP->uriParams |= ORIONLD_URIPARAM_RELOAD;
   }
 
   if (troe)  // CLI Option to turn on Temporal Representation of Entities

--- a/src/lib/orionld/rest/uriParamName.cpp
+++ b/src/lib/orionld/rest/uriParamName.cpp
@@ -56,6 +56,12 @@ const char* uriParamName(uint32_t bit)
   case ORIONLD_URIPARAM_TIMEAT:              return "timeAt";
   case ORIONLD_URIPARAM_ENDTIMEAT:           return "endTimeAt";
   case ORIONLD_URIPARAM_DETAILS:             return "details";
+  case ORIONLD_URIPARAM_PRETTYPRINT:         return "prettyPrint";
+  case ORIONLD_URIPARAM_SPACES:              return "spaces";
+  case ORIONLD_URIPARAM_SUBSCRIPTION_ID:     return "subscriptionId";
+  case ORIONLD_URIPARAM_LOCATION:            return "location";
+  case ORIONLD_URIPARAM_URL:                 return "url";
+  case ORIONLD_URIPARAM_RELOAD:              return "reload";
   }
 
   return "unknown URI parameter";

--- a/src/lib/orionld/serviceRoutines/orionldDeleteContext.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldDeleteContext.cpp
@@ -33,7 +33,11 @@ extern "C"
 #include "rest/ConnectionInfo.h"
 #include "orionld/common/orionldState.h"                         // orionldState
 #include "orionld/common/orionldErrorResponse.h"                 // orionldErrorResponseCreate
+#include "orionld/context/orionldContextFromUrl.h"               // orionldContextFromUrl
+#include "orionld/contextCache/orionldContextCache.h"            // Context Cache Internals
+#include "orionld/contextCache/orionldContextCacheLookup.h"      // orionldContextCacheLookup
 #include "orionld/contextCache/orionldContextCacheDelete.h"      // orionldContextCacheDelete
+#include "orionld/contextCache/orionldContextCacheInsert.h"      // orionldContextCacheInsert
 #include "orionld/serviceRoutines/orionldDeleteContext.h"        // Own Interface
 
 
@@ -44,11 +48,77 @@ extern "C"
 //
 bool orionldDeleteContext(ConnectionInfo* ciP)
 {
-  if (orionldContextCacheDelete(orionldState.wildcard[0]) == false)
+  char*            id          = orionldState.wildcard[0];
+  OrionldContext*  oldContextP = orionldContextCacheLookup(id);
+
+  if (oldContextP == NULL)
   {
-    orionldErrorResponseCreate(OrionldResourceNotFound, "Context Not Found", orionldState.wildcard[0]);
+    LM_W(("Bad Input (context '%s' not found)", id));
+    orionldErrorResponseCreate(OrionldResourceNotFound, "Context Not Found", id);
     orionldState.httpStatusCode = 404;
     return false;
+  }
+
+
+  if (orionldState.uriParams.reload == true)
+  {
+    if (oldContextP->origin != OrionldContextDownloaded)
+    {
+      LM_W(("Bad Input (only cached contexts are subject for reload)"));
+      orionldErrorResponseCreate(OrionldBadRequestData, "Wrong type of context", "only cached contexts are subject for reload");
+      orionldState.httpStatusCode = 400;
+      return false;
+    }
+
+    //
+    // Remove old context from cache (and keep a pointer to) the old context
+    //
+    bool done = false;
+    for (int ix = 0; ix < orionldContextCacheSlotIx; ix++)
+    {
+      if (orionldContextCache[ix] == oldContextP)
+      {
+        orionldContextCache[ix] = NULL;
+        done = true;
+        break;
+      }
+    }
+
+    if (done == false)
+    {
+      LM_E(("Context Cache Error (context to be reloaded not found in cache)"));  // orionldContextCacheLookup found it though ... ???
+      orionldErrorResponseCreate(OrionldInternalError, "Context Cache Error", "context to be reloaded not found in cache");
+      orionldState.httpStatusCode = 500;
+      return false;
+    }
+
+    //
+    // Download, parse and insert the new context
+    // If anything goes wrong, the old context is put back into the cache
+    //
+    OrionldProblemDetails pd;
+    OrionldContext*       contextP = orionldContextFromUrl(oldContextP->url, oldContextP->id, &pd);
+
+    if (contextP == NULL)
+    {
+      LM_W(("orionldContextFromUrl(%s): %s: %s", oldContextP->url, pd.title, pd.detail));
+      orionldErrorResponseCreate(pd.type, pd.title, pd.detail);
+      orionldState.httpStatusCode = pd.status;
+
+      orionldContextCacheInsert(oldContextP);
+      return false;
+    }
+    contextP->createdAt      = oldContextP->createdAt;
+    contextP->usedAt         = orionldState.requestTime;
+  }
+  else
+  {
+    if (orionldContextCacheDelete(id) == false)
+    {
+      orionldState.httpStatusCode = 404;
+      orionldErrorResponseCreate(OrionldResourceNotFound, "Context Not Found", id);
+      return false;
+    }
   }
 
   orionldState.httpStatusCode = 204;

--- a/test/functionalTest/cases/0000_ngsild/ngsild_context-delete-and-reload.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_context-delete-and-reload.test
@@ -107,9 +107,9 @@ echo
 echo
 
 
-echo "07. Kill the context server"
+echo "07. Delete the context on the context server"
 echo "==========================="
-cServerStop
+cServerCurl --url /jsonldContexts/testContext --verb DELETE
 echo
 echo
 
@@ -200,7 +200,7 @@ Date: REGEX(.*)
 }
 
 
-07. Kill the context server
+07. Delete the context on the context server
 ===========================
 REGEX(.*)
 
@@ -237,4 +237,3 @@ Date: REGEX(.*)
 --TEARDOWN--
 brokerStop CB
 dbDrop CB
-cServerStop

--- a/test/functionalTest/cases/0000_ngsild/ngsild_context-delete-and-reload.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_context-delete-and-reload.test
@@ -28,7 +28,6 @@ export BROKER=orionld
 dbInit CB
 dbDrop orionld
 brokerStart CB
-cServerStart
 
 --SHELL--
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_context-delete-and-reload.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_context-delete-and-reload.test
@@ -38,9 +38,10 @@ brokerStart CB
 # 04. Update the context in the context server
 # 05. DELETE and RELOAD the context in the broker's context cache
 # 06. GET the context (from step 05) from the broker and make sure it's been updated
-# 07. Kill the context server
-# 08. Attempt to DELETE and RELOAD	the context in the broker's context cache - fails as the context server is dead
-# 09. GET the context from the broker and make sure it exists in the broker's context cache and is the same as in step 06
+# 07. Delete the context in the context server
+# 08. Get the context in the context server
+# 09. Attempt to DELETE and RELOAD the context in the broker's context cache - fails as the context server is dead
+# 10. GET the context from the broker and make sure it exists in the broker's context cache and is the same as in step 06
 #
 
 echo "01. Create a context in the context server"
@@ -107,20 +108,22 @@ echo
 echo
 
 
-echo "07. Delete the context on the context server"
-echo "==========================="
+echo "07. Delete the context in the context server"
+echo "============================================"
 cServerCurl --url /jsonldContexts/testContext --verb DELETE
 echo
 echo
 
-echo "08. Get the context on the context server"
-echo "==========================="
+
+echo "08. Get the context in the context server"
+echo "========================================="
 cServerCurl --url /jsonldContexts/testContext --verb GET
 echo
 echo
 
-echo "09. Attempt to DELETE and RELOAD	the context in the broker's context cache - fails as the context server is dead"
-echo "================================================================================================================="
+
+echo "09. Attempt to DELETE and RELOAD the context in the broker's context cache - fails as the context server is dead"
+echo "================================================================================================================"
 orionCurl --url '/ngsi-ld/v1/jsonldContexts/http://localhost:7080/jsonldContexts/testContext?reload=true' -X DELETE
 echo
 echo
@@ -205,17 +208,25 @@ Date: REGEX(.*)
 }
 
 
-07. Delete the context on the context server
-===========================
-REGEX(.*)
-
-08. Get the context on the context server
-===========================
-REGEX(.*)
+07. Delete the context in the context server
+============================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+connection: keep-alive
 
 
-09. Attempt to DELETE and RELOAD	the context in the broker's context cache - fails as the context server is dead
-=================================================================================================================
+
+08. Get the context in the context server
+=========================================
+HTTP/1.1 404 Not Found
+Content-Type: application/json
+content-length: 159
+connection: keep-alive
+
+{"type":"https://uri.etsi.org/ngsi-ld/errors/ResourceNotFound ","title":"Context does not exist.","status":404,"detail":"Requested context was not available."}
+
+09. Attempt to DELETE and RELOAD the context in the broker's context cache - fails as the context server is dead
+================================================================================================================
 HTTP/1.1 503 Service Unavailable
 Content-Length: 165
 Content-Type: application/json

--- a/test/functionalTest/cases/0000_ngsild/ngsild_context-delete-and-reload.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_context-delete-and-reload.test
@@ -113,15 +113,20 @@ cServerCurl --url /jsonldContexts/testContext --verb DELETE
 echo
 echo
 
+echo "08. Get the context on the context server"
+echo "==========================="
+cServerCurl --url /jsonldContexts/testContext --verb GET
+echo
+echo
 
-echo "08. Attempt to DELETE and RELOAD	the context in the broker's context cache - fails as the context server is dead"
+echo "09. Attempt to DELETE and RELOAD	the context in the broker's context cache - fails as the context server is dead"
 echo "================================================================================================================="
 orionCurl --url '/ngsi-ld/v1/jsonldContexts/http://localhost:7080/jsonldContexts/testContext?reload=true' -X DELETE
 echo
 echo
 
 
-echo "09. GET the context from the broker and make sure it exists in the broker's context cache and is the same as in step 06"
+echo "10. GET the context from the broker and make sure it exists in the broker's context cache and is the same as in step 06"
 echo "======================================================================================================================="
 orionCurl --url '/ngsi-ld/v1/jsonldContexts/http://localhost:7080/jsonldContexts/testContext'
 echo
@@ -204,8 +209,12 @@ Date: REGEX(.*)
 ===========================
 REGEX(.*)
 
+08. Get the context on the context server
+===========================
+REGEX(.*)
 
-08. Attempt to DELETE and RELOAD	the context in the broker's context cache - fails as the context server is dead
+
+09. Attempt to DELETE and RELOAD	the context in the broker's context cache - fails as the context server is dead
 =================================================================================================================
 HTTP/1.1 503 Service Unavailable
 Content-Length: 165
@@ -219,7 +228,7 @@ Date: REGEX(.*)
 }
 
 
-09. GET the context from the broker and make sure it exists in the broker's context cache and is the same as in step 06
+10. GET the context from the broker and make sure it exists in the broker's context cache and is the same as in step 06
 =======================================================================================================================
 HTTP/1.1 200 OK
 Content-Length: 56

--- a/test/functionalTest/cases/0000_ngsild/ngsild_context-delete-and-reload.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_context-delete-and-reload.test
@@ -1,0 +1,241 @@
+# Copyright 2021 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Delete AND RELOAD a @context from the context cache 
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+dbDrop orionld
+brokerStart CB
+cServerStart
+
+--SHELL--
+
+#
+# 01. Create a context in the context server
+# 02. Create an entity using the context from step 01, just to get the context inside the context cache of the broker
+# 03. GET the context (from step 01) from the broker
+# 04. Update the context in the context server
+# 05. DELETE and RELOAD the context in the broker's context cache
+# 06. GET the context (from step 05) from the broker and make sure it's been updated
+# 07. Kill the context server
+# 08. Attempt to DELETE and RELOAD	the context in the broker's context cache - fails as the context server is dead
+# 09. GET the context from the broker and make sure it exists in the broker's context cache and is the same as in step 06
+#
+
+echo "01. Create a context in the context server"
+echo "=========================================="
+payload='{
+  "@context": {
+    "p1": "urn:p1",
+    "p2": "urn:p2"
+  }
+}'
+cServerCurl --url /jsonldContexts/testContext --payload "$payload" --verb POST
+echo
+echo
+
+
+echo "02. Create an entity using the context from step 01, just to get the context inside the context cache of the broker"
+echo "==================================================================================================================="
+payload='{
+  "id": "urn:ngsi-ld:entities:E1",
+  "type": "T",
+  "A3": {
+    "type": "Property",
+    "value": 1
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload" -H 'Link: <http://localhost:7080/jsonldContexts/testContext>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+echo
+echo
+
+
+echo "03. GET the context (from step 01) from the broker"
+echo "=================================================="
+orionCurl --url '/ngsi-ld/v1/jsonldContexts/http://localhost:7080/jsonldContexts/testContext'
+echo
+echo
+
+
+echo "04. Update the context in the context server"
+echo "============================================"
+cServerCurl --url /jsonldContexts/testContext --verb DELETE
+echo
+payload='{
+  "@context": {
+    "p1": "urn:step04:p1",
+    "p2": "urn:step04:p2"
+  }
+}'
+cServerCurl --url /jsonldContexts/testContext --payload "$payload" --verb POST
+echo
+echo
+
+
+echo "05. DELETE and RELOAD the context in the broker's context cache"
+echo "==============================================================="
+orionCurl --url '/ngsi-ld/v1/jsonldContexts/http://localhost:7080/jsonldContexts/testContext?reload=true' -X DELETE
+echo
+echo
+
+
+echo "06. GET the context (from step 05) from the broker and make sure it's been updated"
+echo "=================================================================================="
+orionCurl --url '/ngsi-ld/v1/jsonldContexts/http://localhost:7080/jsonldContexts/testContext'
+echo
+echo
+
+
+echo "07. Kill the context server"
+echo "==========================="
+cServerStop
+echo
+echo
+
+
+echo "08. Attempt to DELETE and RELOAD	the context in the broker's context cache - fails as the context server is dead"
+echo "================================================================================================================="
+orionCurl --url '/ngsi-ld/v1/jsonldContexts/http://localhost:7080/jsonldContexts/testContext?reload=true' -X DELETE
+echo
+echo
+
+
+echo "09. GET the context from the broker and make sure it exists in the broker's context cache and is the same as in step 06"
+echo "======================================================================================================================="
+orionCurl --url '/ngsi-ld/v1/jsonldContexts/http://localhost:7080/jsonldContexts/testContext'
+echo
+echo
+
+
+--REGEXPECT--
+01. Create a context in the context server
+==========================================
+HTTP/1.1 201 Created
+Location: http://localhost:8080/jsonldContexts/testContext
+Date: REGEX(.*)
+connection: keep-alive
+transfer-encoding: chunked
+
+
+
+02. Create an entity using the context from step 01, just to get the context inside the context cache of the broker
+===================================================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:entities:E1
+Date: REGEX(.*)
+
+
+
+03. GET the context (from step 01) from the broker
+==================================================
+HTTP/1.1 200 OK
+Content-Length: 42
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "@context": {
+        "p1": "urn:p1",
+        "p2": "urn:p2"
+    }
+}
+
+
+04. Update the context in the context server
+============================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+connection: keep-alive
+
+
+HTTP/1.1 201 Created
+Location: http://localhost:8080/jsonldContexts/testContext
+Date: REGEX(.*)
+connection: keep-alive
+transfer-encoding: chunked
+
+
+
+05. DELETE and RELOAD the context in the broker's context cache
+===============================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+06. GET the context (from step 05) from the broker and make sure it's been updated
+==================================================================================
+HTTP/1.1 200 OK
+Content-Length: 56
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "@context": {
+        "p1": "urn:step04:p1",
+        "p2": "urn:step04:p2"
+    }
+}
+
+
+07. Kill the context server
+===========================
+REGEX(.*)
+
+
+08. Attempt to DELETE and RELOAD	the context in the broker's context cache - fails as the context server is dead
+=================================================================================================================
+HTTP/1.1 503 Service Unavailable
+Content-Length: 165
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "http://localhost:7080/jsonldContexts/testContext",
+    "title": "Unable to download context",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/LdContextNotAvailable"
+}
+
+
+09. GET the context from the broker and make sure it exists in the broker's context cache and is the same as in step 06
+=======================================================================================================================
+HTTP/1.1 200 OK
+Content-Length: 56
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "@context": {
+        "p1": "urn:step04:p1",
+        "p2": "urn:step04:p2"
+    }
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB
+cServerStop

--- a/test/functionalTest/cases/0000_ngsild/ngsild_context-delete-with-url.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_context-delete-with-url.test
@@ -1,0 +1,102 @@
+# Copyright 2021 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Delete a @context from the context cache with the URL
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+dbDrop orionld
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Create an entity with a context, only to put the context in the context cache
+# 02. DELETE the context from the cache with the URL
+# 03. Attempt to GET the context - see 404 Not Found
+#
+
+echo "01. Create an entity with a context, only to put the context in the context cache"
+echo "================================================================================="
+payload='{
+  "id": "urn:ngsi-ld:entities:E1",
+  "type": "T",
+  "A3": {
+    "type": "Property",
+    "value": 1
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+echo
+echo
+
+
+echo "02. DELETE the context from the cache with the URL"
+echo "=================================================="
+orionCurl --url /ngsi-ld/v1/jsonldContexts/https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld -X DELETE
+echo
+echo
+
+
+echo "03. Attempt to GET the context - see 404 Not Found"
+echo "=================================================="
+orionCurl --url '/ngsi-ld/v1/jsonldContexts?location=true&url=https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld'
+echo
+echo
+
+
+--REGEXPECT--
+01. Create an entity with a context, only to put the context in the context cache
+=================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:entities:E1
+Date: REGEX(.*)
+
+
+
+02. DELETE the context from the cache with the URL
+==================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+03. Attempt to GET the context - see 404 Not Found
+==================================================
+HTTP/1.1 404 Not Found
+Content-Length: 176
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld",
+    "title": "Context Not Found",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
* DELETE /jsonldContext/<context id> now also supports entire URL as "context id" - for non-hosted contexts.
* Functest against the context server, a test that tries to reload a context when the context server is not responding -
   making sure the old context is not lost upon failed "delete and reload".