### PR TITLE
Cross notification HTTP header

### DIFF
--- a/src/lib/common/RenderFormat.cpp
+++ b/src/lib/common/RenderFormat.cpp
@@ -51,8 +51,8 @@ const char* renderFormatToString(RenderFormat format, bool noDefault, bool useLe
   case NGSI_LD_V1_KEYVALUES:              return "keyValues";
   case NGSI_LD_V1_V2_NORMALIZED:          return "normalized";
   case NGSI_LD_V1_V2_KEYVALUES:           return "keyValues";
-  case NGSI_LD_V1_V2_NORMALIZED_COMPACT:  return "normalized-compacted";
-  case NGSI_LD_V1_V2_KEYVALUES_COMPACT:   return "keyValues-compacted";
+  case NGSI_LD_V1_V2_NORMALIZED_COMPACT:  return "normalized";
+  case NGSI_LD_V1_V2_KEYVALUES_COMPACT:   return "keyValues";
   case NO_FORMAT:
     if (noDefault == true)
     {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_ngsiv2_notification-compact.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_ngsiv2_notification-compact.test
@@ -398,7 +398,7 @@ POST http://REGEX(.*)/notify?subscriptionId=http://a.b.c/subs/sub01
 Fiware-Servicepath: /
 Content-Length: 146
 User-Agent: orion/REGEX(.*)
-Ngsiv2-Attrsformat: normalized-compacted
+Ngsiv2-Attrsformat: normalized
 Host: REGEX(.*)
 Accept: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
@@ -452,7 +452,7 @@ POST http://REGEX(.*)/notify?subscriptionId=http://a.b.c/subs/sub02
 Fiware-Servicepath: /
 Content-Length: 147
 User-Agent: orion/REGEX(.*)
-Ngsiv2-Attrsformat: normalized-compacted
+Ngsiv2-Attrsformat: normalized
 Host: REGEX(.*)
 Accept: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
@@ -506,7 +506,7 @@ POST http://REGEX(.*)/notify?subscriptionId=http://a.b.c/subs/sub03
 Fiware-Servicepath: /
 Content-Length: 148
 User-Agent: orion/REGEX(.*)
-Ngsiv2-Attrsformat: normalized-compacted
+Ngsiv2-Attrsformat: normalized
 Host: REGEX(.*)
 Accept: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
@@ -560,7 +560,7 @@ POST http://localhost:9997/notify?subscriptionId=http://a.b.c/subs/sub04
 Fiware-Servicepath: /
 Content-Length: 193
 User-Agent: REGEX(.*)
-Ngsiv2-Attrsformat: normalized-compacted
+Ngsiv2-Attrsformat: normalized
 Host: localhost:9997
 Accept: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
@@ -640,7 +640,7 @@ POST http://REGEX(.*)/notify?subscriptionId=http://a.b.c/subs/sub04
 Fiware-Servicepath: /
 Content-Length: 343
 User-Agent: orion/REGEX(.*)
-Ngsiv2-Attrsformat: normalized-compacted
+Ngsiv2-Attrsformat: normalized
 Host: REGEX(.*)
 Accept: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
@@ -700,7 +700,7 @@ POST http://REGEX(.*)/notify?subscriptionId=http://a.b.c/subs/sub04
 Fiware-Servicepath: /
 Content-Length: 491
 User-Agent: orion/REGEX(.*)
-Ngsiv2-Attrsformat: normalized-compacted
+Ngsiv2-Attrsformat: normalized
 Host: REGEX(.*)
 Accept: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"


### PR DESCRIPTION
Changed the attrs-format HTTP header in notifications, removing the "-compacted" part of:
* "normalized-compacted"
* "keyValues-compacted"

The creator of the subscription needs to remember that the notifications come in compact form and that expansion is needed to get "the truth".