### PR TITLE
Fixed a problem with the tenant cache for when more than one broker r…

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -18,3 +18,4 @@
 * Issue #925  Bigger char buffer for -troeHost CLI param
 * Issue #937  Fixed a Compilation Error in Ubuntu 20.04, RELEASE compilation
 * Issue #280  Changed values of HTTP header 'Ngsiv2-Attrsformat' from e.g. 'x-ngsiv2-normalized' to just 'normalized'
+* Issue #280  Fixed a problem with the tenant cache for when more than one broker runs against the same DB

--- a/scripts/testEnv.sh
+++ b/scripts/testEnv.sh
@@ -40,6 +40,7 @@ export MAXIMUM_WAIT=${MAXIMUM_WAIT:-30}
 # Ports
 #
 # o CB_PORT          - port where the main contextBroker listens for connections
+# o CB2_PORT         - port where the second contextBroker (on the same DB) listens for connections
 #
 # o CP1_PORT         - port where the first contextProvider listens for connections
 # o CP2_PORT         - port where the second contextProvider listens for connections
@@ -55,6 +56,7 @@ export MAXIMUM_WAIT=${MAXIMUM_WAIT:-30}
 # o MQTT_BROKER_HOST - host of the MQTT Broker
 
 export CB_PORT=${CB_PORT:-9999}
+export CB2_PORT=${CB2_PORT:-8999}
 export CP1_PORT=${CP1_PORT:-9801}
 export CP2_PORT=${CP2_PORT:-9802}
 export CP3_PORT=${CP3_PORT:-9803}
@@ -73,6 +75,7 @@ export MQTT_BROKER_HOST=${MQTT_BROKER_HOST:-localhost}
 # Log directories
 #
 # o CB_LOG_DIR        - directory where the 'main' broker keeps its log file
+# o CB2_LOG_DIR       - directory where the second broker keeps its log file
 # o CP1_LOG_DIR       - directory where contextProvider1 keeps its log file
 # o CP2_LOG_DIR       - directory where contextProvider2 keeps its log file
 # o CP3_LOG_DIR       - directory where contextProvider3 keeps its log file
@@ -80,6 +83,7 @@ export MQTT_BROKER_HOST=${MQTT_BROKER_HOST:-localhost}
 # o CP5_LOG_DIR       - directory where contextProvider5 keeps its log file
 #
 export CB_LOG_DIR=${CB_LOG_DIR:-/var/log/contextBroker}
+export CB2_LOG_DIR=${CB2_LOG_DIR:-/tmp/orion/logs/contextBroker2}
 export CP1_LOG_DIR=${CP1_LOG_DIR:-/tmp/orion/logs/contextProvider1}
 export CP2_LOG_DIR=${CP2_LOG_DIR:-/tmp/orion/logs/contextProvider2}
 export CP3_LOG_DIR=${CP3_LOG_DIR:-/tmp/orion/logs/contextProvider3}
@@ -93,6 +97,7 @@ export CP5_LOG_DIR=${CP5_LOG_DIR:-/tmp/orion/logs/contextProvider5}
 # PID files
 #
 # o CB_PID_FILE       - path to pid file for the main broker
+# o CB2_PID_FILE      - path to pid file for the second broker
 #
 # o CP1_PID_FILE      - path to pid file for the first context provider
 # o CP2_PID_FILE      - path to pid file for the second context provider
@@ -101,6 +106,7 @@ export CP5_LOG_DIR=${CP5_LOG_DIR:-/tmp/orion/logs/contextProvider5}
 # o CP5_PID_FILE      - path to pid file for the fifth context provider
 #
 export CB_PID_FILE=${CB_PID_FILE:-/tmp/orion_${CB_PORT}.pid}
+export CB2_PID_FILE=${CB2_PID_FILE:-/tmp/orion_${CB2_PORT}.pid}
 export CP1_PID_FILE=${CP1_PID_FILE:-/tmp/orion_${CP1_PORT}.pid}
 export CP2_PID_FILE=${CP2_PID_FILE:-/tmp/orion_${CP2_PORT}.pid}
 export CP3_PID_FILE=${CP3_PID_FILE:-/tmp/orion_${CP3_PORT}.pid}

--- a/src/lib/orionld/db/dbConfiguration.cpp
+++ b/src/lib/orionld/db/dbConfiguration.cpp
@@ -68,3 +68,4 @@ DbGeoIndexCreate                          dbGeoIndexCreate;
 DbIdIndexCreate                           dbIdIndexCreate;
 DbEntitiesQuery                           dbEntitiesQuery;
 DbDatasetGet                              dbDatasetGet;
+DbTenantExists                            dbTenantExists;

--- a/src/lib/orionld/db/dbConfiguration.h
+++ b/src/lib/orionld/db/dbConfiguration.h
@@ -96,6 +96,7 @@ typedef bool    (*DbGeoIndexCreate)(OrionldTenant* tenantP, const char* attrName
 typedef bool    (*DbIdIndexCreate)(OrionldTenant* tenantP);
 typedef KjNode* (*DbEntitiesQuery)(KjNode* entityInfoArrayP, KjNode* attrsP, QNode* qP, KjNode* geoqP, int limit, int offset, int* countP);
 typedef KjNode* (*DbDatasetGet)(const char* entityId, const char* attributeNameExpandedEq, const char* datasetId);
+typedef bool    (*DbTenantExists)(const char* tenantName);
 
 
 
@@ -135,5 +136,6 @@ extern DbGeoIndexCreate                          dbGeoIndexCreate;
 extern DbIdIndexCreate                           dbIdIndexCreate;
 extern DbEntitiesQuery                           dbEntitiesQuery;
 extern DbDatasetGet                              dbDatasetGet;
+extern DbTenantExists                            dbTenantExists;
 
 #endif  // SRC_LIB_ORIONLD_DB_DBCONFIGURATION_H_

--- a/src/lib/orionld/db/dbInit.cpp
+++ b/src/lib/orionld/db/dbInit.cpp
@@ -58,6 +58,7 @@
 #include "orionld/mongoCppLegacy/mongoCppLegacyEntityRetrieve.h"           // mongoCppLegacyEntityRetrieve
 #include "orionld/mongoCppLegacy/mongoCppLegacyEntitiesQuery.h"            // mongoCppLegacyEntitiesQuery
 #include "orionld/mongoCppLegacy/mongoCppLegacyDatasetGet.h"               // mongoCppLegacyDatasetGet
+#include "orionld/mongoCppLegacy/mongoCppLegacyTenantExists.h"             // mongoCppLegacyTenantExists
 
 #elif DB_DRIVER_MONGOC
 #include "orionld/mongoc/mongocInit.h"                                     // mongocInit
@@ -111,6 +112,7 @@ void dbInit(const char* dbHost, const char* dbName)
   dbIdIndexCreate                          = mongoCppLegacyIdIndexCreate;
   dbEntitiesQuery                          = mongoCppLegacyEntitiesQuery;
   dbDatasetGet                             = mongoCppLegacyDatasetGet;
+  dbTenantExists                           = mongoCppLegacyTenantExists;
 
   mongoCppLegacyInit(dbHost, dbName);
 

--- a/src/lib/orionld/mongoCppLegacy/CMakeLists.txt
+++ b/src/lib/orionld/mongoCppLegacy/CMakeLists.txt
@@ -60,6 +60,7 @@ SET (SOURCES
     mongoCppLegacyEntitiesAttributeLookup.cpp
     mongoCppLegacyDatasetGet.cpp
     mongoCppLegacyEntityTypeGet.cpp
+    mongoCppLegacyTenantExists.cpp
 )
 
 # Include directories

--- a/src/lib/orionld/mongoCppLegacy/mongoCppLegacyTenantExists.cpp
+++ b/src/lib/orionld/mongoCppLegacy/mongoCppLegacyTenantExists.cpp
@@ -22,23 +22,23 @@
 *
 * Author: Ken Zangelin
 */
-#include <string.h>                                            // strdup
-#include <string>                                              // std::string
-#include <vector>                                              // std::vector
+#include <string.h>                                                  // strdup
+#include <string>                                                    // std::string
+#include <vector>                                                    // std::vector
 
-#include "mongo/client/dbclient.h"                             // mongo legacy driver
+#include "mongo/client/dbclient.h"                                   // mongo legacy driver
 
-#include "logMsg/logMsg.h"                                     // LM_*
-#include "logMsg/traceLevels.h"                                // Lmt*
+#include "logMsg/logMsg.h"                                           // LM_*
+#include "logMsg/traceLevels.h"                                      // Lmt*
 
-#include "mongoBackend/MongoGlobal.h"                          // getMongoConnection
+#include "mongoBackend/MongoGlobal.h"                                // getMongoConnection
 
-#include "orionld/common/orionldState.h"                       // orionldState, dbName
-#include "orionld/common/orionldTenantCreate.h"                // orionldTenantCreate
-#include "orionld/common/orionldTenantLookup.h"                // orionldTenantLookup
+#include "orionld/common/orionldState.h"                             // orionldState, dbName
+#include "orionld/common/orionldTenantCreate.h"                      // orionldTenantCreate
+#include "orionld/common/orionldTenantLookup.h"                      // orionldTenantLookup
 #include "orionld/mongoCppLegacy/mongoCppLegacyDbStringFieldGet.h"   // mongoCppLegacyDbStringFieldGet
-#include "orionld/mongoCppLegacy/mongoCppLegacyDbFieldGet.h"   // mongoCppLegacyDbFieldGet
-#include "orionld/mongoCppLegacy/mongoCppLegacyTenantExists.h" // Own interface
+#include "orionld/mongoCppLegacy/mongoCppLegacyDbFieldGet.h"         // mongoCppLegacyDbFieldGet
+#include "orionld/mongoCppLegacy/mongoCppLegacyTenantExists.h"       // Own interface
 
 
 

--- a/src/lib/orionld/mongoCppLegacy/mongoCppLegacyTenantExists.cpp
+++ b/src/lib/orionld/mongoCppLegacy/mongoCppLegacyTenantExists.cpp
@@ -1,0 +1,99 @@
+/*
+*
+* Copyright 2021 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+#include <string.h>                                            // strdup
+#include <string>                                              // std::string
+#include <vector>                                              // std::vector
+
+#include "mongo/client/dbclient.h"                             // mongo legacy driver
+
+#include "logMsg/logMsg.h"                                     // LM_*
+#include "logMsg/traceLevels.h"                                // Lmt*
+
+#include "mongoBackend/MongoGlobal.h"                          // getMongoConnection
+
+#include "orionld/common/orionldState.h"                       // orionldState, dbName
+#include "orionld/common/orionldTenantCreate.h"                // orionldTenantCreate
+#include "orionld/common/orionldTenantLookup.h"                // orionldTenantLookup
+#include "orionld/mongoCppLegacy/mongoCppLegacyDbStringFieldGet.h"   // mongoCppLegacyDbStringFieldGet
+#include "orionld/mongoCppLegacy/mongoCppLegacyDbFieldGet.h"   // mongoCppLegacyDbFieldGet
+#include "orionld/mongoCppLegacy/mongoCppLegacyTenantExists.h" // Own interface
+
+
+
+// -----------------------------------------------------------------------------
+//
+// mongoCppLegacyTenantExists -
+//
+// Check
+//
+bool mongoCppLegacyTenantExists(const char* tenantName)
+{
+  char tenantDb[64];
+
+  snprintf(tenantDb, sizeof(tenantDb), "%s-%s", dbName, tenantName);
+
+  mongo::DBClientBase* connectionP = getMongoConnection();
+
+  try
+  {
+    mongo::BSONObj  result;
+    mongo::BSONObj  command = BSON("listDatabases" << 1);
+
+    connectionP->runCommand("admin", command, result);
+
+    mongo::BSONElement              bsonElement;
+    std::vector<mongo::BSONElement> dbV;
+
+    if (mongoCppLegacyDbFieldGet(&result, "databases", &bsonElement) == false)
+    {
+      LM_E(("Database Error (mongoCppLegacyDbFieldGet('databases') failed)"));
+      return false;
+    }
+    dbV = bsonElement.Array();
+
+    for (unsigned int ix = 0; ix < dbV.size(); ix++)
+    {
+      mongo::BSONObj  db   = dbV[ix].Obj();
+      char*           name = mongoCppLegacyDbStringFieldGet(&db, "name");
+
+      if (strcmp(name, tenantDb) == 0)
+      {
+        releaseMongoConnection(connectionP);
+        return true;
+      }
+    }
+  }
+  catch (const std::exception &e)
+  {
+    LM_E(("Database Error (listDatabases: %s)", e.what()));
+  }
+  catch (...)
+  {
+    LM_E(("Database Error (listDatabases: %s)", "generic exception"));
+  }
+
+  releaseMongoConnection(connectionP);
+  return false;
+}

--- a/src/lib/orionld/mongoCppLegacy/mongoCppLegacyTenantExists.h
+++ b/src/lib/orionld/mongoCppLegacy/mongoCppLegacyTenantExists.h
@@ -1,0 +1,37 @@
+#ifndef SRC_LIB_ORIONLD_MONGOCPPLEGACY_MONGOCPPLEGACYTENANTEXISTS_H_
+#define SRC_LIB_ORIONLD_MONGOCPPLEGACY_MONGOCPPLEGACYTENANTEXISTS_H_
+
+/*
+*
+* Copyright 2021 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+
+
+
+// -----------------------------------------------------------------------------
+//
+// mongoCppLegacyTenantExists -
+//
+extern bool mongoCppLegacyTenantExists(const char* tenantName);
+
+#endif  // SRC_LIB_ORIONLD_MONGOCPPLEGACY_MONGOCPPLEGACYTENANTEXISTS_H_

--- a/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
@@ -58,6 +58,7 @@ extern "C"
 #include "orionld/common/CHECK.h"                                // CHECK
 #include "orionld/common/uuidGenerate.h"                         // uuidGenerate
 #include "orionld/common/dotForEq.h"                             // dotForEq
+#include "orionld/common/orionldTenantCreate.h"                  // orionldTenantCreate
 #include "orionld/common/orionldTenantLookup.h"                  // orionldTenantLookup
 #include "orionld/common/orionldTenantGet.h"                     // orionldTenantGet
 #include "orionld/common/numberToDate.h"                         // numberToDate
@@ -735,10 +736,22 @@ MHD_Result orionldMhdConnectionTreat(ConnectionInfo* ciP)
       orionldState.tenantP = orionldTenantLookup(orionldState.tenantName);
       if (orionldState.tenantP == NULL)
       {
-        LM_W(("Bad Input (non-existing tenant: '%s')", orionldState.tenantName));
-        orionldErrorResponseCreate(OrionldNonExistingTenant, "No such tenant", orionldState.tenantName);
-        orionldState.httpStatusCode = 404;
-        goto respond;
+        //
+        // Tenant does not exist in the tenant cache of this broker
+        // However, some other broker (load balancer) might have created the tenant!
+        //
+        if (dbTenantExists(orionldState.tenantName) == false)
+        {
+          LM_W(("Bad Input (non-existing tenant: '%s')", orionldState.tenantName));
+          orionldErrorResponseCreate(OrionldNonExistingTenant, "No such tenant", orionldState.tenantName);
+          orionldState.httpStatusCode = 404;
+          goto respond;
+        }
+        else
+        {
+          // Add tenant to the tenant cache
+          orionldState.tenantP = orionldTenantCreate(orionldState.tenantName);
+        }
       }
     }
     else
@@ -1080,4 +1093,4 @@ MHD_Result orionldMhdConnectionTreat(ConnectionInfo* ciP)
 #endif
 
   return MHD_YES;
-}
+  }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_tenant_cache_with_two_brokers_on_same_db.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_tenant_cache_with_two_brokers_on_same_db.test
@@ -1,0 +1,103 @@
+# Copyright 2021 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Tenant Cache and the 'tenant exist check' for retrieve ops
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+dbInit CB tn1
+dbResetAll
+brokerStart CB 0-255 IPv4 -multiservice
+brokerStart CB2 0-255 IPv4 -multiservice
+
+--SHELL--
+
+#
+# Tenants are created on the fly upon creation of entities, and the list of existing tenants
+# are maintained in a cache in RAM - populated on startup and added to when new tenants are created "on the fly".
+#
+# However, what if we have two brokers, CB1 and CB2, running against the same DB, and an entity E1 is created in CB1 on tenant T1.
+# Tenant T1 will be created and added to the tenant cache of broker CB1. Broker CB2 will not know about this new tenant.
+#
+# So instead of blindly checking the tenant cache, if not found, we'll have to ask the DB.
+# 
+# In this test, we start TWO brokers against the same mongo database.
+# We create entity E1 on Tenant T1 on broker CB1.
+# And, then we query broker CB2 for E1.
+#
+# 
+# 01. Create an entity urn:ngsi-ld:entity:E1 on tenant T1, on broker CB1
+# 02. Query broker CB2 for entity E1 on tenant T1
+#
+
+echo "01. Create an entity urn:ngsi-ld:entity:E1 on tenant T1, on broker CB1"
+echo "======================================================================"
+payload='{
+  "id": "urn:ngsi-ld:entity:E1",
+  "type": "T"
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload" --tenant t1
+echo
+echo
+
+
+echo "02. Query broker CB2 for entity E1 on tenant T1"
+echo "==============================================="
+orionCurl --url /ngsi-ld/v1/entities?type=T --port $CB2_PORT --tenant t1
+echo
+echo
+
+
+--REGEXPECT--
+01. Create an entity urn:ngsi-ld:entity:E1 on tenant T1, on broker CB1
+======================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:entity:E1
+Date: REGEX(.*)
+
+
+
+02. Query broker CB2 for entity E1 on tenant T1
+===============================================
+HTTP/1.1 200 OK
+Content-Length: 43
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+[
+    {
+        "id": "urn:ngsi-ld:entity:E1",
+        "type": "T"
+    }
+]
+
+
+--TEARDOWN--
+brokerStop CB
+brokerStop CB2
+accumulatorStop
+dbDrop CB
+dbDrop CB t1

--- a/test/functionalTest/cases/0000_ngsild/ngsild_tenant_cache_with_two_brokers_on_same_db.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_tenant_cache_with_two_brokers_on_same_db.test
@@ -49,6 +49,7 @@ brokerStart CB2 0-255 IPv4 -multiservice
 # 
 # 01. Create an entity urn:ngsi-ld:entity:E1 on tenant T1, on broker CB1
 # 02. Query broker CB2 for entity E1 on tenant T1
+# 03. Query broker CB2 for entity E1 on tenant T2 - see error
 #
 
 echo "01. Create an entity urn:ngsi-ld:entity:E1 on tenant T1, on broker CB1"
@@ -65,6 +66,13 @@ echo
 echo "02. Query broker CB2 for entity E1 on tenant T1"
 echo "==============================================="
 orionCurl --url /ngsi-ld/v1/entities?type=T --port $CB2_PORT --tenant t1
+echo
+echo
+
+
+echo "03. Query broker CB2 for entity E1 on tenant T2 - see error"
+echo "==========================================================="
+orionCurl --url /ngsi-ld/v1/entities?type=T --port $CB2_PORT --tenant t2
 echo
 echo
 
@@ -93,6 +101,20 @@ Date: REGEX(.*)
         "type": "T"
     }
 ]
+
+
+03. Query broker CB2 for entity E1 on tenant T2 - see error
+===========================================================
+HTTP/1.1 404 Not Found
+Content-Length: 103
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "t2",
+    "title": "No such tenant",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/NonExistingTenant"
+}
 
 
 --TEARDOWN--

--- a/test/functionalTest/harnessFunctions.sh
+++ b/test/functionalTest/harnessFunctions.sh
@@ -83,6 +83,9 @@ function dbInit()
   if [ "$role" == "CB" ]
   then
     baseDbName=${CB_DB_NAME}
+  elif [ "$role" == "CB2" ]
+  then
+    baseDbName=${CB_DB_NAME}
   elif [ "$role" == "CP1" ]
   then
     baseDbName=${CP1_DB_NAME}
@@ -368,6 +371,11 @@ function localBrokerStart()
   then
     port=$CB_PORT
     CB_START_CMD="$CB_START_CMD_PREFIX -port $CB_PORT  -pidpath $CB_PID_FILE  -dbhost $dbHost:$dbPort -db $CB_DB_NAME -dbPoolSize $POOL_SIZE -t $traceLevels $IPvOption $extraParams"
+  elif [ "$role" == "CB2" ]
+  then
+    mkdir -p $CB2_LOG_DIR
+    port=$CB2_PORT
+    CB_START_CMD="$CB_START_CMD_PREFIX -port $CB2_PORT  -pidpath $CB2_PID_FILE  -dbhost $dbHost:$dbPort -db $CB_DB_NAME -dbPoolSize $POOL_SIZE -t $traceLevels $IPvOption -logDir $CB2_LOG_DIR $extraParams"
   elif [ "$role" == "CP1" ]
   then
     mkdir -p $CP1_LOG_DIR
@@ -480,6 +488,9 @@ function localBrokerStop
   if [ "$role" == "CB" ]
   then
     port=$CB_PORT
+  elif [ "$role" == "CB2" ]
+  then
+    port=$CB2_PORT
   elif [ "$role" == "CP1" ]
   then
     port=$CP1_PORT
@@ -636,6 +647,10 @@ function brokerStop
   then
     pidFile=$CB_PID_FILE
     port=$CB_PORT
+  elif [ "$role" == "CB2" ]
+  then
+    pidFile=$CB2_PID_FILE
+    port=$CB2_PORT
   elif [ "$role" == "CP1" ]
   then
     pidFile=$CP1_PID_FILE


### PR DESCRIPTION
Fixed a problem with the tenant cache for when more than one broker runs against the same DB:

Tenants are created on the fly upon creation of entities, and the list of existing tenants
are maintained in a cache in RAM - populated on startup and added to when new tenants are created "on the fly".

However, what if we have two brokers, CB1 and CB2, running against the same DB, and an entity E1 is created in CB1 on tenant T1.
Tenant T1 will be created and added to the tenant cache of broker CB1. Broker CB2 will not know about this new tenant.

So instead of blindly checking the tenant cache, if not found, we'll have to ask the DB.
