### PR TITLE
Performance/cip uri params

### DIFF
--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -3895,7 +3895,6 @@ void processContextElement
   ActionType                           action,
   OrionldTenant*                       tenantP,
   const std::vector<std::string>&      servicePathV,
-  std::map<std::string, std::string>&  uriParams,   // FIXME P7: we need this to implement "restriction-based" filters
   const std::string&                   xauthToken,
   const std::string&                   fiwareCorrelator,
   const std::string&                   ngsiV2AttrsFormat,
@@ -3931,7 +3930,7 @@ void processContextElement
   // future we may consider to modify the spec to add such Restriction and avoid this ugly "direct injection"
   // of URI filter into mongoBackend
   //
-  if (uriParams[URI_PARAM_NOT_EXIST] == SCOPE_VALUE_ENTITY_TYPE)
+  if ((orionldState.uriParams.notExists != NULL) && (strcmp(orionldState.uriParams.notExists, SCOPE_VALUE_ENTITY_TYPE) == 0))
   {
     std::string  entityTypeString = std::string("_id.") + ENT_ENTITY_TYPE;
     BSONObj      b                = BSON(entityTypeString << BSON("$exists" << false));

--- a/src/lib/mongoBackend/MongoCommonUpdate.h
+++ b/src/lib/mongoBackend/MongoCommonUpdate.h
@@ -48,7 +48,6 @@ extern void processContextElement
   ActionType                           action,
   OrionldTenant*                       tenantP,
   const std::vector<std::string>&      servicePath,
-  std::map<std::string, std::string>&  uriParams,   // FIXME P7: we need this to implement "restriction-based" filters
   const std::string&                   xauthToken,
   const std::string&                   fiwareCorrelator,
   const std::string&                   ngsiV2AttrsFormat,

--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -1199,7 +1199,7 @@ bool entitiesQuery
   int                              limit,
   bool*                            limitReached,
   long long*                       countP,
-  const std::string&               sortOrderList,
+  char*                            sortOrderList,
   ApiVersion                       apiVersion
 )
 {
@@ -1373,11 +1373,11 @@ bool entitiesQuery
 
   Query  query(finalQuery.obj());
 
-  if (sortOrderList == "")
+  if (sortOrderList == NULL)
   {
     query.sort(BSON(ENT_CREATION_DATE << 1));
   }
-  else if ((sortOrderList == ORDER_BY_PROXIMITY))
+  else if (strcmp(sortOrderList, ORDER_BY_PROXIMITY) == 0)
   {
     // In this case the solution is not setting any query.sort(), as the $near operator will do the
     // sorting itself. Of course, using orderBy=geo:distance without using georel=near will return

--- a/src/lib/mongoBackend/MongoGlobal.h
+++ b/src/lib/mongoBackend/MongoGlobal.h
@@ -277,7 +277,7 @@ extern bool entitiesQuery
   int                              limit          = DEFAULT_PAGINATION_LIMIT_INT,
   bool*                            limitReached   = NULL,
   long long*                       countP         = NULL,
-  const std::string&               sortOrderList  = "",
+  char*                            sortOrderList  = NULL,
   ApiVersion                       apiVersion     = V1
 );
 

--- a/src/lib/mongoBackend/mongoDiscoverContextAvailability.cpp
+++ b/src/lib/mongoBackend/mongoDiscoverContextAvailability.cpp
@@ -131,14 +131,9 @@ HttpStatusCode mongoDiscoverContextAvailability
   DiscoverContextAvailabilityRequest*   requestP,
   DiscoverContextAvailabilityResponse*  responseP,
   OrionldTenant*                        tenantP,
-  std::map<std::string, std::string>&   uriParams,
   const std::vector<std::string>&       servicePathV
 )
 {
-  int          offset         = atoi(uriParams[URI_PARAM_PAGINATION_OFFSET].c_str());
-  int          limit          = atoi(uriParams[URI_PARAM_PAGINATION_LIMIT].c_str());
-  std::string  detailsString  = uriParams[URI_PARAM_PAGINATION_DETAILS];
-  bool         details        = (strcasecmp("on", detailsString.c_str()) == 0)? true : false;
   bool         reqSemTaken;
 
   reqSemTake(__FUNCTION__, "mongo ngsi9 discovery request", SemReadOp, &reqSemTaken);
@@ -148,9 +143,9 @@ HttpStatusCode mongoDiscoverContextAvailability
   HttpStatusCode hsCode = processDiscoverContextAvailability(requestP,
                                                              responseP,
                                                              tenantP,
-                                                             offset,
-                                                             limit,
-                                                             details,
+                                                             orionldState.uriParams.offset,
+                                                             orionldState.uriParams.limit,
+                                                             orionldState.uriParams.details,
                                                              servicePathV);
   if (hsCode != SccOk)
   {

--- a/src/lib/mongoBackend/mongoDiscoverContextAvailability.h
+++ b/src/lib/mongoBackend/mongoDiscoverContextAvailability.h
@@ -46,7 +46,6 @@ extern HttpStatusCode mongoDiscoverContextAvailability
   DiscoverContextAvailabilityRequest*        requestP,
   DiscoverContextAvailabilityResponse*       responseP,
   OrionldTenant*                             tenantP,
-  std::map<std::string, std::string>&        uriParams,
   const std::vector<std::string>&            servicePathV
 );
 

--- a/src/lib/mongoBackend/mongoGetSubscriptions.cpp
+++ b/src/lib/mongoBackend/mongoGetSubscriptions.cpp
@@ -618,7 +618,7 @@ bool mongoGetLdSubscription
 */
 bool mongoGetLdSubscriptions
 (
-  ConnectionInfo*                     ciP,
+  const char*                         servicePath,
   std::vector<ngsiv2::Subscription>*  subVecP,
   OrionldTenant*                      tenantP,
   long long*                          countP,
@@ -640,9 +640,9 @@ bool mongoGetLdSubscriptions
   Query                          q;
 
   // FIXME P6: This here is a bug ... See #3099 for more info
-  if (!ciP->servicePathV[0].empty() && (ciP->servicePathV[0] != "/#"))
+  if ((servicePath != NULL) && (strcmp(servicePath, "/#") != 0))
   {
-    q = Query(BSON(CSUB_SERVICE_PATH << ciP->servicePathV[0]));
+    q = Query(BSON(CSUB_SERVICE_PATH << servicePath));
   }
 
   q.sort(BSON("_id" << 1));

--- a/src/lib/mongoBackend/mongoGetSubscriptions.cpp
+++ b/src/lib/mongoBackend/mongoGetSubscriptions.cpp
@@ -340,7 +340,6 @@ void mongoListSubscriptions
 (
   std::vector<Subscription>*           subs,
   OrionError*                          oe,
-  std::map<std::string, std::string>&  uriParam,
   OrionldTenant*                       tenantP,
   const std::string&                   servicePath,  // FIXME P4: vector of strings and not just a single string? See #3100
   int                                  limit,
@@ -433,7 +432,6 @@ void mongoGetSubscription
   ngsiv2::Subscription*               subP,
   OrionError*                         oe,
   const std::string&                  idSub,
-  std::map<std::string, std::string>& uriParam,
   OrionldTenant*                      tenantP
 )
 {
@@ -627,18 +625,7 @@ bool mongoGetLdSubscriptions
   OrionError*                         oeP
 )
 {
-  bool      reqSemTaken = false;
-  int       offset      = atoi(ciP->uriParam[URI_PARAM_PAGINATION_OFFSET].c_str());
-  int       limit;
-
-  if (ciP->uriParam[URI_PARAM_PAGINATION_LIMIT] != "")
-  {
-    limit = atoi(ciP->uriParam[URI_PARAM_PAGINATION_LIMIT].c_str());
-    if (limit <= 0)
-      limit = DEFAULT_PAGINATION_LIMIT_INT;
-  }
-  else
-    limit = DEFAULT_PAGINATION_LIMIT_INT;
+  bool reqSemTaken = false;
 
   reqSemTake(__FUNCTION__, "Mongo GET Subscriptions", SemReadOp, &reqSemTaken);
 
@@ -665,8 +652,8 @@ bool mongoGetLdSubscriptions
   if (!collectionRangedQuery(connection,
                              tenantP->subscriptions,
                              q,
-                             limit,
-                             offset,
+                             orionldState.uriParams.limit,
+                             orionldState.uriParams.offset,
                              &cursor,
                              countP,
                              &err))

--- a/src/lib/mongoBackend/mongoGetSubscriptions.h
+++ b/src/lib/mongoBackend/mongoGetSubscriptions.h
@@ -88,7 +88,7 @@ extern bool mongoGetLdSubscription
 */
 extern bool mongoGetLdSubscriptions
 (
-  ConnectionInfo*                     ciP,
+  const char*                         servicePath,
   std::vector<ngsiv2::Subscription>*  subVecP,
   OrionldTenant*                      tenantP,
   long long*                          countP,

--- a/src/lib/mongoBackend/mongoGetSubscriptions.h
+++ b/src/lib/mongoBackend/mongoGetSubscriptions.h
@@ -43,7 +43,6 @@ extern void mongoListSubscriptions
 (
   std::vector<ngsiv2::Subscription>*   vec,
   OrionError*                          oe,
-  std::map<std::string, std::string>&  uriParam,
   OrionldTenant*                       tenantP,
   const std::string&                   servicePath,
   int                                  limit,
@@ -62,7 +61,6 @@ extern void mongoGetSubscription
   ngsiv2::Subscription*                sub,
   OrionError*                          oe,
   const std::string&                   idSub,
-  std::map<std::string, std::string>&  uriParam,
   OrionldTenant*                       tenantP
 );
 

--- a/src/lib/mongoBackend/mongoNotifyContext.cpp
+++ b/src/lib/mongoBackend/mongoNotifyContext.cpp
@@ -62,10 +62,9 @@ HttpStatusCode mongoNotifyContext
   for (unsigned int ix = 0; ix < requestP->contextElementResponseVector.size(); ++ix)
   {
     UpdateContextResponse               ucr;        // Unused, necessary for processContextElement()
-    std::map<std::string, std::string>  uriParams;  // Unused, necessary for processContextElement()
     ContextElement*                     ceP = &requestP->contextElementResponseVector[ix]->contextElement;
 
-    processContextElement(ceP, &ucr, ActionTypeAppend, tenantP, servicePathV, uriParams, xauthToken, fiwareCorrelator, ngsiV2AttrsFormat);
+    processContextElement(ceP, &ucr, ActionTypeAppend, tenantP, servicePathV, xauthToken, fiwareCorrelator, ngsiV2AttrsFormat);
   }
 
   reqSemGive(__FUNCTION__, "ngsi10 notification", reqSemTaken);

--- a/src/lib/mongoBackend/mongoQueryContext.cpp
+++ b/src/lib/mongoBackend/mongoQueryContext.cpp
@@ -319,21 +319,14 @@ HttpStatusCode mongoQueryContext
   QueryContextResponse*                responseP,
   OrionldTenant*                       tenantP,
   const std::vector<std::string>&      servicePathV,
-  std::map<std::string, std::string>&  uriParams,
   std::map<std::string, bool>&         options,
   long long*                           countP,
   ApiVersion                           apiVersion
 )
 {
-  int         offset         = atoi(uriParams[URI_PARAM_PAGINATION_OFFSET].c_str());
-  int         limit          = atoi(uriParams[URI_PARAM_PAGINATION_LIMIT].c_str());
-
-  std::string sortOrderList  = uriParams[URI_PARAM_SORTED];
-
-  if (orionldState.uriParams.limit != 0)
-    limit = orionldState.uriParams.limit;
-  if (orionldState.uriParams.offset != 0)
-    offset = orionldState.uriParams.offset;
+  int   offset   = orionldState.uriParams.offset;
+  int   limit    = orionldState.uriParams.limit;
+  char* orderBy  = orionldState.uriParams.orderBy;
 
   LM_T(LmtMongo, ("QueryContext Request"));
   LM_T(LmtPagination, ("Offset: %d, Limit: %d, Count: %s", offset, limit, (countP != NULL)? "true" : "false"));
@@ -392,7 +385,7 @@ HttpStatusCode mongoQueryContext
                      limit,
                      &limitReached,
                      countP,
-                     sortOrderList,
+                     orderBy,
                      apiVersion);
 
   PERFORMANCE_END(0, NULL);

--- a/src/lib/mongoBackend/mongoQueryContext.cpp
+++ b/src/lib/mongoBackend/mongoQueryContext.cpp
@@ -307,11 +307,7 @@ static void processGenericEntities
 * mongoQueryContext - 
 *
 * NOTE
-*   If the in/out-parameter countP is non-NULL then the number of matching entities
-*   must be returned in *countP.
-*
-*   This replaces the 'uriParams[URI_PARAM_PAGINATION_DETAILS]' way of passing this information.
-*   The old method was one-way, using the new method 
+*   If the in/out-parameter countP is non-NULL then the number of matching entities must be returned in *countP.
 */
 HttpStatusCode mongoQueryContext
 (

--- a/src/lib/mongoBackend/mongoQueryContext.h
+++ b/src/lib/mongoBackend/mongoQueryContext.h
@@ -47,7 +47,6 @@ extern HttpStatusCode mongoQueryContext
   QueryContextResponse*                 responseP,
   OrionldTenant*                        tenantP,
   const std::vector<std::string>&       servicePathV,
-  std::map<std::string, std::string>&   uriParams,
   std::map<std::string, bool>&          options,
   long long*                            countP        = NULL,
   ApiVersion                            apiVersion    = V1

--- a/src/lib/mongoBackend/mongoQueryTypes.h
+++ b/src/lib/mongoBackend/mongoQueryTypes.h
@@ -60,7 +60,6 @@ extern HttpStatusCode mongoEntityTypes
   EntityTypeVectorResponse*            responseP,
   OrionldTenant*                       tenantP,
   const std::vector<std::string>&      servicePathV,
-  std::map<std::string, std::string>&  uriParams,
   ApiVersion                           apiVersion,
   unsigned int*                        totalTypesP,
   bool                                 noAttrDetail
@@ -77,7 +76,6 @@ extern HttpStatusCode mongoEntityTypesValues
   EntityTypeVectorResponse*            responseP,
   OrionldTenant*                       tenantP,
   const std::vector<std::string>&      servicePathV,
-  std::map<std::string, std::string>&  uriParams,
   unsigned int*                        totalTypesP
 );
 
@@ -93,7 +91,6 @@ extern HttpStatusCode mongoAttributesForEntityType
   EntityTypeResponse*                  responseP,
   OrionldTenant*                       tenantP,
   const std::vector<std::string>&      servicePathV,
-  std::map<std::string, std::string>&  uriParams,
   bool                                 noAttrDetail,
   ApiVersion                           apiVersion
 );

--- a/src/lib/mongoBackend/mongoUpdateContext.cpp
+++ b/src/lib/mongoBackend/mongoUpdateContext.cpp
@@ -54,7 +54,6 @@ HttpStatusCode mongoUpdateContext
   UpdateContextResponse*                responseP,
   OrionldTenant*                        tenantP,
   const std::vector<std::string>&       servicePathV,
-  std::map<std::string, std::string>&   uriParams,    // FIXME P7: we need this to implement "restriction-based" filters
   const char*                           xauthToken,
   const char*                           fiwareCorrelator,
   const char*                           ngsiV2AttrsFormat,
@@ -88,7 +87,6 @@ HttpStatusCode mongoUpdateContext
                             requestP->updateActionType,
                             tenantP,
                             servicePathV,
-                            uriParams,
                             xauthToken,
                             fiwareCorrelator,
                             ngsiV2AttrsFormat,

--- a/src/lib/mongoBackend/mongoUpdateContext.h
+++ b/src/lib/mongoBackend/mongoUpdateContext.h
@@ -47,7 +47,6 @@ extern HttpStatusCode mongoUpdateContext
   UpdateContextResponse*                responseP,
   OrionldTenant*                        tenantP,
   const std::vector<std::string>&       servicePathV,
-  std::map<std::string, std::string>&   uriParams,    // FIXME P7: we need this to implement "restriction-based" filters
   const char*                           xauthToken,
   const char*                           fiwareCorrelator,
   const char*                           ngsiV2AttrsFormat,

--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -147,6 +147,8 @@ typedef struct OrionldUriParams
   char*     notExists;
   char*     metadata;
   char*     orderBy;
+  bool      collapse;
+  char*     attributeFormat;
 } OrionldUriParams;
 
 

--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -99,6 +99,11 @@ typedef struct OrionldUriParamOptions
   bool update;
   bool replace;
   bool keyValues;
+  bool values;         // Only NGSIv2
+  bool uniqueValues;   // Only NGSIv2
+  bool dateCreated;    // Only NGSIv2
+  bool dateModified;   // Only NGSIv2
+  bool append;         // Only NGSIv2
   bool sysAttrs;
 } OrionldUriParamOptions;
 
@@ -139,6 +144,8 @@ typedef struct OrionldUriParams
   bool      location;
   char*     url;
   bool      reload;
+  char*     notExists;
+  char*     metadata;
 } OrionldUriParams;
 
 

--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -146,6 +146,7 @@ typedef struct OrionldUriParams
   bool      reload;
   char*     notExists;
   char*     metadata;
+  char*     orderBy;
 } OrionldUriParams;
 
 

--- a/src/lib/orionld/rest/OrionLdRestService.h
+++ b/src/lib/orionld/rest/OrionLdRestService.h
@@ -140,7 +140,7 @@ typedef struct OrionLdRestServiceSimplifiedVector
 #define ORIONLD_URIPARAM_LOCATION             (1 << 25)
 #define ORIONLD_URIPARAM_URL                  (1 << 27)
 #define ORIONLD_URIPARAM_RELOAD               (1 << 28)
-
+#define ORIONLD_URIPARAM_NOTEXISTS            (1 << 29)
 
 
 // -----------------------------------------------------------------------------

--- a/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
@@ -188,12 +188,17 @@ static void optionsParse(const char* options)
 
       *cP = 0;  // Zero-terminate
 
-      if      (strcmp(optionStart, "update")      == 0)  orionldState.uriParamOptions.update      = true;
-      else if (strcmp(optionStart, "replace")     == 0)  orionldState.uriParamOptions.replace     = true;
-      else if (strcmp(optionStart, "noOverwrite") == 0)  orionldState.uriParamOptions.noOverwrite = true;
-      else if (strcmp(optionStart, "keyValues")   == 0)  orionldState.uriParamOptions.keyValues   = true;
-      else if (strcmp(optionStart, "sysAttrs")    == 0)  orionldState.uriParamOptions.sysAttrs    = true;
-      else if (strcmp(optionStart, "count")       == 0)  orionldState.uriParams.count             = true;  // NGSIv2 compatibility
+      if      (strcmp(optionStart, "update")        == 0)  orionldState.uriParamOptions.update        = true;
+      else if (strcmp(optionStart, "replace")       == 0)  orionldState.uriParamOptions.replace       = true;
+      else if (strcmp(optionStart, "noOverwrite")   == 0)  orionldState.uriParamOptions.noOverwrite   = true;
+      else if (strcmp(optionStart, "keyValues")     == 0)  orionldState.uriParamOptions.keyValues     = true;
+      else if (strcmp(optionStart, "sysAttrs")      == 0)  orionldState.uriParamOptions.sysAttrs      = true;
+      else if (strcmp(optionStart, "append")        == 0)  orionldState.uriParamOptions.append        = true;  // NGSIv2 compatibility
+      else if (strcmp(optionStart, "count")         == 0)  orionldState.uriParams.count               = true;  // NGSIv2 compatibility
+      else if (strcmp(optionStart, "values")        == 0)  orionldState.uriParamOptions.values        = true;  // NGSIv2 compatibility
+      else if (strcmp(optionStart, "unique")        == 0)  orionldState.uriParamOptions.uniqueValues  = true;  // NGSIv2 compatibility
+      else if (strcmp(optionStart, "dateCreated")   == 0)  orionldState.uriParamOptions.dateCreated   = true;  // NGSIv2 compatibility
+      else if (strcmp(optionStart, "dateModified")  == 0)  orionldState.uriParamOptions.dateModified  = true;  // NGSIv2 compatibility
       else
       {
         LM_W(("Unknown 'options' value: %s", optionStart));
@@ -232,7 +237,7 @@ static int orionldHttpHeaderGet(void* cbDataP, MHD_ValueKind kind, const char* k
 //
 // orionldUriArgumentGet -
 //
-static MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* key, const char* value)
+MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* key, const char* value)
 {
   if (SCOMPARE3(key, 'i', 'd', 0))
   {
@@ -398,6 +403,8 @@ static MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const
       orionldState.uriParams.details = true;
     else if (strcmp(value, "false") == 0)
       orionldState.uriParams.details = false;
+    else if (strcmp(value, "on") == 0)
+      orionldState.uriParams.details = true;
     else
     {
       orionldErrorResponseCreate(OrionldBadRequestData, "Invalid value for uri parameter 'details'", value);
@@ -456,6 +463,15 @@ static MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const
   {
     orionldState.uriParams.reload = true;
     orionldState.uriParams.mask  |= ORIONLD_URIPARAM_RELOAD;
+  }
+  else if (SCOMPARE7(key, '!', 'e', 'x', 'i', 's', 't', 0))
+  {
+    orionldState.uriParams.notExists = (char*) value;
+    orionldState.uriParams.mask  |= ORIONLD_URIPARAM_NOTEXISTS;
+  }
+  else if (SCOMPARE9(key, 'm', 'e', 't', 'a', 'd', 'a', 't', 'a', 0))
+  {
+    orionldState.uriParams.metadata = (char*) value;
   }
   else
   {

--- a/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
@@ -477,6 +477,15 @@ MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* 
   {
     orionldState.uriParams.orderBy = (char*) value;
   }
+  else if (SCOMPARE9(key, 'c', 'o', 'l', 'l', 'a', 'p', 's', 'e', 0))
+  {
+    if (strcmp(value, "true") == 0)
+      orionldState.uriParams.collapse = true;
+  }
+  else if (SCOMPARE16(key, 'a', 't', 't', 'r', 'i', 'b', 'u', 't', 'e', 'F', 'o', 'r', 'm', 'a', 't', 0))
+  {
+    orionldState.uriParams.attributeFormat = (char*) value;
+  }
   else
   {
     LM_W(("Bad Input (unknown URI parameter: '%s')", key));

--- a/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
@@ -473,6 +473,10 @@ MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* 
   {
     orionldState.uriParams.metadata = (char*) value;
   }
+  else if (SCOMPARE8(key, 'o', 'r', 'd', 'e', 'r', 'B', 'y', 0))
+  {
+    orionldState.uriParams.orderBy = (char*) value;
+  }
   else
   {
     LM_W(("Bad Input (unknown URI parameter: '%s')", key));

--- a/src/lib/orionld/serviceRoutines/orionldGetEntities.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntities.cpp
@@ -466,7 +466,6 @@ bool orionldGetEntities(ConnectionInfo* ciP)
                                                   &mongoResponse,
                                                   orionldState.tenantP,
                                                   ciP->servicePathV,
-                                                  ciP->uriParam,
                                                   ciP->uriParamOptions,
                                                   countP,
                                                   orionldState.apiVersion);

--- a/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
@@ -439,7 +439,6 @@ bool orionldGetEntity(ConnectionInfo* ciP)
                                                   &response,
                                                   orionldState.tenantP,
                                                   ciP->servicePathV,
-                                                  ciP->uriParam,
                                                   ciP->uriParamOptions,
                                                   NULL,
                                                   orionldState.apiVersion);

--- a/src/lib/orionld/serviceRoutines/orionldGetSubscriptions.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetSubscriptions.cpp
@@ -54,7 +54,7 @@ bool orionldGetSubscriptions(ConnectionInfo* ciP)
   OrionError                        oe;
   int64_t                           count  = 0;
 
-  mongoGetLdSubscriptions(ciP, &subVec, orionldState.tenantP, (long long*) &count, &oe);
+  mongoGetLdSubscriptions(ciP->servicePathV[0].c_str(), &subVec, orionldState.tenantP, (long long*) &count, &oe);
 
   if (orionldState.uriParams.count == true)
   {

--- a/src/lib/orionld/serviceRoutines/orionldPatchAttribute.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchAttribute.cpp
@@ -848,7 +848,6 @@ bool orionldPatchAttribute(ConnectionInfo* ciP)
                                                    &mongoResponse,
                                                    orionldState.tenantP,
                                                    ciP->servicePathV,
-                                                   ciP->uriParam,
                                                    ciP->httpHeaders.xauthToken.c_str(),
                                                    ciP->httpHeaders.correlator.c_str(),
                                                    ciP->httpHeaders.ngsiv2AttrsFormat.c_str(),

--- a/src/lib/orionld/serviceRoutines/orionldPatchEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchEntity.cpp
@@ -324,7 +324,6 @@ bool orionldPatchEntity(ConnectionInfo* ciP)
                                                      &ucResponse,
                                                      orionldState.tenantP,
                                                      ciP->servicePathV,
-                                                     ciP->uriParam,
                                                      ciP->httpHeaders.xauthToken.c_str(),
                                                      ciP->httpHeaders.correlator.c_str(),
                                                      ciP->httpHeaders.ngsiv2AttrsFormat.c_str(),

--- a/src/lib/orionld/serviceRoutines/orionldPostBatchCreate.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostBatchCreate.cpp
@@ -269,7 +269,6 @@ bool orionldPostBatchCreate(ConnectionInfo* ciP)
                                                      &mongoResponse,
                                                      orionldState.tenantP,
                                                      ciP->servicePathV,
-                                                     ciP->uriParam,
                                                      ciP->httpHeaders.xauthToken.c_str(),
                                                      ciP->httpHeaders.correlator.c_str(),
                                                      ciP->httpHeaders.ngsiv2AttrsFormat.c_str(),

--- a/src/lib/orionld/serviceRoutines/orionldPostBatchUpdate.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostBatchUpdate.cpp
@@ -289,7 +289,6 @@ bool orionldPostBatchUpdate(ConnectionInfo* ciP)
                                                    &mongoResponse,
                                                    orionldState.tenantP,
                                                    ciP->servicePathV,
-                                                   ciP->uriParam,
                                                    ciP->httpHeaders.xauthToken.c_str(),
                                                    ciP->httpHeaders.correlator.c_str(),
                                                    ciP->httpHeaders.ngsiv2AttrsFormat.c_str(),

--- a/src/lib/orionld/serviceRoutines/orionldPostBatchUpsert.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostBatchUpsert.cpp
@@ -386,7 +386,6 @@ bool orionldPostBatchUpsert(ConnectionInfo* ciP)
                                                    &mongoResponse,
                                                    orionldState.tenantP,
                                                    ciP->servicePathV,
-                                                   ciP->uriParam,
                                                    ciP->httpHeaders.xauthToken.c_str(),
                                                    ciP->httpHeaders.correlator.c_str(),
                                                    ciP->httpHeaders.ngsiv2AttrsFormat.c_str(),

--- a/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
@@ -397,7 +397,6 @@ bool orionldPostEntities(ConnectionInfo* ciP)
                                                    &mongoResponse,
                                                    orionldState.tenantP,
                                                    ciP->servicePathV,
-                                                   ciP->uriParam,
                                                    ciP->httpHeaders.xauthToken.c_str(),
                                                    ciP->httpHeaders.correlator.c_str(),
                                                    ciP->httpHeaders.ngsiv2AttrsFormat.c_str(),

--- a/src/lib/orionld/serviceRoutines/orionldPostEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntity.cpp
@@ -470,7 +470,6 @@ bool orionldPostEntity(ConnectionInfo* ciP)
                                 &ucResponse,
                                 orionldState.tenantP,
                                 ciP->servicePathV,
-                                ciP->uriParam,
                                 ciP->httpHeaders.xauthToken.c_str(),
                                 ciP->httpHeaders.correlator.c_str(),
                                 ciP->httpHeaders.ngsiv2AttrsFormat.c_str(),

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -1649,6 +1649,8 @@ static MHD_Result connectionTreatDataReceive(ConnectionInfo* ciP, size_t* upload
 
 
 extern Verb verbGet(const char* method);
+extern MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* key, const char* value);
+
 /* ****************************************************************************
 *
 * connectionTreat -
@@ -1741,6 +1743,8 @@ static MHD_Result connectionTreat
     orionldState.responseTree = NULL;
     orionldState.notify       = false;
     orionldState.urlPath      = (char*) url;
+
+    MHD_get_connection_values(connection, MHD_GET_ARGUMENT_KIND, orionldUriArgumentGet, NULL);
 
     *con_cls = connectionTreatInit(connection, url, method, version, &retVal);
     return retVal;

--- a/src/lib/serviceRoutines/getAttributesForEntityType.cpp
+++ b/src/lib/serviceRoutines/getAttributesForEntityType.cpp
@@ -62,8 +62,8 @@ std::string getAttributesForEntityType
 {
   EntityTypeResponse  response;
   std::string         entityTypeName = compV[2];
-
-  bool asJsonObject = (ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object" && ciP->outMimeType == JSON);
+  char*               attrFormat     = orionldState.uriParams.attributeFormat;
+  bool                asJsonObject = ((attrFormat != NULL) && (strcmp(attrFormat, "object") == 0)) && (ciP->outMimeType == JSON);
 
   response.statusCode.fill(SccOk);
 
@@ -73,13 +73,13 @@ std::string getAttributesForEntityType
   //   set to true (meaning to skip the attribute detail) for NGSIv1 requests.
   //   The parameter is only used for NGSIv2.
   //
-  TIMED_MONGO(mongoAttributesForEntityType(entityTypeName, &response, orionldState.tenantP, ciP->servicePathV, ciP->uriParam, true, orionldState.apiVersion));
+  TIMED_MONGO(mongoAttributesForEntityType(entityTypeName, &response, orionldState.tenantP, ciP->servicePathV, true, orionldState.apiVersion));
 
   std::string rendered;
   TIMED_RENDER(rendered = response.render(orionldState.apiVersion,
                                           asJsonObject,
                                           ciP->outMimeType == JSON,
-                                          ciP->uriParam[URI_PARAM_COLLAPSE] == "true"));
+                                          orionldState.uriParams.collapse));
 
   response.release();
 

--- a/src/lib/serviceRoutines/getEntityTypes.cpp
+++ b/src/lib/serviceRoutines/getEntityTypes.cpp
@@ -78,7 +78,7 @@ std::string getEntityTypes
   //   set to true (meaning to skip the attribute detail) for NGSIv1 requests.
   //   The parameter is only used for NGSIv2
   //
-  TIMED_MONGO(mongoEntityTypes(&response, orionldState.tenantP, ciP->servicePathV, ciP->uriParam, orionldState.apiVersion, totalTypesP, true));
+  TIMED_MONGO(mongoEntityTypes(&response, orionldState.tenantP, ciP->servicePathV, orionldState.apiVersion, totalTypesP, true));
 
   std::string rendered;
   TIMED_RENDER(rendered = response.render(orionldState.apiVersion,

--- a/src/lib/serviceRoutines/postDiscoverContextAvailability.cpp
+++ b/src/lib/serviceRoutines/postDiscoverContextAvailability.cpp
@@ -56,7 +56,7 @@ std::string postDiscoverContextAvailability
   DiscoverContextAvailabilityResponse*  dcarP = &parseDataP->dcars.res;
   std::string                           answer;
 
-  TIMED_MONGO(ciP->httpStatusCode = mongoDiscoverContextAvailability(&parseDataP->dcar.res, dcarP, orionldState.tenantP, ciP->uriParam, ciP->servicePathV));
+  TIMED_MONGO(ciP->httpStatusCode = mongoDiscoverContextAvailability(&parseDataP->dcar.res, dcarP, orionldState.tenantP, ciP->servicePathV));
   TIMED_RENDER(answer = dcarP->render());
 
   return answer;

--- a/src/lib/serviceRoutines/postQueryContext.cpp
+++ b/src/lib/serviceRoutines/postQueryContext.cpp
@@ -314,7 +314,6 @@ std::string postQueryContext
                                                       qcrsP,
                                                       orionldState.tenantP,
                                                       ciP->servicePathV,
-                                                      ciP->uriParam,
                                                       ciP->uriParamOptions,
                                                       countP,
                                                       orionldState.apiVersion));

--- a/src/lib/serviceRoutines/postUpdateContext.cpp
+++ b/src/lib/serviceRoutines/postUpdateContext.cpp
@@ -497,7 +497,6 @@ std::string postUpdateContext
                                                   upcrsP,
                                                   orionldState.tenantP,
                                                   ciP->servicePathV,
-                                                  ciP->uriParam,
                                                   ciP->httpHeaders.xauthToken.c_str(),
                                                   ciP->httpHeaders.correlator.c_str(),
                                                   ciP->httpHeaders.ngsiv2AttrsFormat.c_str(),

--- a/src/lib/serviceRoutinesV2/getAllSubscriptions.cpp
+++ b/src/lib/serviceRoutinesV2/getAllSubscriptions.cpp
@@ -65,7 +65,6 @@ std::string getAllSubscriptions
 
   TIMED_MONGO(mongoListSubscriptions(&subs,
                                      &oe,
-                                     ciP->uriParam,
                                      orionldState.tenantP,
                                      ciP->servicePathV[0],
                                      limit,

--- a/src/lib/serviceRoutinesV2/getEntityAllTypes.cpp
+++ b/src/lib/serviceRoutinesV2/getEntityAllTypes.cpp
@@ -73,14 +73,13 @@ std::string getEntityAllTypes
 
   if (ciP->uriParamOptions[OPT_VALUES])
   {
-    TIMED_MONGO(mongoEntityTypesValues(&response, orionldState.tenantP, ciP->servicePathV, ciP->uriParam, totalTypesP));
+    TIMED_MONGO(mongoEntityTypesValues(&response, orionldState.tenantP, ciP->servicePathV, totalTypesP));
   }
   else  // default
   {
     TIMED_MONGO(mongoEntityTypes(&response,
                                  orionldState.tenantP,
                                  ciP->servicePathV,
-                                 ciP->uriParam,
                                  orionldState.apiVersion,
                                  totalTypesP,
                                  noAttrDetail));

--- a/src/lib/serviceRoutinesV2/getEntityType.cpp
+++ b/src/lib/serviceRoutinesV2/getEntityType.cpp
@@ -75,7 +75,6 @@ std::string getEntityType
                                            &response,
                                            orionldState.tenantP,
                                            ciP->servicePathV,
-                                           ciP->uriParam,
                                            noAttrDetail,
                                            orionldState.apiVersion));
 

--- a/src/lib/serviceRoutinesV2/getSubscription.cpp
+++ b/src/lib/serviceRoutinesV2/getSubscription.cpp
@@ -70,7 +70,7 @@ std::string getSubscription
     return oe.toJson();
   }
 
-  TIMED_MONGO(mongoGetSubscription(&sub, &oe, idSub, ciP->uriParam, orionldState.tenantP));
+  TIMED_MONGO(mongoGetSubscription(&sub, &oe, idSub, orionldState.tenantP));
 
   if (oe.code != SccOk)
   {

--- a/src/lib/serviceRoutinesV2/postBatchQuery.cpp
+++ b/src/lib/serviceRoutinesV2/postBatchQuery.cpp
@@ -25,6 +25,8 @@
 #include <string>
 #include <vector>
 
+#include "orionld/common/orionldState.h"
+
 #include "common/statistics.h"
 #include "common/clockFunctions.h"
 
@@ -75,8 +77,11 @@ std::string postBatchQuery
   // However, the implementation is cleaner and no more code is needed for this, just to set the
   // URI param with the value of the metadata filter from the payload.
   //
-  ciP->uriParam[URI_PARAM_METADATA] = bqP->metadataV.toString();
-  ciP->uriParam[URI_PARAM_ATTRS]    = bqP->attrsV.toString();
+  orionldState.uriParams.metadata = (char*) bqP->metadataV.toString().c_str();
+  orionldState.uriParams.attrs    = (char*) bqP->attrsV.toString().c_str();
+
+  ciP->uriParam[URI_PARAM_METADATA] = bqP->metadataV.toString();  // To be removed
+  ciP->uriParam[URI_PARAM_ATTRS]    = bqP->attrsV.toString();     // To be removed
 
   qcrP->fill(bqP);
   bqP->release();  // qcrP just 'took over' the data from bqP, bqP no longer needed

--- a/src/lib/serviceRoutinesV2/postEntity.cpp
+++ b/src/lib/serviceRoutinesV2/postEntity.cpp
@@ -79,7 +79,7 @@ std::string postEntity
     return oe.toJson();
   }
 
-  if (ciP->uriParamOptions["append"] == true)  // pure-append
+  if (orionldState.uriParamOptions.append == true)  // pure-append
   {
     op     = ActionTypeAppendStrict;
     flavor = NGSIV2_FLAVOUR_ONUPDATE;

--- a/test/unittests/mongoBackend/mongoDiscoverContextAvailability_test.cpp
+++ b/test/unittests/mongoBackend/mongoDiscoverContextAvailability_test.cpp
@@ -386,10 +386,10 @@ TEST(mongoDiscoverContextAvailabilityRequest, paginationDetails)
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E.*", "", "true");
   req.entityIdVector.push_back(&en);
-  uriParams[URI_PARAM_PAGINATION_DETAILS]  = "on";
+  orionldState.uriParams.details = true;
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+  ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -489,10 +489,10 @@ TEST(mongoDiscoverContextAvailabilityRequest, paginationAll)
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E.*", "", "true");
   req.entityIdVector.push_back(&en);
-  uriParams[URI_PARAM_PAGINATION_DETAILS]  = "off";
+  orionldState.uriParams.details = false;
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+  ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -592,12 +592,12 @@ TEST(mongoDiscoverContextAvailabilityRequest, paginationOnlyFirst)
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E.*", "", "true");
   req.entityIdVector.push_back(&en);
-  uriParams[URI_PARAM_PAGINATION_DETAILS]  = "off";
-  uriParams[URI_PARAM_PAGINATION_OFFSET] = "0";
-  uriParams[URI_PARAM_PAGINATION_LIMIT]  = "1";
+  orionldState.uriParams.details = false;
+  orionldState.uriParams.offset  = 0;
+  orionldState.uriParams.limit   = 1;
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+  ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -641,12 +641,12 @@ TEST(mongoDiscoverContextAvailabilityRequest, paginationOnlySecond)
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E.*", "", "true");
   req.entityIdVector.push_back(&en);
-  uriParams[URI_PARAM_PAGINATION_DETAILS]  = "off";
-  uriParams[URI_PARAM_PAGINATION_OFFSET] = "1";
-  uriParams[URI_PARAM_PAGINATION_LIMIT]  = "1";
+  orionldState.uriParams.details = false;
+  orionldState.uriParams.offset  = 1;
+  orionldState.uriParams.limit   = 1;
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+  ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -690,12 +690,12 @@ TEST(mongoDiscoverContextAvailabilityRequest, paginationRange)
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E.*", "", "true");
   req.entityIdVector.push_back(&en);
-  uriParams[URI_PARAM_PAGINATION_DETAILS]  = "off";
-  uriParams[URI_PARAM_PAGINATION_OFFSET] = "2";
-  uriParams[URI_PARAM_PAGINATION_LIMIT]  = "3";
+  orionldState.uriParams.details = false;
+  orionldState.uriParams.offset  = 2;
+  orionldState.uriParams.limit   = 3;
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+  ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -767,12 +767,12 @@ TEST(mongoDiscoverContextAvailabilityRequest, paginationNonExisting)
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E.*", "", "true");
   req.entityIdVector.push_back(&en);
-  uriParams[URI_PARAM_PAGINATION_DETAILS]  = "off";
-  uriParams[URI_PARAM_PAGINATION_OFFSET] = "6";
-  uriParams[URI_PARAM_PAGINATION_LIMIT]  = "2";
+  orionldState.uriParams.details = false;
+  orionldState.uriParams.offset  = 6;
+  orionldState.uriParams.limit   = 2;
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+  ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -803,12 +803,12 @@ TEST(mongoDiscoverContextAvailabilityRequest, paginationNonExistingOverlap)
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E.*", "", "true");
   req.entityIdVector.push_back(&en);
-  uriParams[URI_PARAM_PAGINATION_DETAILS]  = "off";
-  uriParams[URI_PARAM_PAGINATION_OFFSET] = "4";
-  uriParams[URI_PARAM_PAGINATION_LIMIT]  = "4";
+  orionldState.uriParams.details = false;
+  orionldState.uriParams.offset  = 4;
+  orionldState.uriParams.limit   = 4;
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+  ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -852,12 +852,12 @@ TEST(mongoDiscoverContextAvailabilityRequest, paginationNonExistingDetails)
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E.*", "", "true");
   req.entityIdVector.push_back(&en);
-  uriParams[URI_PARAM_PAGINATION_DETAILS]  = "on";
-  uriParams[URI_PARAM_PAGINATION_OFFSET]   = "6";
-  uriParams[URI_PARAM_PAGINATION_LIMIT]    = "2";
+  orionldState.uriParams.details = false;
+  orionldState.uriParams.offset  = 6;
+  orionldState.uriParams.limit   = 2;
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+  ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -890,9 +890,12 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternAttrsAll)
   /* Forge the request (from "inside" to "outside") */
   EntityId en("E3", "T3");
   req.entityIdVector.push_back(&en);
+  orionldState.uriParams.details = false;
+  orionldState.uriParams.offset  = 0;
+  orionldState.uriParams.limit   = 20;
 
   /* Invoke the function in mongoBackend library */
-  ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+  ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, ms);
@@ -954,7 +957,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternAttrOneSingle)
     orionldState.requestTime = 1360232700.0;
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1018,7 +1021,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternAttrOneMulti)
     req.attributeList.push_back("A1");
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1091,7 +1094,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternAttrsSubset)
     orionldState.requestTime = 1360232700.0;
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1151,7 +1154,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternSeveralCREs)
     orionldState.requestTime = 1360232700.0;
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1230,7 +1233,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternSeveralRegistrations)
     orionldState.requestTime = 1360232700.0;
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1308,7 +1311,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternNoEntity)
     orionldState.requestTime = 1360232700.0;
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1353,7 +1356,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternNoAttribute)
     req.attributeList.push_back("A5");
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1399,7 +1402,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternMultiEntity)
     orionldState.requestTime = 1360232700.0;
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1500,7 +1503,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternMultiAttr)
     orionldState.requestTime = 1360232700.0;
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1576,7 +1579,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternMultiEntityAttrs)
     orionldState.requestTime = 1360232700.0;
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1669,7 +1672,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, noPatternNoType)
     orionldState.requestTime = 1360232700.0;
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1772,7 +1775,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, pattern0Attr)
     orionldState.requestTime = 1360232700.0;
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1855,7 +1858,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, pattern1AttrSingle)
     orionldState.requestTime = 1360232700.0;
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1913,7 +1916,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, pattern1AttrMulti)
     orionldState.requestTime = 1360232700.0;
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -1990,7 +1993,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, patternNAttr)
     orionldState.requestTime = 1360232700.0;
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2080,7 +2083,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, patternFail)
     orionldState.requestTime = 1360232700.0;
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2130,7 +2133,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, patternNoType)
     orionldState.requestTime = 1360232700.0;
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2236,7 +2239,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, mixPatternAndNotPattern)
     orionldState.requestTime = 1360232700.0;
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);
@@ -2345,7 +2348,7 @@ TEST(mongoDiscoverContextAvailabilityRequest, mongoDbQueryFail)
     req.entityIdVector.push_back(&en);
 
     /* Invoke the function in mongoBackend library */
-    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, uriParams, servicePathVector);
+    ms = mongoDiscoverContextAvailability(&req, &res, &tenant0, servicePathVector);
 
     /* Check response is as expected */
     EXPECT_EQ(SccOk, ms);

--- a/test/unittests/mongoBackend/mongoGetSubscriptions_test.cpp
+++ b/test/unittests/mongoBackend/mongoGetSubscriptions_test.cpp
@@ -138,7 +138,7 @@ TEST(mongoListSubscriptions, getAllSubscriptionsV1Info)
 
   /* Invoke the function in mongoBackend library */
   std::vector<Subscription> subs;
-  mongoListSubscriptions(&subs, &oe, uriParams, &tenant0, "/#", 20, 0, &count);
+  mongoListSubscriptions(&subs, &oe, &tenant0, "/#", 20, 0, &count);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, oe.code);
@@ -242,7 +242,7 @@ TEST(mongoGetSubscription, getSubscription)
   /* Invoke the function in mongoBackend library */
   Subscription empty, s;
 
-  mongoGetSubscription(&s, &oe, SUB_OID1, uriParams, &tenant0);
+  mongoGetSubscription(&s, &oe, SUB_OID1, &tenant0);
 
   /* Check response is as expected */
   EXPECT_EQ(SccOk, oe.code);
@@ -280,7 +280,7 @@ TEST(mongoGetSubscription, getSubscription)
   // clear subscription
   s = empty;
 
-  mongoGetSubscription(&s, &oe, SUB_OID2, uriParams, &tenant0);
+  mongoGetSubscription(&s, &oe, SUB_OID2, &tenant0);
 
   EXPECT_EQ(SUB_OID2, s.id);
   ents = s.subject.entities;


### PR DESCRIPTION
Another step in the total elimination of ConnectionInfo:
* Removed uriParams as parameter for
  * mongoQueryContext
  * mongoListSubscriptions
  * mongoGetSubscription
  * mongoDiscoverContextAvailability
  * mongoEntityTypes()
  * mongoEntityTypesValues()
  * mongoAttributesForEntityType
*  Removed ConnectionInfo as parameter for:
    *  mongoGetLdSubscriptions



