### PR TITLE
More uriParam stuff for removal of ConnectionInfo

### DIFF
--- a/src/lib/mongoBackend/MongoCommonUpdate.cpp
+++ b/src/lib/mongoBackend/MongoCommonUpdate.cpp
@@ -58,7 +58,6 @@ extern "C"
 #include "cache/subCache.h"
 #include "rest/StringFilter.h"
 #include "ngsi/Scope.h"
-#include "rest/uriParamNames.h"
 
 #include "orionld/types/OrionldTenant.h"                           // OrionldTenant
 #include "orionld/types/AttributeType.h"                           // AttributeType

--- a/src/lib/mongoBackend/MongoGlobal.h
+++ b/src/lib/mongoBackend/MongoGlobal.h
@@ -35,6 +35,7 @@
 
 #include "logMsg/logMsg.h"
 
+#include "rest/uriParamNames.h"                // Default values for URI parameters
 #include "common/RenderFormat.h"
 #include "ngsi/EntityId.h"
 #include "ngsi/ContextRegistrationAttribute.h"
@@ -49,7 +50,6 @@
 #include "ngsi9/RegisterContextRequest.h"
 #include "ngsi9/RegisterContextResponse.h"
 #include "ngsiNotify/Notifier.h"
-#include "rest/uriParamNames.h"
 #include "apiTypesV2/Subscription.h"
 #include "apiTypesV2/HttpInfo.h"
 #include "mongoBackend/TriggeredSubscription.h"

--- a/src/lib/mongoBackend/mongoNotifyContextAvailability.cpp
+++ b/src/lib/mongoBackend/mongoNotifyContextAvailability.cpp
@@ -51,7 +51,6 @@ HttpStatusCode mongoNotifyContextAvailability
 (
   NotifyContextAvailabilityRequest*    requestP,
   NotifyContextAvailabilityResponse*   responseP,
-  std::map<std::string, std::string>&  uriParam,
   const std::string&                   fiwareCorrelator,
   OrionldTenant*                       tenantP,
   const std::string&                   servicePath

--- a/src/lib/mongoBackend/mongoNotifyContextAvailability.h
+++ b/src/lib/mongoBackend/mongoNotifyContextAvailability.h
@@ -44,7 +44,6 @@ extern HttpStatusCode mongoNotifyContextAvailability
 (
   NotifyContextAvailabilityRequest*    requestP,
   NotifyContextAvailabilityResponse*   responseP,
-  std::map<std::string, std::string>&  uriParam,
   const std::string&                   fiwareCorrelator = "no correlator",
   OrionldTenant*                       tenantP          = NULL,
   const std::string&                   servicePath      = ""

--- a/src/lib/mongoBackend/mongoRegisterContext.cpp
+++ b/src/lib/mongoBackend/mongoRegisterContext.cpp
@@ -68,7 +68,6 @@ HttpStatusCode mongoRegisterContext
 (
   RegisterContextRequest*              requestP,
   RegisterContextResponse*             responseP,
-  std::map<std::string, std::string>&  uriParam,
   const std::string&                   fiwareCorrelator,
   OrionldTenant*                       tenantP,
   const std::string&                   servicePath

--- a/src/lib/mongoBackend/mongoRegisterContext.h
+++ b/src/lib/mongoBackend/mongoRegisterContext.h
@@ -44,7 +44,6 @@ extern HttpStatusCode mongoRegisterContext
 (
   RegisterContextRequest*              requestP,
   RegisterContextResponse*             responseP,
-  std::map<std::string, std::string>&  uriParam,
   const std::string&                   fiwareCorrelator = "no correlator",
   OrionldTenant*                       tenantP          = NULL,
   const std::string&                   servicePath      = ""

--- a/src/lib/mongoBackend/mongoSubscribeContextAvailability.cpp
+++ b/src/lib/mongoBackend/mongoSubscribeContextAvailability.cpp
@@ -40,7 +40,6 @@
 #include "mongoBackend/dbConstants.h"
 #include "ngsi9/SubscribeContextAvailabilityRequest.h"
 #include "ngsi9/SubscribeContextAvailabilityResponse.h"
-#include "rest/uriParamNames.h"
 
 
 
@@ -62,7 +61,6 @@ HttpStatusCode mongoSubscribeContextAvailability
 (
   SubscribeContextAvailabilityRequest*   requestP,
   SubscribeContextAvailabilityResponse*  responseP,
-  std::map<std::string, std::string>&    uriParam,
   const std::string&                     fiwareCorrelator,
   OrionldTenant*                         tenantP
 )

--- a/src/lib/mongoBackend/mongoSubscribeContextAvailability.h
+++ b/src/lib/mongoBackend/mongoSubscribeContextAvailability.h
@@ -44,7 +44,6 @@ extern HttpStatusCode mongoSubscribeContextAvailability
 (
   SubscribeContextAvailabilityRequest*   requestP,
   SubscribeContextAvailabilityResponse*  responseP,
-  std::map<std::string, std::string>&    uriParam,
   const std::string&                     fiwareCorrelator = "no correlator",
   OrionldTenant*                         tenantP          = NULL
 );

--- a/src/lib/serviceRoutines/postNotifyContextAvailability.cpp
+++ b/src/lib/serviceRoutines/postNotifyContextAvailability.cpp
@@ -89,7 +89,7 @@ std::string postNotifyContextAvailability
     return answer;
   }
 
-  TIMED_MONGO(ciP->httpStatusCode = mongoNotifyContextAvailability(&parseDataP->ncar.res, &ncar, ciP->uriParam, ciP->httpHeaders.correlator, orionldState.tenantP, ciP->servicePathV[0]));
+  TIMED_MONGO(ciP->httpStatusCode = mongoNotifyContextAvailability(&parseDataP->ncar.res, &ncar, ciP->httpHeaders.correlator, orionldState.tenantP, ciP->servicePathV[0]));
   TIMED_RENDER(answer = ncar.render());
 
   return answer;

--- a/src/lib/serviceRoutines/postRegisterContext.cpp
+++ b/src/lib/serviceRoutines/postRegisterContext.cpp
@@ -111,7 +111,7 @@ std::string postRegisterContext
     return answer;
   }
 
-  TIMED_MONGO(ciP->httpStatusCode = mongoRegisterContext(&parseDataP->rcr.res, &rcr, ciP->uriParam, ciP->httpHeaders.correlator, orionldState.tenantP, ciP->servicePathV[0]));
+  TIMED_MONGO(ciP->httpStatusCode = mongoRegisterContext(&parseDataP->rcr.res, &rcr, ciP->httpHeaders.correlator, orionldState.tenantP, ciP->servicePathV[0]));
   TIMED_RENDER(answer = rcr.render());
 
   return answer;

--- a/src/lib/serviceRoutines/postSubscribeContextAvailability.cpp
+++ b/src/lib/serviceRoutines/postSubscribeContextAvailability.cpp
@@ -56,7 +56,6 @@ std::string postSubscribeContextAvailability
 
   TIMED_MONGO(ciP->httpStatusCode = mongoSubscribeContextAvailability(&parseDataP->scar.res,
                                                                       &scar,
-                                                                      ciP->uriParam,
                                                                       ciP->httpHeaders.correlator,
                                                                       orionldState.tenantP));
   TIMED_RENDER(answer = scar.render());


### PR DESCRIPTION
Removed uriParams as a parameter for
* mongoSubscribeContextAvailability()
* mongoRegisterContext(), and
* mongoNotifyContextAvailability()
