### PR TITLE
cip/httpstatuscode

### DIFF
--- a/src/lib/apiTypesV2/Attribute.cpp
+++ b/src/lib/apiTypesV2/Attribute.cpp
@@ -44,8 +44,8 @@ std::string Attribute::render
   bool                acceptedTextPlain,   // in parameter (pass-through)
   bool                acceptedJson,        // in parameter (pass-through)
   MimeType            outFormatSelection,  // in parameter (pass-through)
-  MimeType*           outContentTypeP,        // out parameter (pass-through)
-  HttpStatusCode*     scP,                 // out parameter (pass-through)
+  MimeType*           outContentTypeP,     // out parameter (pass-through)
+  int*                scP,                 // out parameter (pass-through)
   bool                keyValues,           // in parameter
   const std::string&  metadataList,        // in parameter
   RequestType         requestType,         // in parameter

--- a/src/lib/apiTypesV2/Attribute.h
+++ b/src/lib/apiTypesV2/Attribute.h
@@ -58,7 +58,7 @@ class Attribute
                       bool                acceptedJson,
                       MimeType            outFormatSelection,
                       MimeType*           outContentTypeP,
-                      HttpStatusCode*     scP,
+                      int*                scP,
                       bool                keyValues,
                       const std::string&  metadataList,
                       RequestType         requestType,

--- a/src/lib/jsonParse/jsonParse.cpp
+++ b/src/lib/jsonParse/jsonParse.cpp
@@ -44,6 +44,8 @@
 #include "logMsg/logMsg.h"
 #include "logMsg/traceLevels.h"
 
+#include "orionld/common/orionldState.h"                         // orionldState
+
 #include "common/statistics.h"
 #include "common/clockFunctions.h"
 #include "alarmMgr/alarmMgr.h"
@@ -168,7 +170,7 @@ static bool treat
         std::string details = std::string("found a forbidden value in '") + value + "'";
           
         alarmMgr.badInput(clientIp, details);
-        ciP->httpStatusCode = SccBadRequest;
+        orionldState.httpStatusCode = SccBadRequest;
         ciP->answer = std::string("Illegal value for JSON field");
         return false;
       }
@@ -280,7 +282,7 @@ void eatCompound
         std::string details = std::string("found a forbidden value in compound '") + nodeValue + "'";
         alarmMgr.badInput(clientIp, details);
 
-        ciP->httpStatusCode = SccBadRequest;
+        orionldState.httpStatusCode = SccBadRequest;
         ciP->answer = std::string("Illegal value for JSON field");
         return;
       }
@@ -385,7 +387,7 @@ static std::string jsonParse
     eatCompound(ciP, NULL, v, "");
     compoundValueEnd(ciP, parseDataP);
 
-    if (ciP->httpStatusCode != SccOk)
+    if (orionldState.httpStatusCode != SccOk)
     {
       return ciP->answer;
     }
@@ -394,7 +396,7 @@ static std::string jsonParse
   }
   else if (treated == false)
   {
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
     if (ciP->answer == "")
     {
       ciP->answer = std::string("JSON Parse Error: unknown field: ") + path.c_str();

--- a/src/lib/jsonParse/jsonRequest.cpp
+++ b/src/lib/jsonParse/jsonRequest.cpp
@@ -250,8 +250,8 @@ std::string jsonTreat
     std::string answer;
     
     alarmMgr.badInput(clientIp, details);
-    ciP->httpStatusCode = SccBadRequest;
-    restErrorReplyGet(ciP, ciP->httpStatusCode, res, &answer);
+    orionldState.httpStatusCode = SccBadRequest;
+    restErrorReplyGet(ciP, orionldState.httpStatusCode, res, &answer);
     return answer;
   }
 

--- a/src/lib/jsonParseV2/badInput.cpp
+++ b/src/lib/jsonParseV2/badInput.cpp
@@ -24,6 +24,8 @@
 */
 #include <string>
 
+#include "orionld/common/orionldState.h"             // orionldState
+
 #include "rest/ConnectionInfo.h"
 #include "rest/OrionError.h"
 #include "alarmMgr/alarmMgr.h"
@@ -39,7 +41,7 @@ std::string badInput(ConnectionInfo* ciP, const std::string& msg)
   alarmMgr.badInput(clientIp, msg);
   OrionError oe(SccBadRequest, msg, "BadRequest");
 
-  ciP->httpStatusCode = oe.code;
+  orionldState.httpStatusCode = oe.code;
 
   return oe.toJson();
 }

--- a/src/lib/jsonParseV2/jsonRequestTreat.cpp
+++ b/src/lib/jsonParseV2/jsonRequestTreat.cpp
@@ -82,7 +82,7 @@ std::string jsonRequestTreat
     if ((answer = parseDataP->ent.res.check(EntitiesRequest)) != "OK")
     {
       OrionError oe(SccBadRequest, answer);
-      return oe.setStatusCodeAndSmartRender(orionldState.apiVersion, &(ciP->httpStatusCode));
+      return oe.setStatusCodeAndSmartRender(orionldState.apiVersion, &orionldState.httpStatusCode);
     }
     break;
 
@@ -97,7 +97,7 @@ std::string jsonRequestTreat
     if ((answer = parseDataP->ent.res.check(EntityRequest)) != "OK")
     {
       OrionError oe(SccBadRequest, answer);
-      return oe.setStatusCodeAndSmartRender(orionldState.apiVersion, &(ciP->httpStatusCode));
+      return oe.setStatusCodeAndSmartRender(orionldState.apiVersion, &orionldState.httpStatusCode);
     }
     break;
 
@@ -113,7 +113,7 @@ std::string jsonRequestTreat
     if ((answer = parseDataP->attr.attribute.check(orionldState.apiVersion, EntityAttributeRequest)) != "OK")
     {
       OrionError oe(SccBadRequest, answer);
-      return oe.setStatusCodeAndSmartRender(orionldState.apiVersion, &(ciP->httpStatusCode));
+      return oe.setStatusCodeAndSmartRender(orionldState.apiVersion, &orionldState.httpStatusCode);
     }
     break;
 
@@ -177,7 +177,7 @@ std::string jsonRequestTreat
   default:
     OrionError error(SccNotImplemented, "Request Treat function not implemented");
     answer = error.render();
-    ciP->httpStatusCode = SccNotImplemented;
+    orionldState.httpStatusCode = SccNotImplemented;
     break;
   }
 

--- a/src/lib/jsonParseV2/parseAttributeValue.cpp
+++ b/src/lib/jsonParseV2/parseAttributeValue.cpp
@@ -26,6 +26,8 @@
 
 #include "rapidjson/document.h"
 
+#include "orionld/common/orionldState.h"                         // orionldState
+
 #include "common/errorMessages.h"
 #include "alarmMgr/alarmMgr.h"
 #include "rest/ConnectionInfo.h"
@@ -52,7 +54,7 @@ std::string parseAttributeValue(ConnectionInfo* ciP, ContextAttribute* caP)
   {
     alarmMgr.badInput(clientIp, "JSON parse error");
     oe.fill(SccBadRequest, ERROR_DESC_PARSE, ERROR_PARSE);
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
     return oe.toJson();
   }
 
@@ -61,7 +63,7 @@ std::string parseAttributeValue(ConnectionInfo* ciP, ContextAttribute* caP)
   {
     alarmMgr.badInput(clientIp, "JSON parse error");
     oe.fill(SccBadRequest, "Neither JSON Object nor JSON Array for attribute::value", "BadRequest");
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
     return oe.toJson();
   }
 

--- a/src/lib/jsonParseV2/parseBatchQuery.cpp
+++ b/src/lib/jsonParseV2/parseBatchQuery.cpp
@@ -26,6 +26,8 @@
 
 #include "rapidjson/document.h"
 
+#include "orionld/common/orionldState.h"                         // orionldState
+
 #include "common/errorMessages.h"
 #include "alarmMgr/alarmMgr.h"
 #include "rest/ConnectionInfo.h"
@@ -53,7 +55,7 @@ std::string parseBatchQuery(ConnectionInfo* ciP, BatchQuery* bqrP)
   {
     alarmMgr.badInput(clientIp, "JSON Parse Error");
     oe.fill(SccBadRequest, ERROR_DESC_PARSE, ERROR_PARSE);
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
 
     return oe.toJson();
   }
@@ -62,7 +64,7 @@ std::string parseBatchQuery(ConnectionInfo* ciP, BatchQuery* bqrP)
   {
     alarmMgr.badInput(clientIp, "JSON Parse Error");
     oe.fill(SccBadRequest, ERROR_DESC_PARSE, ERROR_PARSE);
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
 
     return oe.toJson();
   }
@@ -70,7 +72,7 @@ std::string parseBatchQuery(ConnectionInfo* ciP, BatchQuery* bqrP)
   {
     alarmMgr.badInput(clientIp, "Empty JSON payload");
     oe.fill(SccBadRequest, ERROR_DESC_BAD_REQUEST_EMPTY_PAYLOAD, ERROR_BAD_REQUEST);
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
 
     return oe.toJson();
   }
@@ -79,7 +81,7 @@ std::string parseBatchQuery(ConnectionInfo* ciP, BatchQuery* bqrP)
   {
     alarmMgr.badInput(clientIp, "Invalid JSON payload, no relevant fields found");
     oe.fill(SccBadRequest, "Invalid JSON payload, no relevant fields found", "BadRequest");
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
 
     return oe.toJson();
   }
@@ -97,7 +99,7 @@ std::string parseBatchQuery(ConnectionInfo* ciP, BatchQuery* bqrP)
       {
         alarmMgr.badInput(clientIp, r);
         oe.fill(SccBadRequest, r, "BadRequest");
-        ciP->httpStatusCode = SccBadRequest;
+        orionldState.httpStatusCode = SccBadRequest;
 
         return oe.toJson();
       }
@@ -111,7 +113,7 @@ std::string parseBatchQuery(ConnectionInfo* ciP, BatchQuery* bqrP)
       {
         alarmMgr.badInput(clientIp, r);
         oe.fill(SccBadRequest, r, "BadRequest");
-        ciP->httpStatusCode = SccBadRequest;
+        orionldState.httpStatusCode = SccBadRequest;
 
         return oe.toJson();
       }
@@ -124,7 +126,7 @@ std::string parseBatchQuery(ConnectionInfo* ciP, BatchQuery* bqrP)
       {
         alarmMgr.badInput(clientIp, r);
         oe.fill(SccBadRequest, r, "BadRequest");
-        ciP->httpStatusCode = SccBadRequest;
+        orionldState.httpStatusCode = SccBadRequest;
 
         return oe.toJson();
       }
@@ -137,7 +139,7 @@ std::string parseBatchQuery(ConnectionInfo* ciP, BatchQuery* bqrP)
       {
         alarmMgr.badInput(clientIp, r);
         oe.fill(SccBadRequest, r, "BadRequest");
-        ciP->httpStatusCode = SccBadRequest;
+        orionldState.httpStatusCode = SccBadRequest;
 
         return oe.toJson();
       }
@@ -150,7 +152,7 @@ std::string parseBatchQuery(ConnectionInfo* ciP, BatchQuery* bqrP)
       {
         alarmMgr.badInput(clientIp, r);
         oe.fill(SccBadRequest, r, "BadRequest");
-        ciP->httpStatusCode = SccBadRequest;
+        orionldState.httpStatusCode = SccBadRequest;
 
         return oe.toJson();
       }
@@ -161,7 +163,7 @@ std::string parseBatchQuery(ConnectionInfo* ciP, BatchQuery* bqrP)
 
       alarmMgr.badInput(clientIp, description);
       oe.fill(SccBadRequest, description, "BadRequest");
-      ciP->httpStatusCode = SccBadRequest;
+      orionldState.httpStatusCode = SccBadRequest;
 
       return oe.toJson();
     }

--- a/src/lib/jsonParseV2/parseBatchUpdate.cpp
+++ b/src/lib/jsonParseV2/parseBatchUpdate.cpp
@@ -26,6 +26,8 @@
 
 #include "rapidjson/document.h"
 
+#include "orionld/common/orionldState.h"             // orionldState
+
 #include "common/errorMessages.h"
 #include "alarmMgr/alarmMgr.h"
 #include "rest/ConnectionInfo.h"
@@ -53,7 +55,7 @@ std::string parseBatchUpdate(ConnectionInfo* ciP, BatchUpdate* burP)
   {
     alarmMgr.badInput(clientIp, "JSON Parse Error");
     oe.fill(SccBadRequest, ERROR_DESC_PARSE, ERROR_PARSE);
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
 
     return oe.toJson();
   }
@@ -62,7 +64,7 @@ std::string parseBatchUpdate(ConnectionInfo* ciP, BatchUpdate* burP)
   {
     alarmMgr.badInput(clientIp, "JSON Parse Error");
     oe.fill(SccBadRequest, ERROR_DESC_PARSE, ERROR_PARSE);
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
 
     return oe.toJson();
   }
@@ -70,7 +72,7 @@ std::string parseBatchUpdate(ConnectionInfo* ciP, BatchUpdate* burP)
   {
     alarmMgr.badInput(clientIp, "Empty JSON payload");
     oe.fill(SccBadRequest, ERROR_DESC_BAD_REQUEST_EMPTY_PAYLOAD, ERROR_BAD_REQUEST);
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
 
     return oe.toJson();
   }
@@ -80,7 +82,7 @@ std::string parseBatchUpdate(ConnectionInfo* ciP, BatchUpdate* burP)
 
     alarmMgr.badInput(clientIp, details);
     oe.fill(SccBadRequest, details, "BadRequest");
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
 
     return oe.toJson();
   }
@@ -90,7 +92,7 @@ std::string parseBatchUpdate(ConnectionInfo* ciP, BatchUpdate* burP)
 
     alarmMgr.badInput(clientIp, details);
     oe.fill(SccBadRequest, details, "BadRequest");
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
 
     return oe.toJson();
   }
@@ -108,7 +110,7 @@ std::string parseBatchUpdate(ConnectionInfo* ciP, BatchUpdate* burP)
       {
         alarmMgr.badInput(clientIp, r);
         oe.fill(SccBadRequest, r, "BadRequest");
-        ciP->httpStatusCode = SccBadRequest;
+        orionldState.httpStatusCode = SccBadRequest;
         r = oe.toJson();
         return r;
       }
@@ -122,7 +124,7 @@ std::string parseBatchUpdate(ConnectionInfo* ciP, BatchUpdate* burP)
 
         alarmMgr.badInput(clientIp, details);
         oe.fill(SccBadRequest, details, "BadRequest");
-        ciP->httpStatusCode = SccBadRequest;
+        orionldState.httpStatusCode = SccBadRequest;
 
         return oe.toJson();
       }
@@ -134,7 +136,7 @@ std::string parseBatchUpdate(ConnectionInfo* ciP, BatchUpdate* burP)
 
       alarmMgr.badInput(clientIp, description);
       oe.fill(SccBadRequest, description, "BadRequest");
-      ciP->httpStatusCode = SccBadRequest;
+      orionldState.httpStatusCode = SccBadRequest;
 
       return oe.toJson();
     }

--- a/src/lib/jsonParseV2/parseContextAttribute.cpp
+++ b/src/lib/jsonParseV2/parseContextAttribute.cpp
@@ -233,7 +233,7 @@ std::string parseContextAttribute
       if (r != "OK")
       {
         alarmMgr.badInput(clientIp, "json error in ContextAttribute::Vector");
-        ciP->httpStatusCode = SccBadRequest;
+        orionldState.httpStatusCode = SccBadRequest;
         return "json error in ContextAttribute::Vector";
       }
     }
@@ -245,7 +245,7 @@ std::string parseContextAttribute
     else
     {
       alarmMgr.badInput(clientIp, "bad type for ContextAttribute");
-      ciP->httpStatusCode = SccBadRequest;
+      orionldState.httpStatusCode = SccBadRequest;
       return "invalid JSON type for ContextAttribute";
     }
   }
@@ -257,7 +257,7 @@ std::string parseContextAttribute
     {
       std::string details = "attribute must be a JSON object, unless keyValues option is used";
       alarmMgr.badInput(clientIp, details);
-      ciP->httpStatusCode = SccBadRequest;
+      orionldState.httpStatusCode = SccBadRequest;
       return details;
     }
 
@@ -268,14 +268,14 @@ std::string parseContextAttribute
       if (r != "OK")
       {
         alarmMgr.badInput(clientIp, "JSON parse error in ContextAttribute::Object");
-        ciP->httpStatusCode = SccBadRequest;
+        orionldState.httpStatusCode = SccBadRequest;
         return r;
       }
     }
     else
     {
       alarmMgr.badInput(clientIp, "no 'value' for ContextAttribute without keyValues");
-      ciP->httpStatusCode = SccBadRequest;
+      orionldState.httpStatusCode = SccBadRequest;
       return "no 'value' for ContextAttribute without keyValues";
     }
   }
@@ -289,7 +289,7 @@ std::string parseContextAttribute
   if (r != "OK")
   {
     alarmMgr.badInput(clientIp, r);
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
     return r;
   }
 
@@ -313,7 +313,7 @@ std::string parseContextAttribute(ConnectionInfo* ciP, ContextAttribute* caP)
     OrionError oe(SccBadRequest, ERROR_DESC_PARSE, ERROR_PARSE);
 
     alarmMgr.badInput(clientIp, "JSON parse error");
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
 
     return oe.toJson();
   }
@@ -324,7 +324,7 @@ std::string parseContextAttribute(ConnectionInfo* ciP, ContextAttribute* caP)
     OrionError oe(SccBadRequest, ERROR_DESC_PARSE, ERROR_PARSE);
 
     alarmMgr.badInput(clientIp, "JSON Parse Error");
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
 
     return oe.toJson();
   }
@@ -337,7 +337,7 @@ std::string parseContextAttribute(ConnectionInfo* ciP, ContextAttribute* caP)
     OrionError oe(SccBadRequest, r, "BadRequest");
 
     alarmMgr.badInput(clientIp, r);
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
 
     return oe.toJson();
   }

--- a/src/lib/jsonParseV2/parseEntity.cpp
+++ b/src/lib/jsonParseV2/parseEntity.cpp
@@ -72,7 +72,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
     OrionError oe(SccBadRequest, ERROR_DESC_PARSE, ERROR_PARSE);
 
     alarmMgr.badInput(clientIp, "JSON parse error");
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
 
     return oe.toJson();
   }
@@ -83,7 +83,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
     OrionError oe(SccBadRequest, ERROR_DESC_PARSE, ERROR_PARSE);
 
     alarmMgr.badInput(clientIp, "JSON Parse Error");
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
 
     return oe.toJson();
   }
@@ -96,7 +96,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
       OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_EMPTY_ENTITY_ID, ERROR_BAD_REQUEST);
 
       alarmMgr.badInput(clientIp, "No entity id specified");
-      ciP->httpStatusCode = SccBadRequest;
+      orionldState.httpStatusCode = SccBadRequest;
 
       return oe.toJson();
     }
@@ -110,7 +110,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
       OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_ENTID_IN_PAYLOAD, "BadRequest");
 
       alarmMgr.badInput(clientIp, ERROR_DESC_BAD_REQUEST_ENTID_IN_PAYLOAD);
-      ciP->httpStatusCode = SccBadRequest;
+      orionldState.httpStatusCode = SccBadRequest;
 
       return oe.toJson();
     }
@@ -120,7 +120,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
       OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_ENTTYPE_IN_PAYLOAD, "BadRequest");
 
       alarmMgr.badInput(clientIp, ERROR_DESC_BAD_REQUEST_ENTTYPE_IN_PAYLOAD);
-      ciP->httpStatusCode = SccBadRequest;
+      orionldState.httpStatusCode = SccBadRequest;
 
       return oe.toJson();
     }
@@ -135,7 +135,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
     OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_EMPTY_PAYLOAD, ERROR_BAD_REQUEST);
 
     alarmMgr.badInput(clientIp, ERROR_DESC_BAD_REQUEST_EMPTY_PAYLOAD);
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
 
     return oe.toJson();
   }
@@ -157,7 +157,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
           OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_JTYPE_ENTID, "BadRequest");
 
           alarmMgr.badInput(clientIp, ERROR_DESC_BAD_REQUEST_INVALID_JTYPE_ENTID);
-          ciP->httpStatusCode = SccBadRequest;
+          orionldState.httpStatusCode = SccBadRequest;
 
           return oe.toJson();
         }
@@ -169,7 +169,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
           OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_ENTID, "BadRequest");
 
           alarmMgr.badInput(clientIp, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_ENTID);
-          ciP->httpStatusCode = SccBadRequest;
+          orionldState.httpStatusCode = SccBadRequest;
 
           return oe.toJson();
         }
@@ -179,7 +179,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
         OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_ID_AS_ATTR, "BadRequest");
 
         alarmMgr.badInput(clientIp, ERROR_DESC_BAD_REQUEST_ID_AS_ATTR);
-        ciP->httpStatusCode = SccBadRequest;
+        orionldState.httpStatusCode = SccBadRequest;
 
         return oe.toJson();
       }
@@ -191,7 +191,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
         OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_JTYPE_ENTTYPE, "BadRequest");
 
         alarmMgr.badInput(clientIp, ERROR_DESC_BAD_REQUEST_INVALID_JTYPE_ENTTYPE);
-        ciP->httpStatusCode = SccBadRequest;
+        orionldState.httpStatusCode = SccBadRequest;
 
         return oe.toJson();
       }
@@ -205,7 +205,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
         OrionError  oe(SccBadRequest, errorText, "BadRequest");
 
         alarmMgr.badInput(clientIp, errorText);
-        ciP->httpStatusCode = SccBadRequest;
+        orionldState.httpStatusCode = SccBadRequest;
 
         return oe.toJson();
       }
@@ -215,7 +215,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
         OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_ENTTYPE, "BadRequest");
 
         alarmMgr.badInput(clientIp, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_ENTTYPE);
-        ciP->httpStatusCode = SccBadRequest;
+        orionldState.httpStatusCode = SccBadRequest;
 
         return oe.toJson();
       }
@@ -232,7 +232,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
         OrionError oe(SccBadRequest, r, "BadRequest");
 
         alarmMgr.badInput(clientIp, "parse error in context attribute");
-        ciP->httpStatusCode = SccBadRequest;
+        orionldState.httpStatusCode = SccBadRequest;
 
         return oe.toJson();
       }
@@ -244,7 +244,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
     OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_EMPTY_PAYLOAD, ERROR_BAD_REQUEST);
 
     alarmMgr.badInput(clientIp, "empty payload");
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
 
     return oe.toJson();
   }
@@ -256,7 +256,7 @@ std::string parseEntity(ConnectionInfo* ciP, Entity* eP, bool eidInURL)
       OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_EMPTY_ENTITY_ID, ERROR_BAD_REQUEST);
 
       alarmMgr.badInput(clientIp, "empty entity id");
-      ciP->httpStatusCode = SccBadRequest;
+      orionldState.httpStatusCode = SccBadRequest;
 
       return oe.toJson();
     }

--- a/src/lib/jsonParseV2/parseNotification.cpp
+++ b/src/lib/jsonParseV2/parseNotification.cpp
@@ -26,6 +26,8 @@
 
 #include "rapidjson/document.h"
 
+#include "orionld/common/orionldState.h"             // orionldState
+
 #include "common/errorMessages.h"
 #include "apiTypesV2/Entity.h"
 #include "alarmMgr/alarmMgr.h"
@@ -138,7 +140,7 @@ static bool parseNotificationNormalized(ConnectionInfo* ciP, NotifyContextReques
   {
     alarmMgr.badInput(clientIp, "JSON Parse Error");
     oeP->fill(SccBadRequest, ERROR_DESC_PARSE, ERROR_PARSE);
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
 
     return false;
   }
@@ -147,7 +149,7 @@ static bool parseNotificationNormalized(ConnectionInfo* ciP, NotifyContextReques
   {
     alarmMgr.badInput(clientIp, "JSON Parse Error");
     oeP->fill(SccBadRequest, ERROR_DESC_PARSE, ERROR_PARSE);
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
 
     return false;
   }
@@ -155,7 +157,7 @@ static bool parseNotificationNormalized(ConnectionInfo* ciP, NotifyContextReques
   {
     alarmMgr.badInput(clientIp, "Empty JSON payload");
     oeP->fill(SccBadRequest, ERROR_DESC_BAD_REQUEST_EMPTY_PAYLOAD, ERROR_BAD_REQUEST);
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
 
     return false;
   }
@@ -163,7 +165,7 @@ static bool parseNotificationNormalized(ConnectionInfo* ciP, NotifyContextReques
   {
     alarmMgr.badInput(clientIp, ERROR_DESC_BAD_REQUEST_NO_SUBSCRIPTION_ID);
     oeP->fill(SccBadRequest, ERROR_DESC_BAD_REQUEST_NO_SUBSCRIPTION_ID, "BadRequest");
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
 
     return false;
   }
@@ -173,7 +175,7 @@ static bool parseNotificationNormalized(ConnectionInfo* ciP, NotifyContextReques
 
     alarmMgr.badInput(clientIp, details);
     oeP->fill(SccBadRequest, details, "BadRequest");
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
 
     return false;
   }
@@ -190,7 +192,7 @@ static bool parseNotificationNormalized(ConnectionInfo* ciP, NotifyContextReques
         oeP->fill(SccBadRequest, ERROR_DESC_BAD_REQUEST_SUBSCRIPTIONID_NOT_STRING, "BadRequest");
 
         alarmMgr.badInput(clientIp, ERROR_DESC_BAD_REQUEST_SUBSCRIPTIONID_NOT_STRING);
-        ciP->httpStatusCode = SccBadRequest;
+        orionldState.httpStatusCode = SccBadRequest;
 
         return false;
       }
@@ -204,7 +206,7 @@ static bool parseNotificationNormalized(ConnectionInfo* ciP, NotifyContextReques
         oeP->fill(SccBadRequest, ERROR_DESC_BAD_REQUEST_DATA_NOT_ARRAY, "BadRequest");
 
         alarmMgr.badInput(clientIp, ERROR_DESC_BAD_REQUEST_DATA_NOT_ARRAY);
-        ciP->httpStatusCode = SccBadRequest;
+        orionldState.httpStatusCode = SccBadRequest;
 
         return false;
       }
@@ -212,7 +214,7 @@ static bool parseNotificationNormalized(ConnectionInfo* ciP, NotifyContextReques
       if (parseNotificationData(ciP, iter, ncrP, oeP) == false)
       {
         alarmMgr.badInput(clientIp, oeP->details);
-        ciP->httpStatusCode = SccBadRequest;
+        orionldState.httpStatusCode = SccBadRequest;
 
         return false;
       }
@@ -223,7 +225,7 @@ static bool parseNotificationNormalized(ConnectionInfo* ciP, NotifyContextReques
 
       alarmMgr.badInput(clientIp, description);
       oeP->fill(SccBadRequest, description, "BadRequest");
-      ciP->httpStatusCode = SccBadRequest;
+      orionldState.httpStatusCode = SccBadRequest;
 
       return false;
     }

--- a/src/lib/jsonParseV2/parseSubscription.cpp
+++ b/src/lib/jsonParseV2/parseSubscription.cpp
@@ -31,6 +31,8 @@
 
 #include "rapidjson/document.h"
 
+#include "orionld/common/orionldState.h"             // orionldState
+
 #include "alarmMgr/alarmMgr.h"
 #include "common/globals.h"
 #include "common/errorMessages.h"
@@ -91,7 +93,7 @@ std::string parseSubscription(ConnectionInfo* ciP, SubscriptionUpdate* subsP, bo
     OrionError oe(SccBadRequest, ERROR_DESC_PARSE, ERROR_PARSE);
 
     alarmMgr.badInput(clientIp, "JSON parse error");
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
 
     return oe.toJson();
   }
@@ -101,7 +103,7 @@ std::string parseSubscription(ConnectionInfo* ciP, SubscriptionUpdate* subsP, bo
     OrionError oe(SccBadRequest, ERROR_DESC_PARSE, ERROR_PARSE);
 
     alarmMgr.badInput(clientIp, "JSON parse error");
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
 
     return oe.toJson();
   }

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -940,7 +940,7 @@ std::string ContextAttribute::toJsonAsValue
   bool             acceptedJson,        // in parameter
   MimeType         outFormatSelection,  // in parameter
   MimeType*        outContentTypeP,     // out parameter
-  HttpStatusCode*  scP                  // out parameter
+  int*             scP                  // out parameter
 )
 {
   std::string  out;

--- a/src/lib/ngsi/ContextAttribute.h
+++ b/src/lib/ngsi/ContextAttribute.h
@@ -107,7 +107,7 @@ public:
                              bool             acceptedJson,
                              MimeType         outFormatSelection,
                              MimeType*        outContentTypeP,
-                             HttpStatusCode*  scP);
+                             int*             scP);
   void         release(void);
   std::string  getName(void);
 

--- a/src/lib/orionld/common/entityTypeCheck.cpp
+++ b/src/lib/orionld/common/entityTypeCheck.cpp
@@ -54,7 +54,7 @@ bool entityTypeCheck(KjNode* entityTypeNodeP, bool duplicatedType, char* entityI
   // Entity TYPE must not be duplicated
   if (duplicatedType == true)
   {
-    LM_W(("KZ: Bad Input (UPSERT: Duplicated entity::type)"));
+    LM_W(("Bad Input (UPSERT: Duplicated entity::type)"));
     entityErrorPush(errorsArrayP, entityId, OrionldBadRequestData, "Duplicated field", "entity::type", 400, false);
     return false;
   }

--- a/src/lib/orionld/common/orionldState.cpp
+++ b/src/lib/orionld/common/orionldState.cpp
@@ -165,18 +165,24 @@ void orionldStateInit(MHD_Connection* connection)
   orionldState.correlator  = (char*) "";
 
   // Outgoing HTTP headers
+#if 0
   orionldState.out.httpHeader     = orionldState.out.httpHeaderV;
   orionldState.out.httpHeaderSize = K_VEC_SIZE(orionldState.out.httpHeaderV);
   orionldState.out.httpHeaderIx   = 0;
+#endif
 
   orionldState.out.contentType    = JSON;  // Default outgoing Content-Type
 
   // Incoming HTTP headers
   orionldState.in.contentType    = JSON;  // Default incoming Content-Type
+
+
+  // Default response status code is 200 OK
+  orionldState.httpStatusCode = 200;
 }
 
 
-
+#if 0
 // -----------------------------------------------------------------------------
 //
 // orionldOutHeaderAdd -
@@ -217,7 +223,7 @@ void orionldOutHeaderAdd(char* key, char* sValue, int iValue)
 
   ++orionldState.out.httpHeaderIx;
 }
-
+#endif
 
 
 // -----------------------------------------------------------------------------

--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -105,6 +105,8 @@ typedef struct OrionldUriParamOptions
   bool dateCreated;    // Only NGSIv2
   bool dateModified;   // Only NGSIv2
   bool append;         // Only NGSIv2
+  bool noAttrDetail;   // Only NGSIv2
+  bool upsert;         // Only NGSIv2
   bool sysAttrs;
 } OrionldUriParamOptions;
 
@@ -118,6 +120,7 @@ typedef struct OrionldUriParams
 {
   char*     id;
   char*     type;
+  char*     typePattern;
   char*     idPattern;
   char*     attrs;
   char*     options;
@@ -125,6 +128,7 @@ typedef struct OrionldUriParams
   int       limit;
   bool      count;
   char*     q;
+  char*     mq;
   char*     geometry;
   char*     coordinates;
   char*     georel;
@@ -145,11 +149,14 @@ typedef struct OrionldUriParams
   bool      location;
   char*     url;
   bool      reload;
+  char*     exists;
   char*     notExists;
   char*     metadata;
   char*     orderBy;
   bool      collapse;
+  bool      reset;
   char*     attributeFormat;
+  char*     level;
 } OrionldUriParams;
 
 
@@ -187,10 +194,12 @@ typedef struct OrionldStateOut
   // Outgoing HTTP headers
   MimeType  contentType;
 
+#if 0
   char*     httpHeaderV[10];    // Buffer to be used if less than 10 headers
   char**    httpHeader;         // Points to httpHeaderV, reallocated if necessary
   int       httpHeaderSize;     // Max number of headers (reallocation if necessary)
   int       httpHeaderIx;       // Current index of 'httpHeader'
+#endif
 } OrionldStateOut;
 
 

--- a/src/lib/orionld/common/typeCheckForNonExistingEntities.cpp
+++ b/src/lib/orionld/common/typeCheckForNonExistingEntities.cpp
@@ -60,7 +60,7 @@ bool typeCheckForNonExistingEntities(KjNode* incomingTree, KjNode* idTypeAndCreD
 
     if (inEntityIdNodeP == NULL)  // Entity ID is mandatory
     {
-      LM_E(("KZ: Invalid Entity: Mandatory field entity::id is missing"));
+      LM_E(("Invalid Entity: Mandatory field entity::id is missing"));
       entityErrorPush(errorsArrayP, "No ID", OrionldBadRequestData, "Invalid Entity", "Mandatory field entity::id is missing", 400, true);
       next = inNodeP->next;
       kjChildRemove(incomingTree, inNodeP);
@@ -83,7 +83,7 @@ bool typeCheckForNonExistingEntities(KjNode* incomingTree, KjNode* idTypeAndCreD
 
       if (inEntityTypeNodeP == NULL)
       {
-        LM_E(("KZ: Invalid Entity: Mandatory field entity::type is missing"));
+        LM_E(("Invalid Entity: Mandatory field entity::type is missing"));
         entityErrorPush(errorsArrayP, inEntityIdNodeP->value.s, OrionldBadRequestData, "Invalid Entity", "Mandatory field entity::type is missing", 400, false);
 
         if (removeArray != NULL)

--- a/src/lib/orionld/rest/OrionLdRestService.h
+++ b/src/lib/orionld/rest/OrionLdRestService.h
@@ -102,7 +102,6 @@ typedef struct OrionLdRestServiceSimplifiedVector
 #define ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD  (1 << 2)
 #define ORIONLD_SERVICE_OPTION_MAKE_SURE_TENANT_EXISTS               (1 << 3)
 #define ORIONLD_SERVICE_OPTION_CLONE_PAYLOAD                         (1 << 4)
-#define ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS                      (1 << 5)
 #define ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED                     (1 << 6)
 #define ORIONLD_SERVICE_OPTION_NO_CONTEXT_TYPE_CHECK                 (1 << 7)
 

--- a/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
@@ -40,7 +40,6 @@ extern "C"
 #include "rest/ConnectionInfo.h"                                 // ConnectionInfo
 #include "orionld/common/orionldErrorResponse.h"                 // OrionldBadRequestData, ...
 #include "orionld/common/orionldState.h"                         // orionldState, orionldStateInit
-#include "orionld/common/SCOMPARE.h"                             // SCOMPARE
 #include "orionld/common/performance.h"                          // REQUEST_PERFORMANCE
 #include "orionld/common/tenantList.h"                           // tenant0
 #include "orionld/serviceRoutines/orionldBadVerb.h"              // orionldBadVerb
@@ -366,14 +365,10 @@ MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* 
     return MHD_YES;
   }
 
-  if (SCOMPARE3(key, 'i', 'd', 0))
+  if (strcmp(key, "id") == 0)
   {
     orionldState.uriParams.id = (char*) value;
     orionldState.uriParams.mask |= ORIONLD_URIPARAM_IDLIST;
-  }
-  else if (SCOMPARE13(key, 'e', 'n', 't', 'i', 't', 'y', ':', ':', 't', 'y', 'p', 'e', 0))
-  {
-    orionldState.uriParams.type = (char*) value;
   }
   else if (strcmp(key, "type") == 0)
   {
@@ -384,17 +379,17 @@ MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* 
   {
     orionldState.uriParams.typePattern = (char*) value;
   }
-  else if (SCOMPARE10(key, 'i', 'd', 'P', 'a', 't', 't', 'e', 'r', 'n', 0))
+  else if (strcmp(key, "idPattern") == 0)
   {
     orionldState.uriParams.idPattern = (char*) value;
     orionldState.uriParams.mask |= ORIONLD_URIPARAM_IDPATTERN;
   }
-  else if (SCOMPARE6(key, 'a', 't', 't', 'r', 's', 0))
+  else if (strcmp(key, "attrs") == 0)
   {
     orionldState.uriParams.attrs = (char*) value;
     orionldState.uriParams.mask |= ORIONLD_URIPARAM_ATTRS;
   }
-  else if (SCOMPARE7(key, 'o', 'f', 'f', 's', 'e', 't', 0))
+  else if (strcmp(key, "offset") == 0)
   {
     if (value[0] == '-')
     {
@@ -408,7 +403,7 @@ MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* 
 
     orionldState.uriParams.mask |= ORIONLD_URIPARAM_OFFSET;
   }
-  else if (SCOMPARE6(key, 'l', 'i', 'm', 'i', 't', 0))
+  else if (strcmp(key, "limit") == 0)
   {
     if (value[0] == '-')
     {
@@ -430,42 +425,42 @@ MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* 
 
     orionldState.uriParams.mask |= ORIONLD_URIPARAM_LIMIT;
   }
-  else if (SCOMPARE8(key, 'o', 'p', 't', 'i', 'o', 'n', 's', 0))
+  else if (strcmp(key, "options") == 0)
   {
     orionldState.uriParams.options = (char*) value;
     optionsParse(value);
     orionldState.uriParams.mask |= ORIONLD_URIPARAM_OPTIONS;
   }
-  else if (SCOMPARE9(key, 'g', 'e', 'o', 'm', 'e', 't', 'r', 'y', 0))
+  else if (strcmp(key, "geometry") == 0)
   {
     orionldState.uriParams.geometry = (char*) value;
     orionldState.uriParams.mask |= ORIONLD_URIPARAM_GEOMETRY;
   }
-  else if (SCOMPARE12(key, 'c', 'o', 'o', 'r', 'd', 'i', 'n', 'a', 't', 'e', 's', 0))
+  else if (strcmp(key, "coordinates") == 0)
   {
     orionldState.uriParams.coordinates = (char*) value;
     orionldState.uriParams.mask |= ORIONLD_URIPARAM_COORDINATES;
   }
-  else if (SCOMPARE7(key, 'c', 'o', 'o', 'r', 'd', 's', 0))  // Only NGSIv1/v2
+  else if (strcmp(key, "coords") == 0)  // Only NGSIv1/v2
   {
     orionldState.uriParams.coordinates = (char*) value;
   }
-  else if (SCOMPARE7(key, 'g', 'e', 'o', 'r', 'e', 'l', 0))
+  else if (strcmp(key, "georel") == 0)
   {
     orionldState.uriParams.georel = (char*) value;
     orionldState.uriParams.mask |= ORIONLD_URIPARAM_GEOREL;
   }
-  else if (SCOMPARE12(key, 'g', 'e', 'o', 'p', 'r', 'o', 'p', 'e', 'r', 't', 'y', 0))
+  else if (strcmp(key, "geoproperty") == 0)
   {
     orionldState.uriParams.geoproperty = (char*) value;
     orionldState.uriParams.mask |= ORIONLD_URIPARAM_GEOPROPERTY;
   }
-  else if (SCOMPARE17(key, 'g', 'e', 'o', 'm', 'e', 't', 'r', 'y', 'P', 'r', 'o', 'p', 'e', 'r', 't', 'y', 0))
+  else if (strcmp(key, "geometryProperty") == 0)
   {
     orionldState.uriParams.geometryProperty = (char*) value;
     orionldState.uriParams.mask |= ORIONLD_URIPARAM_GEOMETRYPROPERTY;
   }
-  else if (SCOMPARE6(key, 'c', 'o', 'u', 'n', 't', 0))
+  else if (strcmp(key, "count") == 0)
   {
     if (strcmp(value, "true") == 0)
       orionldState.uriParams.count = true;
@@ -479,7 +474,7 @@ MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* 
 
     orionldState.uriParams.mask |= ORIONLD_URIPARAM_COUNT;
   }
-  else if (SCOMPARE2(key, 'q', 0))
+  else if (strcmp(key, "q") == 0)
   {
     orionldState.uriParams.q = (char*) value;
     orionldState.uriParams.mask |= ORIONLD_URIPARAM_Q;
@@ -488,7 +483,7 @@ MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* 
   {
     orionldState.uriParams.mq = (char*) value;
   }
-  else if (SCOMPARE10(key, 'd', 'a', 't', 'a', 's', 'e', 't', 'I', 'd', 0))
+  else if (strcmp(key, "datasetId") == 0)
   {
     char* detail;
 
@@ -502,7 +497,7 @@ MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* 
     orionldState.uriParams.datasetId = (char*) value;
     orionldState.uriParams.mask |= ORIONLD_URIPARAM_DATASETID;
   }
-  else if (SCOMPARE10(key, 'd', 'e', 'l', 'e', 't', 'e', 'A', 'l', 'l', 0))
+  else if (strcmp(key, "deleteAll") == 0)
   {
     if (strcmp(value, "true") == 0)
       orionldState.uriParams.deleteAll = true;
@@ -517,30 +512,30 @@ MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* 
 
     orionldState.uriParams.mask |= ORIONLD_URIPARAM_DELETEALL;
   }
-  else if (SCOMPARE13(key, 't', 'i', 'm', 'e', 'p', 'r', 'o', 'p', 'e', 'r', 't', 'y', 0))
+  else if (strcmp(key, "timeproperty") == 0)
   {
     orionldState.uriParams.timeproperty = (char*) value;
     orionldState.uriParams.mask |= ORIONLD_URIPARAM_TIMEPROPERTY;
   }
-  else if (SCOMPARE8(key, 't', 'i', 'm', 'e', 'r', 'e', 'l', 0))
+  else if (strcmp(key, "timerel") == 0)
   {
     // FIXME: Check the value of timerel
     orionldState.uriParams.timerel = (char*) value;
     orionldState.uriParams.mask |= ORIONLD_URIPARAM_TIMEREL;
   }
-  else if (SCOMPARE7(key, 't', 'i', 'm', 'e', 'A', 't', 0))
+  else if (strcmp(key, "timeAt") == 0)
   {
     // FIXME: Check the value
     orionldState.uriParams.timeAt = (char*) value;
     orionldState.uriParams.mask |= ORIONLD_URIPARAM_TIMEAT;
   }
-  else if (SCOMPARE10(key, 'e', 'n', 'd', 'T', 'i', 'm', 'e', 'A', 't', 0))
+  else if (strcmp(key, "endTimeAt") == 0)
   {
     // FIXME: Check the value
     orionldState.uriParams.endTimeAt = (char*) value;
     orionldState.uriParams.mask |= ORIONLD_URIPARAM_ENDTIMEAT;
   }
-  else if (SCOMPARE8(key, 'd', 'e', 't', 'a', 'i', 'l', 's', 0))
+  else if (strcmp(key, "details") == 0)
   {
     if (strcmp(value, "true") == 0)
       orionldState.uriParams.details = true;
@@ -557,7 +552,7 @@ MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* 
 
     orionldState.uriParams.mask |= ORIONLD_URIPARAM_DETAILS;
   }
-  else if (SCOMPARE12(key, 'p', 'r', 'e', 't', 't', 'y', 'P', 'r', 'i', 'n', 't', 0))
+  else if (strcmp(key, "prettyPrint") == 0)
   {
     if (strcmp(value, "yes") == 0)
       orionldState.uriParams.prettyPrint = true;
@@ -572,17 +567,17 @@ MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* 
 
     orionldState.uriParams.mask |= ORIONLD_URIPARAM_PRETTYPRINT;
   }
-  else if (SCOMPARE7(key, 's', 'p', 'a', 'c', 'e', 's', 0))
+  else if (strcmp(key, "spaces") == 0)
   {
     orionldState.uriParams.spaces = atoi(value);
     orionldState.uriParams.mask  |= ORIONLD_URIPARAM_SPACES;
   }
-  else if (SCOMPARE15(key, 's', 'u', 'b', 's', 'c', 'r', 'i', 'p', 't', 'i', 'o', 'n', 'I', 'd', 0))
+  else if (strcmp(key, "subscriptionId") == 0)
   {
     orionldState.uriParams.subscriptionId  = (char*) value;
     orionldState.uriParams.mask           |= ORIONLD_URIPARAM_SUBSCRIPTION_ID;
   }
-  else if (SCOMPARE9(key, 'l', 'o', 'c', 'a', 't', 'i', 'o', 'n', 0))
+  else if (strcmp(key, "location") == 0)
   {
     if (strcmp(value, "true") == 0)
       orionldState.uriParams.location = true;
@@ -597,34 +592,34 @@ MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* 
 
     orionldState.uriParams.mask |= ORIONLD_URIPARAM_LOCATION;
   }
-  else if (SCOMPARE4(key, 'u', 'r', 'l', 0))
+  else if (strcmp(key, "url") == 0)
   {
     orionldState.uriParams.url   = (char*) value;
     orionldState.uriParams.mask |= ORIONLD_URIPARAM_URL;
   }
-  else if (SCOMPARE7(key, 'r', 'e', 'l', 'o', 'a', 'd', 0))
+  else if (strcmp(key, "reload") == 0)
   {
     orionldState.uriParams.reload = true;
     orionldState.uriParams.mask  |= ORIONLD_URIPARAM_RELOAD;
   }
-  else if (SCOMPARE6(key, 'e', 'x', 'i', 's', 't', 0))
+  else if (strcmp(key, "exist") == 0)
   {
     orionldState.uriParams.exists = (char*) value;
   }
-  else if (SCOMPARE7(key, '!', 'e', 'x', 'i', 's', 't', 0))
+  else if (strcmp(key, "!exist") == 0)
   {
     orionldState.uriParams.notExists = (char*) value;
     orionldState.uriParams.mask  |= ORIONLD_URIPARAM_NOTEXISTS;
   }
-  else if (SCOMPARE9(key, 'm', 'e', 't', 'a', 'd', 'a', 't', 'a', 0))
+  else if (strcmp(key, "metadata") == 0)
   {
     orionldState.uriParams.metadata = (char*) value;
   }
-  else if (SCOMPARE8(key, 'o', 'r', 'd', 'e', 'r', 'B', 'y', 0))
+  else if (strcmp(key, "orderBy") == 0)
   {
     orionldState.uriParams.orderBy = (char*) value;
   }
-  else if (SCOMPARE9(key, 'c', 'o', 'l', 'l', 'a', 'p', 's', 'e', 0))
+  else if (strcmp(key, "collapse") == 0)
   {
     if (strcmp(value, "true") == 0)
       orionldState.uriParams.collapse = true;
@@ -632,15 +627,15 @@ MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* 
   //
   // FIXME: attributeFormat AND attributesFormat ???
   //
-  else if (SCOMPARE16(key, 'a', 't', 't', 'r', 'i', 'b', 'u', 't', 'e', 'F', 'o', 'r', 'm', 'a', 't', 0))
+  else if (strcmp(key, "attributeFormat") == 0)
   {
     orionldState.uriParams.attributeFormat = (char*) value;
   }
-  else if (SCOMPARE17(key, 'a', 't', 't', 'r', 'i', 'b', 'u', 't', 'e', 's', 'F', 'o', 'r', 'm', 'a', 't', 0))
+  else if (strcmp(key, "attributesFormat") == 0)
   {
     orionldState.uriParams.attributeFormat = (char*) value;
   }
-  else if (SCOMPARE6(key, 'r', 'e', 's', 'e', 't', 0))
+  else if (strcmp(key, "reset") == 0)
   {
     if (strcmp(value, "true") == 0)
       orionldState.uriParams.reset = true;
@@ -648,6 +643,10 @@ MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* 
   else if (strcmp(key, "level") == 0)
   {
     orionldState.uriParams.level = (char*) value;
+  }
+  else if (strcmp(key, "entity::type") == 0)
+  {
+    orionldState.uriParams.type = (char*) value;
   }
   else
   {

--- a/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
@@ -697,6 +697,7 @@ MHD_Result orionldMhdConnectionTreat(ConnectionInfo* ciP)
   bool     contextToBeCashed    = false;
   bool     serviceRoutineResult = false;
 
+  LM_TMP(("KZ: orionldState.httpStatusCode == %d", orionldState.httpStatusCode));
   //
   // Predetected Error from orionldMhdConnectionInit?
   //
@@ -858,7 +859,9 @@ MHD_Result orionldMhdConnectionTreat(ConnectionInfo* ciP)
   // Call the SERVICE ROUTINE
   //
   PERFORMANCE(serviceRoutineStart);
+  LM_TMP(("KZ: orionldState.httpStatusCode == %d", orionldState.httpStatusCode));
   serviceRoutineResult = orionldState.serviceP->serviceRoutine(ciP);
+  LM_TMP(("KZ: orionldState.httpStatusCode == %d", orionldState.httpStatusCode));
   PERFORMANCE(serviceRoutineEnd);
 
   //
@@ -886,6 +889,7 @@ MHD_Result orionldMhdConnectionTreat(ConnectionInfo* ciP)
   //
   if ((orionldState.httpStatusCode >= 400) && (orionldState.responseTree == NULL) && (orionldState.httpStatusCode != 405))
   {
+    LM_TMP(("KZ: orionldState.httpStatusCode == %d", orionldState.httpStatusCode));
     orionldErrorResponseCreate(OrionldInternalError, "Unknown Error", "The reason for this error is unknown");
     orionldState.httpStatusCode = 500;
   }
@@ -1012,12 +1016,6 @@ MHD_Result orionldMhdConnectionTreat(ConnectionInfo* ciP)
 
     PERFORMANCE(renderEnd);
   }
-
-  //
-  // restReply assumes that the HTTP Status Code for the response is in 'ciP->httpStatusCode'
-  // FIXME: make the HTTP Status Code a parameter for restReply
-  //
-  ciP->httpStatusCode = (HttpStatusCode) orionldState.httpStatusCode;
 
   PERFORMANCE(restReplyStart);
 

--- a/src/lib/orionld/rest/orionldServiceInit.cpp
+++ b/src/lib/orionld/rest/orionldServiceInit.cpp
@@ -274,12 +274,9 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
     serviceP->uriParams |= ORIONLD_URIPARAM_OPTIONS;
     serviceP->uriParams |= ORIONLD_URIPARAM_ATTRS;
     serviceP->uriParams |= ORIONLD_URIPARAM_GEOMETRYPROPERTY;
-
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
   }
   else if (serviceP->serviceRoutine == orionldDeleteEntity)
   {
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
     serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED;
   }
   else if (serviceP->serviceRoutine == orionldPostEntity)
@@ -294,8 +291,6 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
   {
     serviceP->uriParams |= ORIONLD_URIPARAM_DATASETID;
     serviceP->uriParams |= ORIONLD_URIPARAM_DELETEALL;
-
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
   }
   else if (serviceP->serviceRoutine == orionldPostRegistrations)
   {
@@ -331,11 +326,9 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
   }
   else if (serviceP->serviceRoutine == orionldPatchRegistration)
   {
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
   }
   else if (serviceP->serviceRoutine == orionldDeleteRegistration)
   {
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
     serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED;
   }
   else if (serviceP->serviceRoutine == orionldPostSubscriptions)
@@ -362,11 +355,9 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
   }
   else if (serviceP->serviceRoutine == orionldPatchSubscription)
   {
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
   }
   else if (serviceP->serviceRoutine == orionldDeleteSubscription)
   {
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
     serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED;
   }
   else if (serviceP->serviceRoutine == orionldPostBatchCreate)
@@ -401,32 +392,25 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
   else if (serviceP->serviceRoutine == orionldGetEntityTypes)
   {
     serviceP->uriParams |= ORIONLD_URIPARAM_DETAILS;
-
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
   }
   else if (serviceP->serviceRoutine == orionldGetEntityAttributes)
   {
     serviceP->uriParams |= ORIONLD_URIPARAM_DETAILS;
-
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
   }
   else if (serviceP->serviceRoutine == orionldGetEntityAttribute)
   {
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
   }
   else if (serviceP->serviceRoutine == orionldPostTemporalEntities)
   {
     serviceP->options  = 0;  // Tenant will be created if necessary
 
     serviceP->options |= ORIONLD_SERVICE_OPTION_PREFETCH_ID_AND_TYPE;
-    serviceP->options |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
   }
   else if (serviceP->serviceRoutine == orionldGetVersion)
   {
     serviceP->options  = 0;  // Tenant is Ignored
 
     serviceP->options  = ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
-    serviceP->options |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
     serviceP->options |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED;
   }
   else if (serviceP->serviceRoutine == orionldGetTenants)
@@ -434,7 +418,6 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
     serviceP->options = 0;  // Tenant is Ignored
 
     serviceP->options |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
-    serviceP->options |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
     serviceP->options |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED;
   }
   else if (serviceP->serviceRoutine == orionldGetDbIndexes)
@@ -442,7 +425,6 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
     serviceP->options  = 0;  // Tenant is Ignored
 
     serviceP->options |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
-    serviceP->options |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
     serviceP->options |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED;
   }
   else if (serviceP->serviceRoutine == orionldGetContexts)
@@ -454,21 +436,18 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
     serviceP->uriParams |= ORIONLD_URIPARAM_URL;
 
     serviceP->options   |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
   }
   else if (serviceP->serviceRoutine == orionldGetContext)
   {
     serviceP->options  = 0;  // Tenant is Ignored
 
     serviceP->options   |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
   }
   else if (serviceP->serviceRoutine == orionldPostContexts)
   {
     serviceP->options  = 0;  // Tenant is Ignored
 
     serviceP->options   |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
     serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED;
     serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_TYPE_CHECK;
   }
@@ -477,7 +456,6 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
     serviceP->options  = 0;  // Tenant is Ignored
 
     serviceP->options   |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_V2_URI_PARAMS;
     serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED;
     serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_TYPE_CHECK;
 

--- a/src/lib/orionld/serviceRoutines/orionldGetEntities.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntities.cpp
@@ -144,11 +144,15 @@ bool orionldGetEntities(ConnectionInfo* ciP)
   QueryContextRequest   mongoRequest;
   QueryContextResponse  mongoResponse;
 
+  LM_TMP(("KZ2: geometry:    '%s'", geometry));
+  LM_TMP(("KZ2: georel:      '%s'", georel));
+  LM_TMP(("KZ2: coordinates: '%s'", orionldState.uriParams.coordinates));
+
   //
   // FIXME: Move all this to orionldMhdConnectionInit()
   //
   if ((id          != NULL) && (*id          == 0)) id          = NULL;
-  if ((coordinates != NULL) && (*coordinates == 0)) coordinates = NULL;
+//  if ((coordinates != NULL) && (*coordinates == 0)) coordinates = NULL;
 
   //
   // If URI param 'id' is given AND only one identifier in the list, then let the service routine for

--- a/src/lib/orionld/serviceRoutines/orionldPostBatchCreate.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostBatchCreate.cpp
@@ -128,6 +128,9 @@ bool orionldPostBatchCreate(ConnectionInfo* ciP)
   // Error or not, the Link header should never be present in the reponse
   orionldState.noLinkHeader = true;
 
+  // The response is never JSON-LD
+  orionldState.out.contentType = JSON;
+
   //
   // Prerequisites for the payload in orionldState.requestTree:
   // * must be an array

--- a/src/lib/orionld/serviceRoutines/orionldPostBatchDelete.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostBatchDelete.cpp
@@ -62,6 +62,9 @@ bool orionldPostBatchDelete(ConnectionInfo* ciP)
   // Error or not, the Link header should never be present in the reponse
   orionldState.noLinkHeader = true;
 
+  // The response is never JSON-LD
+  orionldState.out.contentType = JSON;
+
   if (orionldState.requestTree->type != KjArray)
   {
     LM_W(("Bad Input (Payload must be a JSON Array)"));

--- a/src/lib/orionld/serviceRoutines/orionldPostBatchUpdate.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostBatchUpdate.cpp
@@ -85,6 +85,9 @@ bool orionldPostBatchUpdate(ConnectionInfo* ciP)
   // Error or not, the Link header should never be present in the reponse
   orionldState.noLinkHeader = true;
 
+  // The response is never JSON-LD
+  orionldState.out.contentType = JSON;
+
   //
   // Prerequisites for the payload in orionldState.requestTree:
   // * must be an array with objects

--- a/src/lib/orionld/serviceRoutines/orionldPostBatchUpsert.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostBatchUpsert.cpp
@@ -180,6 +180,9 @@ bool orionldPostBatchUpsert(ConnectionInfo* ciP)
   // Error or not, the Link header should never be present in the reponse
   orionldState.noLinkHeader = true;
 
+  // The response is never JSON-LD
+  orionldState.out.contentType = JSON;
+
   //
   // Prerequisites for URI params:
   // * both 'update' and 'replace' cannot be set in options (replace is default)

--- a/src/lib/parse/compoundValue.cpp
+++ b/src/lib/parse/compoundValue.cpp
@@ -27,6 +27,8 @@
 #include "logMsg/logMsg.h"
 #include "logMsg/traceLevels.h"
 
+#include "orionld/common/orionldState.h"                       // orionldState
+
 #include "common/globals.h"
 #include "alarmMgr/alarmMgr.h"
 
@@ -55,7 +57,7 @@ void compoundValueEnd(ConnectionInfo* ciP, ParseData* parseDataP)
   // If so, mark as erroneous
   if (status != "OK")
   {
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
     ciP->answer = std::string("compound value error: ") + status;
     alarmMgr.badInput(clientIp, ciP->answer);
   }

--- a/src/lib/parse/textParse.cpp
+++ b/src/lib/parse/textParse.cpp
@@ -58,7 +58,7 @@ static std::string textParseAttributeValue(ConnectionInfo* ciP, ContextAttribute
     else
     {
       OrionError oe(SccBadRequest, "Missing citation-mark at end of string");
-      return oe.setStatusCodeAndSmartRender(orionldState.apiVersion, &(ciP->httpStatusCode));
+      return oe.setStatusCodeAndSmartRender(orionldState.apiVersion, &orionldState.httpStatusCode);
     }
   }
 
@@ -90,7 +90,7 @@ static std::string textParseAttributeValue(ConnectionInfo* ciP, ContextAttribute
   else  // 5. None of the above - it's an error
   {
     OrionError oe(SccBadRequest, "attribute value type not recognized");
-    return oe.setStatusCodeAndSmartRender(orionldState.apiVersion, &(ciP->httpStatusCode));
+    return oe.setStatusCodeAndSmartRender(orionldState.apiVersion, &orionldState.httpStatusCode);
   }
 
   return "OK";
@@ -118,14 +118,14 @@ std::string textRequestTreat(ConnectionInfo* ciP, ParseData* parseDataP, Request
     if ((answer = parseDataP->av.attribute.check(orionldState.apiVersion, EntityAttributeValueRequest)) != "OK")
     {
       OrionError oe(SccBadRequest, answer);
-      return oe.setStatusCodeAndSmartRender(orionldState.apiVersion, &(ciP->httpStatusCode));
+      return oe.setStatusCodeAndSmartRender(orionldState.apiVersion, &orionldState.httpStatusCode);
     }
     break;
 
   default:
     OrionError oe(SccUnsupportedMediaType, "not supported content type: text/plain");
 
-    answer = oe.setStatusCodeAndSmartRender(orionldState.apiVersion, &(ciP->httpStatusCode));
+    answer = oe.setStatusCodeAndSmartRender(orionldState.apiVersion, &orionldState.httpStatusCode);
 
     alarmMgr.badInput(clientIp, "not supported content type: text/plain");
     break;

--- a/src/lib/rest/ConnectionInfo.cpp
+++ b/src/lib/rest/ConnectionInfo.cpp
@@ -72,8 +72,7 @@ ConnectionInfo::ConnectionInfo():
   transactionStart       { 0, 0 },
   inCompoundValue        (false),
   compoundValueP         (NULL),
-  compoundValueRoot      (NULL),
-  httpStatusCode         (SccOk)
+  compoundValueRoot      (NULL)
 {
 }
 
@@ -90,8 +89,7 @@ ConnectionInfo::ConnectionInfo(MHD_Connection* _connection):
   transactionStart       { 0, 0 },
   inCompoundValue        (false),
   compoundValueP         (NULL),
-  compoundValueRoot      (NULL),
-  httpStatusCode         (SccOk)
+  compoundValueRoot      (NULL)
 {
   orionldState.mhdConnection = _connection;
 

--- a/src/lib/rest/ConnectionInfo.h
+++ b/src/lib/rest/ConnectionInfo.h
@@ -33,6 +33,11 @@
 #include <vector>
 #include <map>
 
+extern "C"
+{
+#include "kjson/kjson.h"
+}
+
 #include "logMsg/logMsg.h"
 #include "logMsg/traceLevels.h"
 
@@ -40,16 +45,8 @@
 #include "ngsi/Request.h"
 #include "parse/CompoundValueNode.h"
 
-#include "rest/HttpStatusCode.h"
 #include "rest/mhd.h"
 #include "rest/HttpHeaders.h"
-#ifdef ORIONLD
-extern "C"
-{
-#include "kjson/kjson.h"
-}
-
-#endif  
 
 
 
@@ -95,7 +92,6 @@ public:
   ::std::vector<orion::CompoundValueNode*>  compoundValueVector;
 
   // Outgoing
-  HttpStatusCode            httpStatusCode;
   std::vector<std::string>  httpHeader;
   std::vector<std::string>  httpHeaderValue;
 

--- a/src/lib/rest/OrionError.cpp
+++ b/src/lib/rest/OrionError.cpp
@@ -120,11 +120,11 @@ std::string OrionError::smartRender(ApiVersion apiVersion)
 *
 * OrionError::setStatusCodeAndSmartRender -
 */
-std::string OrionError::setStatusCodeAndSmartRender(ApiVersion apiVersion, HttpStatusCode* scP)
+std::string OrionError::setStatusCodeAndSmartRender(ApiVersion apiVersion, int* scP)
 {
   if ((apiVersion == V2) || (apiVersion == ADMIN_API))
   {
-    *scP = code;
+    *scP = (HttpStatusCode) code;
   }
 
   return smartRender(apiVersion);

--- a/src/lib/rest/OrionError.h
+++ b/src/lib/rest/OrionError.h
@@ -50,7 +50,7 @@ public:
   OrionError(HttpStatusCode _code, const std::string& _details = "", const std::string& _reasonPhrase = "");
 
   std::string  smartRender(ApiVersion apiVersion);
-  std::string  setStatusCodeAndSmartRender(ApiVersion apiVersion, HttpStatusCode* scP);
+  std::string  setStatusCodeAndSmartRender(ApiVersion apiVersion, int* scP);
   std::string  toJson(void);
   std::string  render(void);
   void         fill(HttpStatusCode _code, const std::string& _details,  const std::string& _reasonPhrase = "");

--- a/src/lib/rest/RestService.cpp
+++ b/src/lib/rest/RestService.cpp
@@ -539,9 +539,8 @@ std::string restService(ConnectionInfo* ciP, RestService* serviceV)
     OrionError  error(SccBadRequest, "The Orion Context Broker is a REST service, not a 'web page'");
     std::string response = error.render();
 
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
     alarmMgr.badInput(clientIp, "The Orion Context Broker is a REST service, not a 'web page'");
-    ciP->httpStatusCode = SccBadRequest;
     restReply(ciP, response);
 
     return std::string("Empty URL");
@@ -554,7 +553,7 @@ std::string restService(ConnectionInfo* ciP, RestService* serviceV)
     if (compErrorDetect(orionldState.apiVersion, ciP->urlComponents, ciP->urlCompV, &oe))
     {
       alarmMgr.badInput(clientIp, oe.details);
-      ciP->httpStatusCode = SccBadRequest;
+      orionldState.httpStatusCode = SccBadRequest;
       restReply(ciP, oe.smartRender(orionldState.apiVersion));
       return "URL PATH component error";
     }
@@ -607,7 +606,7 @@ std::string restService(ConnectionInfo* ciP, RestService* serviceV)
   {
     OrionError  oe(SccBadRequest, result);
 
-    std::string  response = oe.setStatusCodeAndSmartRender(orionldState.apiVersion, &(ciP->httpStatusCode));
+    std::string  response = oe.setStatusCodeAndSmartRender(orionldState.apiVersion, &orionldState.httpStatusCode);
 
     alarmMgr.badInput(clientIp, result);
 

--- a/src/lib/rest/orionLogReply.cpp
+++ b/src/lib/rest/orionLogReply.cpp
@@ -24,6 +24,8 @@
 */
 #include <string>
 
+#include "orionld/common/orionldState.h"                         // orionldState
+
 #include "common/tag.h"
 #include "rest/ConnectionInfo.h"
 #include "rest/restReply.h"
@@ -42,7 +44,7 @@ std::string orionLogReply(ConnectionInfo* ciP, const std::string& what, const st
    out += valueTag(what, value);
    out += '}';
 
-   ciP->httpStatusCode = SccOk;
+   orionldState.httpStatusCode = SccOk;
    restReply(ciP, out);
 
    return out;

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -152,6 +152,7 @@ MHD_Result uriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, c
 {
   ConnectionInfo*  ciP   = (ConnectionInfo*) cbDataP;
 
+  LM_TMP(("orionldState.httpStatusCode == %d", orionldState.httpStatusCode));
   if ((val == NULL) || (*val == 0))
   {
     std::string  errorString = std::string("Empty right-hand-side for URI param /") + ckey + "/";
@@ -159,23 +160,20 @@ MHD_Result uriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, c
     if (orionldState.apiVersion == V2)
     {
       OrionError error(SccBadRequest, errorString);
-      ciP->httpStatusCode = error.code;
-      ciP->answer         = error.smartRender(orionldState.apiVersion);
+      orionldState.httpStatusCode = error.code;
+      ciP->answer                 = error.smartRender(orionldState.apiVersion);
 
-#ifdef ORIONLD
       orionldErrorResponseCreate(OrionldBadRequestData, "Empty right-hand-side for URI param", ckey);
-#endif
     }
     else if (orionldState.apiVersion == ADMIN_API)
     {
-      ciP->httpStatusCode = SccBadRequest;
-      ciP->answer         = "{" + JSON_STR("error") + ":" + JSON_STR(errorString) + "}";
+      orionldState.httpStatusCode = SccBadRequest;
+      ciP->answer                 = "{" + JSON_STR("error") + ":" + JSON_STR(errorString) + "}";
 
-#ifdef ORIONLD
       orionldErrorResponseCreate(OrionldBadRequestData, "Error in URI param", errorString.c_str());
-#endif
     }
 
+    LM_TMP(("orionldState.httpStatusCode == %d", orionldState.httpStatusCode));
     return MHD_YES;
   }
 
@@ -191,12 +189,12 @@ MHD_Result uriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, c
       if ((*cP < '0') || (*cP > '9'))
       {
         OrionError error(SccBadRequest, std::string("Bad pagination offset: /") + value + "/ [must be a decimal number]");
-        ciP->httpStatusCode = error.code;
-        ciP->answer         = error.smartRender(orionldState.apiVersion);
+        orionldState.httpStatusCode = error.code;
+        ciP->answer                 = error.smartRender(orionldState.apiVersion);
 
-#ifdef ORIONLD
         orionldErrorResponseCreate(OrionldBadRequestData, "Invalid value for URI parameter /offset/", "must be an integer value >= 0");
-#endif
+
+        LM_TMP(("orionldState.httpStatusCode == %d", orionldState.httpStatusCode));
         return MHD_YES;
       }
 
@@ -213,14 +211,14 @@ MHD_Result uriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, c
       if ((*cP < '0') || (*cP > '9'))
       {
         OrionError error(SccBadRequest, std::string("Bad pagination limit: /") + value + "/ [must be a decimal number]");
-        ciP->httpStatusCode = error.code;
-        ciP->answer         = error.smartRender(orionldState.apiVersion);
+        orionldState.httpStatusCode = error.code;
+        ciP->answer                 = error.smartRender(orionldState.apiVersion);
 
-#ifdef ORIONLD
         LM_E(("Invalid value for URI parameter 'limit': '%s'", val));
         orionldErrorResponseCreate(OrionldBadRequestData, "Invalid value for URI parameter /limit/", "must be an integer value >= 1");
         orionldState.httpStatusCode = SccBadRequest;
-#endif
+        LM_TMP(("orionldState.httpStatusCode == %d", orionldState.httpStatusCode));
+
         return MHD_YES;
       }
 
@@ -231,14 +229,14 @@ MHD_Result uriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, c
     if (limit > atoi(MAX_PAGINATION_LIMIT))
     {
       OrionError error(SccBadRequest, std::string("Bad pagination limit: /") + value + "/ [max: " + MAX_PAGINATION_LIMIT + "]");
-      ciP->httpStatusCode = error.code;
-      ciP->answer         = error.smartRender(orionldState.apiVersion);
+      orionldState.httpStatusCode = error.code;
+      ciP->answer                 = error.smartRender(orionldState.apiVersion);
 
-#ifdef ORIONLD
         LM_E(("Invalid value for URI parameter 'limit': '%s'", val));
         orionldErrorResponseCreate(OrionldBadRequestData, "Invalid value for URI parameter /limit/", "must be an integer value <= 1000");
         orionldState.httpStatusCode = SccBadRequest;
-#endif
+        LM_TMP(("orionldState.httpStatusCode == %d", orionldState.httpStatusCode));
+
       return MHD_YES;
     }
     else if (limit == 0)
@@ -246,8 +244,9 @@ MHD_Result uriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, c
       if (orionldState.apiVersion != NGSI_LD_V1)
       {
         OrionError error(SccBadRequest, std::string("Bad pagination limit: /") + value + "/ [a value of ZERO is unacceptable]");
-        ciP->httpStatusCode = error.code;
-        ciP->answer         = error.smartRender(orionldState.apiVersion);
+        orionldState.httpStatusCode = error.code;
+        ciP->answer                 = error.smartRender(orionldState.apiVersion);
+        LM_TMP(("orionldState.httpStatusCode == %d", orionldState.httpStatusCode));
       }
       return MHD_YES;
     }
@@ -259,12 +258,12 @@ MHD_Result uriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, c
     if ((strcasecmp(value.c_str(), "on") != 0) && (strcasecmp(value.c_str(), "off") != 0))
     {
       OrionError error(SccBadRequest, std::string("Bad value for /details/: /") + value + "/ [accepted: /on/, /ON/, /off/, /OFF/. Default is /off/]");
-      ciP->httpStatusCode = error.code;
-      ciP->answer         = error.smartRender(orionldState.apiVersion);
+      orionldState.httpStatusCode = error.code;
+      ciP->answer                 = error.smartRender(orionldState.apiVersion);
 
-#ifdef ORIONLD
       orionldErrorResponseCreate(OrionldBadRequestData, "Bad value for /details/ - accepted: /on/, /ON/, /off/, /OFF/. Default is /off/", val);
-#endif
+      LM_TMP(("orionldState.httpStatusCode == %d", orionldState.httpStatusCode));
+
       return MHD_YES;
     }
   }
@@ -287,12 +286,11 @@ MHD_Result uriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, c
       OrionError error(SccBadRequest, "Invalid value for URI param /options/");
 
       LM_W(("Bad Input (Invalid value for URI param /options/)"));
-      ciP->httpStatusCode = error.code;
-      ciP->answer         = error.smartRender(orionldState.apiVersion);
+      orionldState.httpStatusCode = error.code;
+      ciP->answer                 = error.smartRender(orionldState.apiVersion);
 
-#ifdef ORIONLD
       orionldErrorResponseCreate(OrionldBadRequestData, "Invalid value for URI parameter /options/", val);
-#endif
+      LM_TMP(("orionldState.httpStatusCode == %d", orionldState.httpStatusCode));
     }
   }
   else if (key == URI_PARAM_TYPE)
@@ -308,7 +306,6 @@ MHD_Result uriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, c
       ciP->uriParamTypes.push_back(val);
     }
   }
-#ifdef ORIONLD
   else if (key == URI_PARAM_PRETTY_PRINT)
   {
     if (strcmp(val, "yes") == 0)
@@ -320,7 +317,6 @@ MHD_Result uriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, c
   {
     orionldState.uriParams.spaces = atoi(val);
   }
-#endif
   else if ((key != URI_PARAM_Q)       &&
            (key != URI_PARAM_MQ)      &&
            (key != URI_PARAM_LEVEL))  // FIXME P1: possibly more known options here ...
@@ -366,12 +362,13 @@ MHD_Result uriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* ckey, c
     std::string details = std::string("found a forbidden character in URI param '") + key + "'";
     OrionError error(SccBadRequest, "invalid character in URI parameter");
 
-#ifdef ORIONLD
     orionldErrorResponseCreate(OrionldBadRequestData, "found a forbidden character in URI param", key.c_str());
-#endif
+
     alarmMgr.badInput(clientIp, details);
-    ciP->httpStatusCode = error.code;
-    ciP->answer         = error.smartRender(orionldState.apiVersion);
+    orionldState.httpStatusCode = error.code;
+    ciP->answer                 = error.smartRender(orionldState.apiVersion);
+    LM_W(("Bad Input (forbidden character in URI parameter value: %s=%s)", key.c_str(), val));
+    LM_TMP(("orionldState.httpStatusCode == %d", orionldState.httpStatusCode));
   }
 
   return MHD_YES;
@@ -441,10 +438,8 @@ static bool acceptItemParse(ConnectionInfo* ciP, char* value)
   //
   if ((strcmp(cP, "*/*")                  != 0) &&
       (strcmp(cP, "application/*")        != 0) &&
-#ifdef ORIONLD
       (strcmp(cP, "application/ld+json")  != 0) &&
       (strcmp(cP, "application/geo+json") != 0) &&
-#endif
       (strcmp(cP, "application/json")     != 0) &&
       (strcmp(cP, "text/*")               != 0) &&
       (strcmp(cP, "text/plain")           != 0))
@@ -483,8 +478,8 @@ static bool acceptItemParse(ConnectionInfo* ciP, char* value)
 
   if (*rest != 'q')
   {
-    ciP->acceptHeaderError = "q missing in accept header";
-    ciP->httpStatusCode    = SccBadRequest;
+    ciP->acceptHeaderError      = "q missing in accept header";
+    orionldState.httpStatusCode = SccBadRequest;
     delete acceptHeaderP;
     return false;
   }
@@ -493,8 +488,8 @@ static bool acceptItemParse(ConnectionInfo* ciP, char* value)
   ++rest;
   if (*rest != '=')
   {
-    ciP->acceptHeaderError = "missing equal-sign after q in accept header";
-    ciP->httpStatusCode    = SccBadRequest;
+    ciP->acceptHeaderError      = "missing equal-sign after q in accept header";
+    orionldState.httpStatusCode = SccBadRequest;
     delete acceptHeaderP;
     return false;
   }
@@ -510,8 +505,8 @@ static bool acceptItemParse(ConnectionInfo* ciP, char* value)
   // qvalue there?
   if (*rest == 0)
   {
-    ciP->acceptHeaderError = "qvalue in accept header is missing";
-    ciP->httpStatusCode    = SccBadRequest;
+    ciP->acceptHeaderError      = "qvalue in accept header is missing";
+    orionldState.httpStatusCode = SccBadRequest;
     delete acceptHeaderP;
     return false;
   }
@@ -519,8 +514,8 @@ static bool acceptItemParse(ConnectionInfo* ciP, char* value)
   // qvalue a number?
   if (str2double(rest, &acceptHeaderP->qvalue) == false)
   {
-    ciP->acceptHeaderError = "qvalue in accept header is not a number";
-    ciP->httpStatusCode    = SccBadRequest;
+    ciP->acceptHeaderError      = "qvalue in accept header is not a number";
+    orionldState.httpStatusCode = SccBadRequest;
 
     orionldState.out.contentType = mimeTypeSelect(ciP);
 
@@ -553,8 +548,8 @@ static void acceptParse(ConnectionInfo* ciP, const char* value)
 
   if (value[0] == 0)
   {
-    ciP->acceptHeaderError = "empty accept header";
-    ciP->httpStatusCode    = SccBadRequest;
+    ciP->acceptHeaderError      = "empty accept header";
+    orionldState.httpStatusCode = SccBadRequest;
     return;
   }
 
@@ -586,13 +581,13 @@ static void acceptParse(ConnectionInfo* ciP, const char* value)
 
   if ((ciP->httpHeaders.acceptHeaderV.size() == 0) && (ciP->acceptHeaderError == ""))
   {
-    ciP->httpStatusCode    = SccNotAcceptable;
-    ciP->acceptHeaderError = "no acceptable mime-type in accept header";
+    orionldState.httpStatusCode = SccNotAcceptable;
+    ciP->acceptHeaderError      = "no acceptable mime-type in accept header";
   }
 
-  if ((ciP->httpStatusCode == SccNotAcceptable) || (ciP->httpStatusCode == SccBadRequest))
+  if ((orionldState.httpStatusCode == SccNotAcceptable) || (orionldState.httpStatusCode == SccBadRequest))
   {
-    OrionError oe(ciP->httpStatusCode, ciP->acceptHeaderError);
+    OrionError oe((HttpStatusCode) orionldState.httpStatusCode, ciP->acceptHeaderError);
 
     ciP->answer = oe.smartRender(orionldState.apiVersion);
   }
@@ -639,10 +634,13 @@ MHD_Result httpHeaderGet(void* cbDataP, MHD_ValueKind kind, const char* key, con
     }
     else
     {
-      // Tenant used when tenant is not supported by the broker
-      LM_E(("tenant in use but tenant support is not enabled for the broker"));
-      orionldState.httpStatusCode = 400;
-      orionldErrorResponseCreate(OrionldBadRequestData, "Tenants not supported", "tenant in use but tenant support is not enabled for the broker");
+      // Tenant used when tenant is not supported by the broker - silently ignored for NGSIv2/v2, error for NGSI-LD
+      if (orionldState.apiVersion == NGSI_LD_V1)
+      {
+        LM_E(("tenant in use but tenant support is not enabled for the broker"));
+        orionldState.httpStatusCode = 400;
+        orionldErrorResponseCreate(OrionldBadRequestData, "Tenants not supported", "tenant in use but tenant support is not enabled for the broker");
+      }
     }
   }
   else if (strcasecmp(key, "X-Auth-Token") == 0)
@@ -659,11 +657,8 @@ MHD_Result httpHeaderGet(void* cbDataP, MHD_ValueKind kind, const char* key, con
   {
     headerP->servicePath         = value;
     headerP->servicePathReceived = true;
-#ifdef ORIONLD
     orionldState.servicePath = (char*) value;
-#endif
   }
-#ifdef ORIONLD
   else if (strcasecmp(key, HTTP_LINK) == 0)
   {
     orionldState.link                  = (char*) value;
@@ -673,7 +668,6 @@ MHD_Result httpHeaderGet(void* cbDataP, MHD_ValueKind kind, const char* key, con
   {
     orionldState.preferHeader = (char*) value;
   }
-#endif
   else
   {
     LM_T(LmtHttpUnsupportedHeader, ("'unsupported' HTTP header: '%s', value '%s'", key, value));
@@ -715,6 +709,7 @@ static void requestCompleted
 {
   PERFORMANCE(requestCompletedStart);
 
+  LM_TMP(("orionldState.httpStatusCode == %d", orionldState.httpStatusCode));
   ConnectionInfo*  ciP      = (ConnectionInfo*) *con_cls;
   const char*      spath    = (ciP->servicePathV.size() > 0)? ciP->servicePathV[0].c_str() : "";
   struct timespec  reqEndTime;
@@ -784,7 +779,7 @@ static void requestCompleted
   //
   // If the httpStatusCode is above the set of 200s, an error has occurred
   //
-  if (ciP->httpStatusCode >= SccBadRequest)
+  if (orionldState.httpStatusCode >= SccBadRequest)
   {
     if (metricsMgr.isOn())
       metricsMgr.add(orionldState.tenantP->tenant, spath, METRIC_TRANS_IN_ERRORS, 1);
@@ -915,7 +910,7 @@ int servicePathCheck(ConnectionInfo* ciP, const char* servicePath)
   if (servicePath[0] != '/')
   {
     OrionError oe(SccBadRequest, "Only /absolute/ Service Paths allowed [a service path must begin with /]");
-    ciP->answer = oe.setStatusCodeAndSmartRender(orionldState.apiVersion, &(ciP->httpStatusCode));
+    ciP->answer = oe.setStatusCodeAndSmartRender(orionldState.apiVersion, &orionldState.httpStatusCode);
     return 1;
   }
 
@@ -924,7 +919,7 @@ int servicePathCheck(ConnectionInfo* ciP, const char* servicePath)
   if (components > SERVICE_PATH_MAX_LEVELS)
   {
     OrionError oe(SccBadRequest, "too many components in ServicePath");
-    ciP->answer = oe.setStatusCodeAndSmartRender(orionldState.apiVersion, &(ciP->httpStatusCode));
+    ciP->answer = oe.setStatusCodeAndSmartRender(orionldState.apiVersion, &orionldState.httpStatusCode);
     return 2;
   }
 
@@ -933,14 +928,14 @@ int servicePathCheck(ConnectionInfo* ciP, const char* servicePath)
     if (strlen(compV[ix].c_str()) > SERVICE_PATH_MAX_COMPONENT_LEN)
     {
       OrionError oe(SccBadRequest, "component-name too long in ServicePath");
-      ciP->answer = oe.setStatusCodeAndSmartRender(orionldState.apiVersion, &(ciP->httpStatusCode));
+      ciP->answer = oe.setStatusCodeAndSmartRender(orionldState.apiVersion, &orionldState.httpStatusCode);
       return 3;
     }
 
     if (compV[ix].c_str()[0] == 0)
     {
       OrionError oe(SccBadRequest, "empty component in ServicePath");
-      ciP->answer = oe.setStatusCodeAndSmartRender(orionldState.apiVersion, &(ciP->httpStatusCode));
+      ciP->answer = oe.setStatusCodeAndSmartRender(orionldState.apiVersion, &orionldState.httpStatusCode);
       return 3;
     }
 
@@ -959,7 +954,7 @@ int servicePathCheck(ConnectionInfo* ciP, const char* servicePath)
       if (!isalnum(comp[cIx]) && (comp[cIx] != '_'))
       {
         OrionError oe(SccBadRequest, "a component of ServicePath contains an illegal character");
-        ciP->answer = oe.setStatusCodeAndSmartRender(orionldState.apiVersion, &(ciP->httpStatusCode));
+        ciP->answer = oe.setStatusCodeAndSmartRender(orionldState.apiVersion, &orionldState.httpStatusCode);
         return 4;
       }
     }
@@ -1140,9 +1135,9 @@ static int contentTypeCheck(ConnectionInfo* ciP)
   if (ciP->httpHeaders.contentType == "")
   {
     std::string details = "Content-Type header not used, default application/octet-stream is not supported";
-    ciP->httpStatusCode = SccUnsupportedMediaType;
+    orionldState.httpStatusCode = SccUnsupportedMediaType;
     restErrorReplyGet(ciP, SccUnsupportedMediaType, details, &ciP->answer);
-    ciP->httpStatusCode = SccUnsupportedMediaType;
+    orionldState.httpStatusCode = SccUnsupportedMediaType;
 
     return 1;
   }
@@ -1151,9 +1146,9 @@ static int contentTypeCheck(ConnectionInfo* ciP)
   if ((orionldState.apiVersion == V1) && (ciP->httpHeaders.contentType != "application/json"))
   {
     std::string details = std::string("not supported content type: ") + ciP->httpHeaders.contentType;
-    ciP->httpStatusCode = SccUnsupportedMediaType;
+    orionldState.httpStatusCode = SccUnsupportedMediaType;
     restErrorReplyGet(ciP, SccUnsupportedMediaType, details, &ciP->answer);
-    ciP->httpStatusCode = SccUnsupportedMediaType;
+    orionldState.httpStatusCode = SccUnsupportedMediaType;
     return 1;
   }
 
@@ -1162,9 +1157,9 @@ static int contentTypeCheck(ConnectionInfo* ciP)
   if ((orionldState.apiVersion == V2) && (ciP->httpHeaders.contentType != "application/json") && (ciP->httpHeaders.contentType != "text/plain"))
   {
     std::string details = std::string("not supported content type: ") + ciP->httpHeaders.contentType;
-    ciP->httpStatusCode = SccUnsupportedMediaType;
+    orionldState.httpStatusCode = SccUnsupportedMediaType;
     restErrorReplyGet(ciP, SccUnsupportedMediaType, details, &ciP->answer);
-    ciP->httpStatusCode = SccUnsupportedMediaType;
+    orionldState.httpStatusCode = SccUnsupportedMediaType;
     return 1;
   }
 
@@ -1178,7 +1173,7 @@ static int contentTypeCheck(ConnectionInfo* ciP)
 * urlCheck - check for forbidden characters and remove trailing slashes
 *
 * Returns 'true' if the URL is OK, 'false' otherwise.
-* ciP->answer and ciP->httpStatusCode are set if an error is encountered.
+* ciP->answer and orionldState.httpStatusCode are set if an error is encountered.
 *
 */
 bool urlCheck(ConnectionInfo* ciP, const std::string& url)
@@ -1186,8 +1181,8 @@ bool urlCheck(ConnectionInfo* ciP, const std::string& url)
   if (forbiddenChars(url.c_str()) == true)
   {
     OrionError error(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_URI);
-    ciP->httpStatusCode = error.code;
-    ciP->answer         = error.smartRender(orionldState.apiVersion);
+    orionldState.httpStatusCode = error.code;
+    ciP->answer                 = error.smartRender(orionldState.apiVersion);
     return false;
   }
 
@@ -1421,6 +1416,7 @@ ConnectionInfo* connectionTreatInit
     return NULL;
   }
 
+  LM_TMP(("KZ: orionldState.httpStatusCode == %d", orionldState.httpStatusCode));
   // LM_K(("--------------------- Serving APIv%d request %s %s -----------------", orionldState.apiVersion, method, url));
 
   ciP->transactionStart.tv_sec  = transactionStart.tv_sec;
@@ -1447,7 +1443,9 @@ ConnectionInfo* connectionTreatInit
   ciP->uriParam[URI_PARAM_PAGINATION_LIMIT]   = DEFAULT_PAGINATION_LIMIT;
   ciP->uriParam[URI_PARAM_PAGINATION_DETAILS] = DEFAULT_PAGINATION_DETAILS;
 
+  LM_TMP(("KZ: Calling httpHeaderGet: orionldState.httpStatusCode == %d", orionldState.httpStatusCode));
   MHD_get_connection_values(connection, MHD_HEADER_KIND, httpHeaderGet, ciP);
+  LM_TMP(("KZ: Called httpHeaderGet: orionldState.httpStatusCode == %d", orionldState.httpStatusCode));
 
   if (ciP->httpHeaders.accept == "")  // No Accept: given, treated as */*
   {
@@ -1475,8 +1473,8 @@ ConnectionInfo* connectionTreatInit
     alarmMgr.badInput(clientIp, details);
     OrionError oe(SccRequestEntityTooLarge, details);
 
-    ciP->httpStatusCode = oe.code;
-    ciP->answer = oe.smartRender(orionldState.apiVersion);
+    orionldState.httpStatusCode = oe.code;
+    ciP->answer                 = oe.smartRender(orionldState.apiVersion);
 
     //
     // FIXME P4:
@@ -1511,7 +1509,9 @@ ConnectionInfo* connectionTreatInit
 
   orionldState.out.contentType = mimeTypeSelect(ciP);
 
+  LM_TMP(("KZ: Calling uriArgumentGet: orionldState.httpStatusCode == %d", orionldState.httpStatusCode));
   MHD_get_connection_values(connection, MHD_GET_ARGUMENT_KIND, uriArgumentGet, ciP);
+  LM_TMP(("KZ: After uriArgumentGet: orionldState.httpStatusCode == %d", orionldState.httpStatusCode));
 
   // Lookup Rest Service
   bool badVerb = false;
@@ -1541,16 +1541,14 @@ ConnectionInfo* connectionTreatInit
     std::string errorMsg;
 
     restErrorReplyGet(ciP, SccContentLengthRequired, "Zero/No Content-Length in PUT/POST/PATCH request", &errorMsg);
-    ciP->httpStatusCode  = SccContentLengthRequired;
+    orionldState.httpStatusCode  = SccContentLengthRequired;
     restReply(ciP, errorMsg);  // OK to respond as no payload
     alarmMgr.badInput(clientIp, errorMsg);
-
-    return ciP;
   }
   else if (orionldState.badVerb == true)
   {
     // Not ready to answer here - must wait until all the payload has been read
-    ciP->httpStatusCode = SccBadVerb;
+    orionldState.httpStatusCode = SccBadVerb;
   }
 
   return ciP;
@@ -1658,7 +1656,6 @@ static MHD_Result connectionTreat
    void**           con_cls
 )
 {
-#ifdef ORIONLD
   //
   // NGSI-LD requests implement a different URL parsing algorithm, a different payload parse algorithm, etc.
   // A complete new set of functions are used for NGSI-LD, so ...
@@ -1687,7 +1684,7 @@ static MHD_Result connectionTreat
       //
       // The entire message has been read, we're allowed to respond.
       //
-      // If any error has been encountered during stage I and II (init + payload-read), then ciP->httpStatusCode has been set to != SccOk (200)
+      // If any error has been encountered during stage I and II (init + payload-read), then orionldState.httpStatusCode has been set to != SccOk (200)
       // and, optionally a payload tree hangs under ciP->response.
       // No need to call the stage III function if this is the case.
       //
@@ -1699,7 +1696,6 @@ static MHD_Result connectionTreat
       return orionldMhdConnectionTreat((ConnectionInfo*) *con_cls);
     }
   }
-#endif
 
   //
   //  NOT NGSI-LD
@@ -1715,18 +1711,21 @@ static MHD_Result connectionTreat
     //
     kTimeGet(&orionldState.timestamp);
     orionldStateInit(connection);
-    orionldState.httpVersion  = (char*) version;
-    orionldState.apiVersion   = apiVersionGet(url);
-    orionldState.verbString   = (char*) method;
-    orionldState.verb         = verbGet(method);
-    orionldState.requestTime  = orionldState.timestamp.tv_sec + ((double) orionldState.timestamp.tv_nsec) / 1000000000;
-    orionldState.responseTree = NULL;
-    orionldState.notify       = false;
-    orionldState.urlPath      = (char*) url;
-    orionldState.attrsFormat  = (char*) "normalized";
-    orionldState.correlator   = (char*) "";
+    orionldState.httpVersion    = (char*) version;
+    orionldState.apiVersion     = apiVersionGet(url);
+    orionldState.verbString     = (char*) method;
+    orionldState.verb           = verbGet(method);
+    orionldState.requestTime    = orionldState.timestamp.tv_sec + ((double) orionldState.timestamp.tv_nsec) / 1000000000;
+    orionldState.responseTree   = NULL;
+    orionldState.notify         = false;
+    orionldState.urlPath        = (char*) url;
+    orionldState.attrsFormat    = (char*) "normalized";
+    orionldState.correlator     = (char*) "";
+    orionldState.httpStatusCode = 200;
 
+    LM_TMP(("KZ: Before orionldUriArgumentGet: orionldState.httpStatusCode == %d", orionldState.httpStatusCode));
     MHD_get_connection_values(connection, MHD_GET_ARGUMENT_KIND, orionldUriArgumentGet, NULL);
+    LM_TMP(("KZ: After orionldUriArgumentGet: orionldState.httpStatusCode == %d", orionldState.httpStatusCode));
 
     *con_cls = connectionTreatInit(connection, url, method, version, &retVal);
     return retVal;
@@ -1762,7 +1761,7 @@ static MHD_Result connectionTreat
 
   lmTransactionSetSubservice(ciP->httpHeaders.servicePath.c_str());
 
-  if ((ciP->httpStatusCode != SccOk) && (ciP->httpStatusCode != SccBadVerb))
+  if ((orionldState.httpStatusCode != SccOk) && (orionldState.httpStatusCode != SccBadVerb))
   {
     // An error has occurred. Here we are ready to respond, as all data has been read
     // However, if badVerb, then the service routine needs to execute to add the "Allow" HTTP header
@@ -1781,7 +1780,7 @@ static MHD_Result connectionTreat
     alarmMgr.badInput(clientIp, details);
     restErrorReplyGet(ciP, SccRequestEntityTooLarge, details, &ciP->answer);
 
-    ciP->httpStatusCode = SccRequestEntityTooLarge;
+    orionldState.httpStatusCode = SccRequestEntityTooLarge;
   }
 
 
@@ -1792,7 +1791,7 @@ static MHD_Result connectionTreat
   {
     OrionError   oe(SccBadRequest, ciP->acceptHeaderError);
 
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
     alarmMgr.badInput(clientIp, ciP->acceptHeaderError);
     restReply(ciP, oe.smartRender(orionldState.apiVersion));
     return MHD_YES;
@@ -1813,7 +1812,7 @@ static MHD_Result connectionTreat
       oe.details = "acceptable MIME types: application/json";
     }
 
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
     alarmMgr.badInput(clientIp, oe.details);
     restReply(ciP, oe.smartRender(orionldState.apiVersion));
     return MHD_YES;
@@ -1828,7 +1827,7 @@ static MHD_Result connectionTreat
       oe.details = "acceptable MIME types: application/json";
     }
 
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
     alarmMgr.badInput(clientIp, oe.details);
     restReply(ciP, oe.smartRender(orionldState.apiVersion));
     return MHD_YES;
@@ -1843,7 +1842,7 @@ static MHD_Result connectionTreat
     const char*  details = "Orion accepts no payload for GET/DELETE requests. HTTP header Content-Type is thus forbidden";
     OrionError   oe(SccBadRequest, details);
 
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
     alarmMgr.badInput(clientIp, details);
     restReply(ciP, oe.smartRender(orionldState.apiVersion));
 
@@ -1866,12 +1865,12 @@ static MHD_Result connectionTreat
   //
   // If error detected, just call treat function and respond to caller
   //
-  if (ciP->httpStatusCode != SccOk)
+  if (orionldState.httpStatusCode != SccOk)
   {
     ciP->answer = ciP->restServiceP->treat(ciP, ciP->urlComponents, ciP->urlCompV, NULL);
 
     // Bad Verb in API v1 should have empty payload
-    if ((orionldState.apiVersion == V1) && (ciP->httpStatusCode == SccBadVerb))
+    if ((orionldState.apiVersion == V1) && (orionldState.httpStatusCode == SccBadVerb))
     {
       ciP->answer = "";
     }

--- a/src/lib/rest/restReply.h
+++ b/src/lib/rest/restReply.h
@@ -44,6 +44,6 @@ extern void restReply(ConnectionInfo* ciP, const std::string& answer);
 *
 * restErrorReplyGet - 
 */
-extern void restErrorReplyGet(ConnectionInfo* ciP, HttpStatusCode code, const std::string& detail, std::string* outStringP);
+extern void restErrorReplyGet(ConnectionInfo* ciP, int statusCode, const std::string& detail, std::string* outStringP);
 
 #endif

--- a/src/lib/rest/restServiceLookup.cpp
+++ b/src/lib/rest/restServiceLookup.cpp
@@ -99,8 +99,8 @@ RestService* restServiceLookup(ConnectionInfo* ciP, bool* badVerbP)
   {
     if (serviceV == restBadVerbV)
     {
-      ciP->httpStatusCode  = SccBadVerb;
-      orionldState.badVerb = true;
+      orionldState.httpStatusCode = SccBadVerb;
+      orionldState.badVerb        = true;
     }
 
     return &serviceV[serviceIx];

--- a/src/lib/serviceRoutines/badVerbAllFive.cpp
+++ b/src/lib/serviceRoutines/badVerbAllFive.cpp
@@ -58,7 +58,7 @@ std::string badVerbAllFive
 
   ciP->httpHeader.push_back(HTTP_ALLOW);
   ciP->httpHeaderValue.push_back("POST, GET, PUT, DELETE, PATCH");
-  ciP->httpStatusCode = SccBadVerb;
+  orionldState.httpStatusCode = SccBadVerb;
 
   alarmMgr.badInput(clientIp, details);
 

--- a/src/lib/serviceRoutines/badVerbAllFour.cpp
+++ b/src/lib/serviceRoutines/badVerbAllFour.cpp
@@ -58,7 +58,7 @@ std::string badVerbAllFour
 
   ciP->httpHeader.push_back(HTTP_ALLOW);
   ciP->httpHeaderValue.push_back("POST, GET, PUT, DELETE");
-  ciP->httpStatusCode = SccBadVerb;
+  orionldState.httpStatusCode = SccBadVerb;
 
   alarmMgr.badInput(clientIp, details);
 

--- a/src/lib/serviceRoutines/badVerbGetDeleteOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbGetDeleteOnly.cpp
@@ -65,7 +65,7 @@ std::string badVerbGetDeleteOnly
     headerValue = headerValue + ", OPTIONS";
   }
   ciP->httpHeaderValue.push_back(headerValue);
-  ciP->httpStatusCode = SccBadVerb;
+  orionldState.httpStatusCode = SccBadVerb;
 
   alarmMgr.badInput(clientIp, details);
 

--- a/src/lib/serviceRoutines/badVerbGetOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbGetOnly.cpp
@@ -65,7 +65,7 @@ std::string badVerbGetOnly
     headerValue = headerValue + ", OPTIONS";
   }
   ciP->httpHeaderValue.push_back(headerValue);
-  ciP->httpStatusCode = SccBadVerb;
+  orionldState.httpStatusCode = SccBadVerb;
 
   alarmMgr.badInput(clientIp, details);
 

--- a/src/lib/serviceRoutines/badVerbGetPostDeleteOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbGetPostDeleteOnly.cpp
@@ -58,7 +58,7 @@ std::string badVerbGetPostDeleteOnly
 
   ciP->httpHeader.push_back(HTTP_ALLOW);
   ciP->httpHeaderValue.push_back("GET, POST, DELETE");
-  ciP->httpStatusCode = SccBadVerb;
+  orionldState.httpStatusCode = SccBadVerb;
 
   alarmMgr.badInput(clientIp, details);
 

--- a/src/lib/serviceRoutines/badVerbGetPostOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbGetPostOnly.cpp
@@ -66,7 +66,7 @@ std::string badVerbGetPostOnly
     headerValue = headerValue + ", OPTIONS";
   }
   ciP->httpHeaderValue.push_back(headerValue);
-  ciP->httpStatusCode = SccBadVerb;
+  orionldState.httpStatusCode = SccBadVerb;
 
   alarmMgr.badInput(clientIp, details);
 

--- a/src/lib/serviceRoutines/badVerbGetPutDeleteOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbGetPutDeleteOnly.cpp
@@ -65,7 +65,7 @@ std::string badVerbGetPutDeleteOnly
     headerValue = headerValue + ", OPTIONS";
   }
   ciP->httpHeaderValue.push_back(headerValue);
-  ciP->httpStatusCode = SccBadVerb;
+  orionldState.httpStatusCode = SccBadVerb;
 
   alarmMgr.badInput(clientIp, details);
 

--- a/src/lib/serviceRoutines/badVerbPostOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbPostOnly.cpp
@@ -65,7 +65,7 @@ std::string badVerbPostOnly
     headerValue = headerValue + ", OPTIONS";
   }
   ciP->httpHeaderValue.push_back(headerValue);
-  ciP->httpStatusCode = SccBadVerb;
+  orionldState.httpStatusCode = SccBadVerb;
 
   alarmMgr.badInput(clientIp, details);
 

--- a/src/lib/serviceRoutines/badVerbPutDeleteOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbPutDeleteOnly.cpp
@@ -58,7 +58,7 @@ std::string badVerbPutDeleteOnly
 
   ciP->httpHeader.push_back(HTTP_ALLOW);
   ciP->httpHeaderValue.push_back("PUT, DELETE");
-  ciP->httpStatusCode = SccBadVerb;
+  orionldState.httpStatusCode = SccBadVerb;
 
   return (orionldState.apiVersion == V1 || orionldState.apiVersion == NO_VERSION)? "" :  oe.smartRender(orionldState.apiVersion);
 }

--- a/src/lib/serviceRoutines/badVerbPutOnly.cpp
+++ b/src/lib/serviceRoutines/badVerbPutOnly.cpp
@@ -58,7 +58,7 @@ std::string badVerbPutOnly
 
   ciP->httpHeader.push_back(HTTP_ALLOW);
   ciP->httpHeaderValue.push_back("PUT");
-  ciP->httpStatusCode = SccBadVerb;
+  orionldState.httpStatusCode = SccBadVerb;
 
   alarmMgr.badInput(clientIp, details);
 

--- a/src/lib/serviceRoutines/deleteIndividualContextEntity.cpp
+++ b/src/lib/serviceRoutines/deleteIndividualContextEntity.cpp
@@ -77,6 +77,8 @@ std::string deleteIndividualContextEntity
   std::string  entityType = ciP->uriParam[URI_PARAM_ENTITY_TYPE];
   StatusCode   response;
 
+  LM_TMP(("KZ: entityType: '%s'", entityType));
+
   // 01. Fill in UpdateContextRequest fromURL-data + URI params
   parseDataP->upcr.res.fill(entityId, entityType, "false", "", "", ActionTypeDelete);
 

--- a/src/lib/serviceRoutines/exitTreat.cpp
+++ b/src/lib/serviceRoutines/exitTreat.cpp
@@ -28,6 +28,8 @@
 #include "logMsg/logMsg.h"
 #include "logMsg/traceLevels.h"
 
+#include "orionld/common/orionldState.h"                        // orionldState
+
 #include "common/globals.h"
 #include "mongoBackend/MongoGlobal.h"
 #include "ngsi/ParseData.h"
@@ -59,7 +61,7 @@ std::string exitTreat
   {
     OrionError orionError(SccBadRequest, "no such service");
 
-    ciP->httpStatusCode = SccOk;
+    orionldState.httpStatusCode = SccOk;
     out = orionError.render();
     return out;
   }
@@ -72,13 +74,13 @@ std::string exitTreat
   if (components == 1)
   {
     OrionError orionError(SccBadRequest, "Password requested");
-    ciP->httpStatusCode = SccOk;
+    orionldState.httpStatusCode = SccOk;
     out = orionError.render();
   }
   else if (password != "harakiri")
   {
     OrionError orionError(SccBadRequest, "Request denied - password erroneous");
-    ciP->httpStatusCode = SccOk;
+    orionldState.httpStatusCode = SccOk;
     out = orionError.render();
   }
   else

--- a/src/lib/serviceRoutines/leakTreat.cpp
+++ b/src/lib/serviceRoutines/leakTreat.cpp
@@ -28,6 +28,8 @@
 #include "logMsg/logMsg.h"
 #include "logMsg/traceLevels.h"
 
+#include "orionld/common/orionldState.h"                       // orionldState
+
 #include "common/statistics.h"
 #include "common/clockFunctions.h"
 
@@ -60,7 +62,7 @@ std::string leakTreat
   {
     OrionError orionError(SccBadRequest, "no such service");
 
-    ciP->httpStatusCode = SccOk;
+    orionldState.httpStatusCode = SccOk;
     TIMED_RENDER(out = orionError.render());
     return out;
   }
@@ -73,14 +75,14 @@ std::string leakTreat
   if (components == 1)
   {
     OrionError orionError(SccBadRequest, "Password requested");
-    ciP->httpStatusCode = SccOk;
+    orionldState.httpStatusCode = SccOk;
 
     TIMED_RENDER(out = orionError.render());
   }
   else if (password != "harakiri")
   {
     OrionError orionError(SccBadRequest, "Request denied - password erroneous");
-    ciP->httpStatusCode = SccOk;
+    orionldState.httpStatusCode = SccOk;
 
     TIMED_RENDER(out = orionError.render());
   }

--- a/src/lib/serviceRoutines/optionsVersionRequest.cpp
+++ b/src/lib/serviceRoutines/optionsVersionRequest.cpp
@@ -25,6 +25,8 @@
 #include <string>
 #include <vector>
 
+#include "orionld/common/orionldState.h"             // orionldState
+
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
 #include "rest/HttpHeaders.h"
@@ -77,7 +79,7 @@ std::string optionsVersionRequest
     ciP->httpHeaderValue.push_back(maxAge);
   }
 
-  ciP->httpStatusCode = SccOk;
+  orionldState.httpStatusCode = SccOk;
 
   return "";
 }

--- a/src/lib/serviceRoutines/postDiscoverContextAvailability.cpp
+++ b/src/lib/serviceRoutines/postDiscoverContextAvailability.cpp
@@ -56,7 +56,7 @@ std::string postDiscoverContextAvailability
   DiscoverContextAvailabilityResponse*  dcarP = &parseDataP->dcars.res;
   std::string                           answer;
 
-  TIMED_MONGO(ciP->httpStatusCode = mongoDiscoverContextAvailability(&parseDataP->dcar.res, dcarP, orionldState.tenantP, ciP->servicePathV));
+  TIMED_MONGO(orionldState.httpStatusCode = mongoDiscoverContextAvailability(&parseDataP->dcar.res, dcarP, orionldState.tenantP, ciP->servicePathV));
   TIMED_RENDER(answer = dcarP->render());
 
   return answer;

--- a/src/lib/serviceRoutines/postIndividualContextEntity.cpp
+++ b/src/lib/serviceRoutines/postIndividualContextEntity.cpp
@@ -100,6 +100,8 @@ std::string postIndividualContextEntity
   std::string                   answer;
   std::string                   out;
 
+  LM_TMP(("KZ: entityTypeFromURL == '%s'", entityTypeFromURL.c_str()));
+
   bool asJsonObject = (ciP->uriParam[URI_PARAM_ATTRIBUTE_FORMAT] == "object") && (orionldState.out.contentType == JSON);
 
   //

--- a/src/lib/serviceRoutines/postNotifyContext.cpp
+++ b/src/lib/serviceRoutines/postNotifyContext.cpp
@@ -56,13 +56,13 @@ std::string postNotifyContext
   NotifyContextResponse  ncr;
   std::string            answer;
 
-  TIMED_MONGO(ciP->httpStatusCode = mongoNotifyContext(&parseDataP->ncr.res,
-                                                       &ncr,
-                                                       orionldState.tenantP,
-                                                       orionldState.xAuthToken,
-                                                       ciP->servicePathV,
-                                                       ciP->httpHeaders.correlator,
-                                                       ciP->httpHeaders.ngsiv2AttrsFormat));
+  TIMED_MONGO(orionldState.httpStatusCode = mongoNotifyContext(&parseDataP->ncr.res,
+                                                               &ncr,
+                                                               orionldState.tenantP,
+                                                               orionldState.xAuthToken,
+                                                               ciP->servicePathV,
+                                                               ciP->httpHeaders.correlator,
+                                                               ciP->httpHeaders.ngsiv2AttrsFormat));
   TIMED_RENDER(answer = ncr.render());
 
   return answer;

--- a/src/lib/serviceRoutines/postNotifyContextAvailability.cpp
+++ b/src/lib/serviceRoutines/postNotifyContextAvailability.cpp
@@ -89,7 +89,7 @@ std::string postNotifyContextAvailability
     return answer;
   }
 
-  TIMED_MONGO(ciP->httpStatusCode = mongoNotifyContextAvailability(&parseDataP->ncar.res, &ncar, ciP->httpHeaders.correlator, orionldState.tenantP, servicePath));
+  TIMED_MONGO(orionldState.httpStatusCode = mongoNotifyContextAvailability(&parseDataP->ncar.res, &ncar, ciP->httpHeaders.correlator, orionldState.tenantP, servicePath));
   TIMED_RENDER(answer = ncar.render());
 
   return answer;

--- a/src/lib/serviceRoutines/postQueryContext.cpp
+++ b/src/lib/serviceRoutines/postQueryContext.cpp
@@ -182,15 +182,18 @@ static bool queryForward(ConnectionInfo* ciP, QueryContextRequest* qcrP, QueryCo
   // Overriding original verb to be a POST, now that this service routine has been invoked
   orionldState.verb = POST;
 
-  // Note that jsonTreat() is thought for client-to-CB interactions, thus it modifies ciP->httpStatusCode
+
+  //
+  // Note that jsonTreat() is thought for client-to-CB interactions, thus it modifies orionldState.httpStatusCode
   // Thus, we need to preserve it before (and recover after) in order a fail in the CB-to-CPr interaction doesn't
   // "corrupt" the status code in the client-to-CB interaction.
   // FIXME P5: not sure if I like this approach... very "hacking-style". Probably it would be better
   // to make JSON parsing logic (internal to jsonTreat()) independent of ciP (in fact, parsing process
   // hasn't anything to do with connection).
-  HttpStatusCode sc = ciP->httpStatusCode;
+  //
+  int saved = orionldState.httpStatusCode;
   s = jsonTreat(cleanPayload, ciP, &parseData, RtQueryContextResponse, NULL);
-  ciP->httpStatusCode = sc;
+  orionldState.httpStatusCode = saved;
 
   if (s != "OK")
   {
@@ -310,12 +313,12 @@ std::string postQueryContext
   //
   qcrsP->errorCode.fill(SccOk);
 
-  TIMED_MONGO(ciP->httpStatusCode = mongoQueryContext(qcrP,
-                                                      qcrsP,
-                                                      orionldState.tenantP,
-                                                      ciP->servicePathV,
-                                                      countP,
-                                                      orionldState.apiVersion));
+  TIMED_MONGO(orionldState.httpStatusCode = mongoQueryContext(qcrP,
+                                                              qcrsP,
+                                                              orionldState.tenantP,
+                                                              ciP->servicePathV,
+                                                              countP,
+                                                              orionldState.apiVersion));
 
   if (qcrsP->errorCode.code == SccBadRequest)
   {

--- a/src/lib/serviceRoutines/postRegisterContext.cpp
+++ b/src/lib/serviceRoutines/postRegisterContext.cpp
@@ -77,7 +77,7 @@ std::string postRegisterContext
         OrionError   oe(SccBadRequest, details);
 
         alarmMgr.badInput(clientIp, details);
-        ciP->httpStatusCode = SccBadRequest;
+        orionldState.httpStatusCode = SccBadRequest;
         return oe.render();
       }
     }
@@ -111,7 +111,7 @@ std::string postRegisterContext
     return answer;
   }
 
-  TIMED_MONGO(ciP->httpStatusCode = mongoRegisterContext(&parseDataP->rcr.res, &rcr, ciP->httpHeaders.correlator, orionldState.tenantP, ciP->servicePathV[0]));
+  TIMED_MONGO(orionldState.httpStatusCode = mongoRegisterContext(&parseDataP->rcr.res, &rcr, ciP->httpHeaders.correlator, orionldState.tenantP, ciP->servicePathV[0]));
   TIMED_RENDER(answer = rcr.render());
 
   return answer;

--- a/src/lib/serviceRoutines/postSubscribeContext.cpp
+++ b/src/lib/serviceRoutines/postSubscribeContext.cpp
@@ -73,7 +73,7 @@ std::string postSubscribeContext
   {
     char  noOfV[STRING_SIZE_FOR_LONG + 3];
     snprintf(noOfV, sizeof(noOfV) - 1, "%lu", ciP->servicePathV.size());
-    ciP->httpStatusCode           = SccOk;  // NGSIv1 is weird... it uses 200 OK at HTTP level for errors
+    orionldState.httpStatusCode   = SccOk;  // NGSIv1 is weird... it uses 200 OK at HTTP level for errors
     std::string details           = std::string("max *one* service-path allowed for subscriptions (") + noOfV + " given";
 
     alarmMgr.badInput(clientIp, details);
@@ -84,7 +84,7 @@ std::string postSubscribeContext
     return answer;
   }
 
-  TIMED_MONGO(ciP->httpStatusCode = mongoSubscribeContext(&parseDataP->scr.res, &scr, orionldState.tenantP, orionldState.xAuthToken, ciP->servicePathV, ciP->httpHeaders.correlator));
+  TIMED_MONGO(orionldState.httpStatusCode = mongoSubscribeContext(&parseDataP->scr.res, &scr, orionldState.tenantP, orionldState.xAuthToken, ciP->servicePathV, ciP->httpHeaders.correlator));
   TIMED_RENDER(answer = scr.render());
 
   parseDataP->scr.res.release();

--- a/src/lib/serviceRoutines/postSubscribeContextAvailability.cpp
+++ b/src/lib/serviceRoutines/postSubscribeContextAvailability.cpp
@@ -54,10 +54,10 @@ std::string postSubscribeContextAvailability
   SubscribeContextAvailabilityResponse  scar;
   std::string                           answer;
 
-  TIMED_MONGO(ciP->httpStatusCode = mongoSubscribeContextAvailability(&parseDataP->scar.res,
-                                                                      &scar,
-                                                                      ciP->httpHeaders.correlator,
-                                                                      orionldState.tenantP));
+  TIMED_MONGO(orionldState.httpStatusCode = mongoSubscribeContextAvailability(&parseDataP->scar.res,
+                                                                              &scar,
+                                                                              ciP->httpHeaders.correlator,
+                                                                              orionldState.tenantP));
   TIMED_RENDER(answer = scar.render());
 
   return answer;

--- a/src/lib/serviceRoutines/postUnsubscribeContext.cpp
+++ b/src/lib/serviceRoutines/postUnsubscribeContext.cpp
@@ -52,7 +52,7 @@ std::string postUnsubscribeContext
   UnsubscribeContextResponse  uncr;
   std::string                 answer;
 
-  TIMED_MONGO(ciP->httpStatusCode = mongoUnsubscribeContext(&parseDataP->uncr.res, &uncr, orionldState.tenantP));
+  TIMED_MONGO(orionldState.httpStatusCode = mongoUnsubscribeContext(&parseDataP->uncr.res, &uncr, orionldState.tenantP));
   TIMED_RENDER(answer = uncr.render());
 
   return answer;

--- a/src/lib/serviceRoutines/postUnsubscribeContextAvailability.cpp
+++ b/src/lib/serviceRoutines/postUnsubscribeContextAvailability.cpp
@@ -52,7 +52,7 @@ std::string postUnsubscribeContextAvailability
   UnsubscribeContextAvailabilityResponse  ucar;
   std::string                             answer;
 
-  TIMED_MONGO(ciP->httpStatusCode = mongoUnsubscribeContextAvailability(&parseDataP->ucar.res, &ucar, orionldState.tenantP));
+  TIMED_MONGO(orionldState.httpStatusCode = mongoUnsubscribeContextAvailability(&parseDataP->ucar.res, &ucar, orionldState.tenantP));
   TIMED_RENDER(answer = ucar.render());
 
   return answer;

--- a/src/lib/serviceRoutines/postUpdateContext.cpp
+++ b/src/lib/serviceRoutines/postUpdateContext.cpp
@@ -503,13 +503,10 @@ std::string postUpdateContext
                                                   orionldState.apiVersion,
                                                   ngsiV2Flavour));
 
-  if (ciP->httpStatusCode != SccCreated)
-  {
-    ciP->httpStatusCode = httpStatusCode;
-  }
+  if (orionldState.httpStatusCode != SccCreated)
+    orionldState.httpStatusCode = httpStatusCode;
 
   foundAndNotFoundAttributeSeparation(upcrsP, upcrP, ciP);
-
 
 
   //

--- a/src/lib/serviceRoutines/postUpdateContextAvailabilitySubscription.cpp
+++ b/src/lib/serviceRoutines/postUpdateContextAvailabilitySubscription.cpp
@@ -54,10 +54,10 @@ std::string postUpdateContextAvailabilitySubscription
 
   ucas.subscriptionId = parseDataP->ucas.res.subscriptionId;
 
-  TIMED_MONGO(ciP->httpStatusCode = mongoUpdateContextAvailabilitySubscription(&parseDataP->ucas.res,
-                                                                               &ucas,
-                                                                               ciP->httpHeaders.correlator,
-                                                                               orionldState.tenantP));
+  TIMED_MONGO(orionldState.httpStatusCode = mongoUpdateContextAvailabilitySubscription(&parseDataP->ucas.res,
+                                                                                       &ucas,
+                                                                                       ciP->httpHeaders.correlator,
+                                                                                       orionldState.tenantP));
 
   TIMED_RENDER(answer = ucas.render());
 

--- a/src/lib/serviceRoutines/postUpdateContextSubscription.cpp
+++ b/src/lib/serviceRoutines/postUpdateContextSubscription.cpp
@@ -56,12 +56,12 @@ std::string postUpdateContextSubscription
 
   ucsr.subscribeError.subscriptionId = parseDataP->ucsr.res.subscriptionId;
 
-  TIMED_MONGO(ciP->httpStatusCode = mongoUpdateContextSubscription(&parseDataP->ucsr.res,
-                                                                   &ucsr,
-                                                                   orionldState.tenantP,
-                                                                   orionldState.xAuthToken,
-                                                                   ciP->servicePathV,
-                                                                   ciP->httpHeaders.correlator));
+  TIMED_MONGO(orionldState.httpStatusCode = mongoUpdateContextSubscription(&parseDataP->ucsr.res,
+                                                                           &ucsr,
+                                                                           orionldState.tenantP,
+                                                                           orionldState.xAuthToken,
+                                                                           ciP->servicePathV,
+                                                                           ciP->httpHeaders.correlator));
 
   TIMED_RENDER(answer = ucsr.render());
 

--- a/src/lib/serviceRoutines/statisticsTreat.cpp
+++ b/src/lib/serviceRoutines/statisticsTreat.cpp
@@ -336,7 +336,7 @@ std::string statisticsTreat
   int nSimNotif = __sync_fetch_and_add(&noOfSimulatedNotifications, 0);
   renderUsedCounter(&js, "simulatedNotifications", nSimNotif);
 
-  ciP->httpStatusCode = SccOk;
+  orionldState.httpStatusCode = SccOk;
   return js.str();
 }
 
@@ -386,6 +386,6 @@ std::string statisticsCacheTreat
   js.addNumber("updates", (long long)mscUpdates);
   js.addNumber("items", (long long)cacheItems);
 
-  ciP->httpStatusCode = SccOk;
+  orionldState.httpStatusCode = SccOk;
   return js.str();
 }

--- a/src/lib/serviceRoutines/versionTreat.cpp
+++ b/src/lib/serviceRoutines/versionTreat.cpp
@@ -122,6 +122,6 @@ std::string versionTreat
   out += "  \"doc\":             \"" + std::string(API_DOC)        + "\"\n";
   out += "}\n";
 
-  ciP->httpStatusCode = SccOk;
+  orionldState.httpStatusCode = SccOk;
   return out;
 }

--- a/src/lib/serviceRoutinesV2/badVerbAllNotDelete.cpp
+++ b/src/lib/serviceRoutinesV2/badVerbAllNotDelete.cpp
@@ -66,7 +66,7 @@ std::string badVerbAllNotDelete
     headerValue = headerValue + ", OPTIONS";
   }
   ciP->httpHeaderValue.push_back(headerValue);
-  ciP->httpStatusCode = SccBadVerb;
+  orionldState.httpStatusCode = SccBadVerb;
 
   alarmMgr.badInput(clientIp, details);
 

--- a/src/lib/serviceRoutinesV2/badVerbGetDeletePatchOnly.cpp
+++ b/src/lib/serviceRoutinesV2/badVerbGetDeletePatchOnly.cpp
@@ -65,7 +65,7 @@ std::string badVerbGetDeletePatchOnly
     headerValue = headerValue + ", OPTIONS";
   }
   ciP->httpHeaderValue.push_back(headerValue);
-  ciP->httpStatusCode = SccBadVerb;
+  orionldState.httpStatusCode = SccBadVerb;
 
   alarmMgr.badInput(clientIp, details);
 

--- a/src/lib/serviceRoutinesV2/badVerbGetPutOnly.cpp
+++ b/src/lib/serviceRoutinesV2/badVerbGetPutOnly.cpp
@@ -65,7 +65,7 @@ std::string badVerbGetPutOnly
     headerValue = headerValue + ", OPTIONS";
   }
   ciP->httpHeaderValue.push_back(headerValue);
-  ciP->httpStatusCode = SccBadVerb;
+  orionldState.httpStatusCode = SccBadVerb;
 
   alarmMgr.badInput(clientIp, details);
 

--- a/src/lib/serviceRoutinesV2/deleteEntity.cpp
+++ b/src/lib/serviceRoutinesV2/deleteEntity.cpp
@@ -71,13 +71,13 @@ std::string deleteEntity
   if (forbiddenIdChars(orionldState.apiVersion, compV[2].c_str() , NULL))
   {
     OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_URI, ERROR_BAD_REQUEST);
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
     return oe.toJson();
   }
 
   eP       = new Entity();
   eP->id   = compV[2];
-  eP->type = ciP->uriParam["type"];
+  eP->type = orionldState.uriParams.type;
 
   if (compV.size() == 5)  // Deleting an attribute
   {
@@ -97,12 +97,10 @@ std::string deleteEntity
   if (parseDataP->upcrs.res.oe.code != SccNone)
   {
     TIMED_RENDER(answer = parseDataP->upcrs.res.oe.toJson());
-    ciP->httpStatusCode = parseDataP->upcrs.res.oe.code;
+    orionldState.httpStatusCode = parseDataP->upcrs.res.oe.code;
   }
   else
-  {
-    ciP->httpStatusCode = SccNoContent;
-  }
+    orionldState.httpStatusCode = SccNoContent;
 
   // Cleanup and return result
   eP->release();

--- a/src/lib/serviceRoutinesV2/deleteEntity.cpp
+++ b/src/lib/serviceRoutinesV2/deleteEntity.cpp
@@ -77,7 +77,7 @@ std::string deleteEntity
 
   eP       = new Entity();
   eP->id   = compV[2];
-  eP->type = orionldState.uriParams.type;
+  eP->type = (orionldState.uriParams.type != NULL)? orionldState.uriParams.type : (char*) "";
 
   if (compV.size() == 5)  // Deleting an attribute
   {

--- a/src/lib/serviceRoutinesV2/deleteMetrics.cpp
+++ b/src/lib/serviceRoutinesV2/deleteMetrics.cpp
@@ -28,6 +28,8 @@
 #include "logMsg/logMsg.h"
 #include "logMsg/traceLevels.h"
 
+#include "orionld/common/orionldState.h"                         // orionldState
+
 #include "alarmMgr/alarmMgr.h"
 #include "metricsMgr/metricsMgr.h"
 #include "ngsi/ParseData.h"
@@ -54,13 +56,13 @@ std::string deleteMetrics
   {
     OrionError oe(SccBadRequest, "metrics desactivated");
 
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
 
     return oe.toJson();
   }
 
   metricsMgr.reset();
 
-  ciP->httpStatusCode = SccNoContent;
+  orionldState.httpStatusCode = SccNoContent;
   return "";
 }

--- a/src/lib/serviceRoutinesV2/deleteRegistration.cpp
+++ b/src/lib/serviceRoutinesV2/deleteRegistration.cpp
@@ -62,7 +62,7 @@ std::string deleteRegistration
 
   TIMED_MONGO(mongoRegistrationDelete(regId, orionldState.tenantP, ciP->servicePathV[0], &oe));
 
-  ciP->httpStatusCode = oe.code;
+  orionldState.httpStatusCode = oe.code;
 
   if (oe.code != SccNoContent)
   {

--- a/src/lib/serviceRoutinesV2/deleteSubscription.cpp
+++ b/src/lib/serviceRoutinesV2/deleteSubscription.cpp
@@ -72,12 +72,10 @@ std::string deleteSubscription
   if (uncr.oe.code != SccNone )
   {
     TIMED_RENDER(answer = uncr.oe.toJson());
-    ciP->httpStatusCode = uncr.oe.code;
+    orionldState.httpStatusCode = uncr.oe.code;
   }
   else
-  {
-    ciP->httpStatusCode = SccNoContent;
-  }
+    orionldState.httpStatusCode = SccNoContent;
 
   return answer;
 }

--- a/src/lib/serviceRoutinesV2/entryPointsTreat.cpp
+++ b/src/lib/serviceRoutinesV2/entryPointsTreat.cpp
@@ -28,6 +28,8 @@
 #include "logMsg/logMsg.h"
 #include "logMsg/traceLevels.h"
 
+#include "orionld/common/orionldState.h"                       // orionldState
+
 #include "common/string.h"
 #include "common/globals.h"
 #include "common/tag.h"
@@ -58,6 +60,6 @@ std::string entryPointsTreat
 
   out += "}";
 
-  ciP->httpStatusCode = SccOk;
+  orionldState.httpStatusCode = SccOk;
   return out;
 }

--- a/src/lib/serviceRoutinesV2/getAllSubscriptions.cpp
+++ b/src/lib/serviceRoutinesV2/getAllSubscriptions.cpp
@@ -76,7 +76,7 @@ std::string getAllSubscriptions
     std::string out;
 
     TIMED_RENDER(out = oe.toJson());
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
 
     return out;
   }

--- a/src/lib/serviceRoutinesV2/getEntities.cpp
+++ b/src/lib/serviceRoutinesV2/getEntities.cpp
@@ -85,26 +85,26 @@ std::string getEntities
   Entities     entities;
   std::string  answer;
   std::string  pattern     = ".*";  // all entities, default value
-  std::string  id          = ciP->uriParam["id"];
-  std::string  idPattern   = ciP->uriParam["idPattern"];
-  std::string  type        = ciP->uriParam["type"];
-  std::string  typePattern = ciP->uriParam["typePattern"];
-  std::string  q           = ciP->uriParam[URI_PARAM_Q];
-  std::string  mq          = ciP->uriParam[URI_PARAM_MQ];
   std::string  geometry    = ciP->uriParam["geometry"];
   std::string  coords      = ciP->uriParam["coords"];
   std::string  georel      = ciP->uriParam["georel"];
   std::string  out;
+  char*  id          = orionldState.uriParams.id;
+  char*  idPattern   = orionldState.uriParams.idPattern;
+  char*  type        = orionldState.uriParams.type;
+  char*  q           = orionldState.uriParams.q;
+  char*  mq          = orionldState.uriParams.mq;
+  char*  typePattern = orionldState.uriParams.typePattern;
 
-  if ((idPattern != "") && (id != ""))
+  if ((idPattern != NULL) && (id != NULL))
   {
     OrionError oe(SccBadRequest, "Incompatible parameters: id, IdPattern", "BadRequest");
 
     TIMED_RENDER(answer = oe.toJson());
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
     return answer;
   }
-  else if (id != "")
+  else if (id != NULL)
   {
     pattern = "";
 
@@ -128,17 +128,17 @@ std::string getEntities
       pattern += idsV[ix] + "$";
     }
   }
-  else if (idPattern != "")
+  else if (idPattern != NULL)
   {
-    pattern   = idPattern;
+    pattern = idPattern;
   }
 
-  if ((typePattern != "") && (type != ""))
+  if ((typePattern != NULL) && (type != NULL))
   {
     OrionError oe(SccBadRequest, "Incompatible parameters: type, typePattern", "BadRequest");
 
     TIMED_RENDER(answer = oe.toJson());
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
     return answer;
   }
 
@@ -150,7 +150,7 @@ std::string getEntities
     OrionError oe(SccBadRequest, "Invalid query: URI param /coords/ used without /geometry/", "BadRequest");
 
     TIMED_RENDER(out = oe.toJson());
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
     return out;
   }
   else if ((geometry != "") && (coords == ""))
@@ -158,7 +158,7 @@ std::string getEntities
     OrionError oe(SccBadRequest, "Invalid query: URI param /geometry/ used without /coords/", "BadRequest");
 
     TIMED_RENDER(out = oe.toJson());
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
     return out;
   }
 
@@ -167,7 +167,7 @@ std::string getEntities
     OrionError oe(SccBadRequest, "Invalid query: URI param /georel/ used without /geometry/", "BadRequest");
 
     TIMED_RENDER(out = oe.toJson());
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
     return out;
   }
 
@@ -189,7 +189,7 @@ std::string getEntities
       OrionError oe(SccBadRequest, std::string("Invalid query: ") + errorString, "BadRequest");
 
       TIMED_RENDER(out = oe.toJson());
-      ciP->httpStatusCode = oe.code;
+      orionldState.httpStatusCode = oe.code;
 
       scopeP->release();
       delete scopeP;
@@ -208,13 +208,13 @@ std::string getEntities
   // The plain q-string is saved in Scope::value, just in case.
   // Might be useful for debugging, if nothing else.
   //
-  if (q != "")
+  if (q != NULL)
   {
     Scope*       scopeP = new Scope(SCOPE_TYPE_SIMPLE_QUERY, q);
     std::string  errorString;
 
     scopeP->stringFilterP = new StringFilter(SftQ);
-    if (scopeP->stringFilterP->parse(q.c_str(), &errorString) == false)
+    if (scopeP->stringFilterP->parse(q, &errorString) == false)
     {
       OrionError oe(SccBadRequest, errorString, "BadRequest");
 
@@ -223,7 +223,7 @@ std::string getEntities
       delete scopeP;
 
       TIMED_RENDER(out = oe.toJson());
-      ciP->httpStatusCode = oe.code;
+      orionldState.httpStatusCode = oe.code;
       return out;
     }
 
@@ -237,13 +237,13 @@ std::string getEntities
   // The plain mq-string is saved in Scope::value, just in case.
   // Might be useful for debugging, if nothing else.
   //
-  if (mq != "")
+  if (mq != NULL)
   {
     Scope*       scopeP = new Scope(SCOPE_TYPE_SIMPLE_QUERY_MD, mq);
     std::string  errorString;
 
     scopeP->mdStringFilterP = new StringFilter(SftMq);
-    if (scopeP->mdStringFilterP->parse(mq.c_str(), &errorString) == false)
+    if (scopeP->mdStringFilterP->parse(mq, &errorString) == false)
     {
       OrionError oe(SccBadRequest, errorString, "BadRequest");
 
@@ -252,7 +252,7 @@ std::string getEntities
       delete scopeP;
 
       TIMED_RENDER(out = oe.toJson());
-      ciP->httpStatusCode = oe.code;
+      orionldState.httpStatusCode = oe.code;
       return out;
     }
 
@@ -270,9 +270,9 @@ std::string getEntities
   // 2. Used with a single type name, so add it to the fill
   // 3. Used and with more than ONE typename
 
-  if (!typePattern.empty())
+  if ((typePattern != NULL) && (*typePattern != 0))
   {
-    bool      isIdPattern = (idPattern != "" || pattern == ".*");
+    bool      isIdPattern = (idPattern != NULL || pattern == ".*");
     EntityId* entityId    = new EntityId(pattern, typePattern, isIdPattern ? "true" : "false", true);
 
     parseDataP->qcr.res.entityIdVector.push_back(entityId);
@@ -310,7 +310,7 @@ std::string getEntities
   // 03. Render Entities response
   if (parseDataP->qcrs.res.contextElementResponseVector.size() == 0)
   {
-    ciP->httpStatusCode = SccOk;
+    orionldState.httpStatusCode = SccOk;
     answer = "[]";
   }
   else
@@ -320,12 +320,12 @@ std::string getEntities
     if (entities.oe.code != SccNone)
     {
       TIMED_RENDER(answer = entities.oe.toJson());
-      ciP->httpStatusCode = entities.oe.code;
+      orionldState.httpStatusCode = entities.oe.code;
     }
     else
     {
       TIMED_RENDER(answer = entities.render());
-      ciP->httpStatusCode = SccOk;
+      orionldState.httpStatusCode = SccOk;
     }
   }
 

--- a/src/lib/serviceRoutinesV2/getEntity.cpp
+++ b/src/lib/serviceRoutinesV2/getEntity.cpp
@@ -68,7 +68,7 @@ std::string getEntity
 )
 {
   std::string entityId        = compV[2];
-  char*       type            = orionldState.uriParams.type;
+  char*       type            = (orionldState.uriParams.type == NULL)? (char*) "" : orionldState.uriParams.type;
 
   if (entityId == "")
   {

--- a/src/lib/serviceRoutinesV2/getEntity.cpp
+++ b/src/lib/serviceRoutinesV2/getEntity.cpp
@@ -68,19 +68,19 @@ std::string getEntity
 )
 {
   std::string entityId        = compV[2];
-  std::string type            = ciP->uriParam[URI_PARAM_TYPE];
+  char*       type            = orionldState.uriParams.type;
 
   if (entityId == "")
   {
     OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_EMPTY_ENTITY_ID, ERROR_BAD_REQUEST);
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
     return oe.toJson();
   }
 
   if (forbiddenIdChars(orionldState.apiVersion, entityId.c_str(), NULL))
   {
     OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_URI, ERROR_BAD_REQUEST);
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
     return oe.toJson();
   }
 
@@ -108,12 +108,12 @@ std::string getEntity
   if (parseDataP->qcrs.res.errorCode.code == SccOk && parseDataP->qcrs.res.contextElementResponseVector.size() > 1)
   {
     // No problem found, but we expect only one entity
-    ciP->httpStatusCode = SccConflict;
+    orionldState.httpStatusCode = SccConflict;
   }
   else
   {
     // the same of the wrapped operation
-    ciP->httpStatusCode = parseDataP->qcrs.res.errorCode.code;
+    orionldState.httpStatusCode = parseDataP->qcrs.res.errorCode.code;
   }
 
   // 04. Cleanup and return result

--- a/src/lib/serviceRoutinesV2/getEntityAllTypes.cpp
+++ b/src/lib/serviceRoutinesV2/getEntityAllTypes.cpp
@@ -62,7 +62,7 @@ std::string getEntityAllTypes
   EntityTypeVectorResponse  response;
   std::string               answer;
   unsigned int              totalTypes   = 0;
-  bool                      noAttrDetail = ciP->uriParamOptions[OPT_NO_ATTR_DETAIL];
+  bool                      noAttrDetail = orionldState.uriParamOptions.noAttrDetail;
   unsigned int*             totalTypesP  = NULL;
 
   // NGSIv2 uses options=count to request count

--- a/src/lib/serviceRoutinesV2/getEntityAttribute.cpp
+++ b/src/lib/serviceRoutinesV2/getEntityAttribute.cpp
@@ -66,7 +66,7 @@ std::string getEntityAttribute
   ParseData*                 parseDataP
 )
 {
-  std::string  type   = ciP->uriParam["type"];
+  char*        type   = orionldState.uriParams.type;
   std::string  answer;
   Attribute    attribute;
 
@@ -74,7 +74,7 @@ std::string getEntityAttribute
       forbiddenIdChars(orionldState.apiVersion, compV[4].c_str(), NULL))
   {
     OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_URI, ERROR_BAD_REQUEST);
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
     return oe.toJson();
   }
 
@@ -94,23 +94,23 @@ std::string getEntityAttribute
                                          ciP->httpHeaders.accepted("application/json"),
                                          ciP->httpHeaders.outformatSelect(),
                                          &orionldState.out.contentType,
-                                         &ciP->httpStatusCode,
+                                         &orionldState.httpStatusCode,
                                          ciP->uriParamOptions[OPT_KEY_VALUES],
                                          ciP->uriParam[URI_PARAM_METADATA],
                                          EntityAttributeResponse));
 
   if (attribute.oe.reasonPhrase == ERROR_TOO_MANY)
   {
-    ciP->httpStatusCode = SccConflict;
+    orionldState.httpStatusCode = SccConflict;
   }
   else if (attribute.oe.reasonPhrase == ERROR_NOT_FOUND)
   {
-    ciP->httpStatusCode = SccContextElementNotFound;  // Attribute to be precise!
+    orionldState.httpStatusCode = SccContextElementNotFound;  // Attribute to be precise!
   }
   else
   {
     // the same of the wrapped operation
-    ciP->httpStatusCode = parseDataP->qcrs.res.errorCode.code;
+    orionldState.httpStatusCode = parseDataP->qcrs.res.errorCode.code;
   }
 
   // 04. Cleanup and return result

--- a/src/lib/serviceRoutinesV2/getEntityAttribute.cpp
+++ b/src/lib/serviceRoutinesV2/getEntityAttribute.cpp
@@ -66,7 +66,7 @@ std::string getEntityAttribute
   ParseData*                 parseDataP
 )
 {
-  char*        type   = orionldState.uriParams.type;
+  char*        type   = (orionldState.uriParams.type != NULL)? orionldState.uriParams.type : (char*) "";
   std::string  answer;
   Attribute    attribute;
 

--- a/src/lib/serviceRoutinesV2/getEntityAttributeValue.cpp
+++ b/src/lib/serviceRoutinesV2/getEntityAttributeValue.cpp
@@ -68,7 +68,7 @@ std::string getEntityAttributeValue
 {
   Attribute    attribute;
   std::string  answer;
-  std::string  type       = orionldState.uriParams.type;
+  std::string  type       = (orionldState.uriParams.type != NULL)? orionldState.uriParams.type : (char*) "";
 
   if (forbiddenIdChars(orionldState.apiVersion,  compV[2].c_str(), NULL) ||
       (forbiddenIdChars(orionldState.apiVersion, compV[4].c_str(), NULL)))

--- a/src/lib/serviceRoutinesV2/getEntityAttributeValue.cpp
+++ b/src/lib/serviceRoutinesV2/getEntityAttributeValue.cpp
@@ -68,13 +68,13 @@ std::string getEntityAttributeValue
 {
   Attribute    attribute;
   std::string  answer;
-  std::string  type       = ciP->uriParam["type"];
+  std::string  type       = orionldState.uriParams.type;
 
   if (forbiddenIdChars(orionldState.apiVersion,  compV[2].c_str(), NULL) ||
       (forbiddenIdChars(orionldState.apiVersion, compV[4].c_str(), NULL)))
   {
     OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_URI, ERROR_BAD_REQUEST);
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
     return oe.toJson();
   }
 
@@ -88,7 +88,7 @@ std::string getEntityAttributeValue
   if (attribute.oe.code != SccNone)
   {
     TIMED_RENDER(answer = attribute.oe.toJson());
-    ciP->httpStatusCode = attribute.oe.code;
+    orionldState.httpStatusCode = attribute.oe.code;
   }
   else
   {
@@ -96,7 +96,7 @@ std::string getEntityAttributeValue
     std::string attributeType = attribute.pcontextAttribute->type;
 
     // the same of the wrapped operation
-    ciP->httpStatusCode = parseDataP->qcrs.res.errorCode.code;
+    orionldState.httpStatusCode = parseDataP->qcrs.res.errorCode.code;
 
     // Remove unwanted fields from attribute before rendering
     attribute.pcontextAttribute->type = "";
@@ -111,7 +111,7 @@ std::string getEntityAttributeValue
                                              ciP->httpHeaders.accepted("application/json"),
                                              ciP->httpHeaders.outformatSelect(),
                                              &orionldState.out.contentType,
-                                             &ciP->httpStatusCode,
+                                             &orionldState.httpStatusCode,
                                              ciP->uriParamOptions[OPT_KEY_VALUES],
                                              ciP->uriParam[URI_PARAM_METADATA],
                                              EntityAttributeValueRequest,

--- a/src/lib/serviceRoutinesV2/getEntityType.cpp
+++ b/src/lib/serviceRoutinesV2/getEntityType.cpp
@@ -62,12 +62,12 @@ std::string getEntityType
   EntityTypeResponse  response;
   std::string         entityTypeName = compV[2];
   std::string         answer;
-  bool                noAttrDetail   = ciP->uriParamOptions[OPT_NO_ATTR_DETAIL];
+  bool                noAttrDetail = orionldState.uriParamOptions.noAttrDetail;
 
   if (entityTypeName == "")
   {
     OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_EMPTY_ENTITY_TYPE, ERROR_BAD_REQUEST);
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
     return oe.toJson();
   }
 
@@ -82,7 +82,7 @@ std::string getEntityType
   {
     OrionError oe(SccContextElementNotFound, ERROR_DESC_NOT_FOUND_ENTITY_TYPE, ERROR_NOT_FOUND);
     TIMED_RENDER(answer = oe.toJson());
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
   }
   else
   {

--- a/src/lib/serviceRoutinesV2/getMetrics.cpp
+++ b/src/lib/serviceRoutinesV2/getMetrics.cpp
@@ -28,6 +28,8 @@
 #include "logMsg/logMsg.h"
 #include "logMsg/traceLevels.h"
 
+#include "orionld/common/orionldState.h"                         // orionldState
+
 #include "alarmMgr/alarmMgr.h"
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
@@ -59,12 +61,11 @@ std::string getMetrics
   {
     OrionError oe(SccBadRequest, "metrics desactivated");
 
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
     return oe.toJson();
   }
 
-  bool         doReset  = (ciP->uriParam["reset"] == "true")? true : false;
-  std::string  payload  = metricsMgr.toJson(doReset);
+  std::string  payload = metricsMgr.toJson(orionldState.uriParams.reset);
 
   return payload;
 }

--- a/src/lib/serviceRoutinesV2/getRegistrations.cpp
+++ b/src/lib/serviceRoutinesV2/getRegistrations.cpp
@@ -78,7 +78,7 @@ std::string getRegistrations
   if (oe.code != SccOk)
   {
     TIMED_RENDER(out = oe.toJson());
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
 
     return out;
   }

--- a/src/lib/serviceRoutinesV2/getSubscription.cpp
+++ b/src/lib/serviceRoutinesV2/getSubscription.cpp
@@ -66,7 +66,7 @@ std::string getSubscription
   if ((err = idCheck(idSub)) != "OK")
   {
     oe.fill(SccBadRequest, "Invalid subscription ID: " + err, "BadRequest");
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
     return oe.toJson();
   }
 
@@ -75,7 +75,7 @@ std::string getSubscription
   if (oe.code != SccOk)
   {
     TIMED_RENDER(out = oe.toJson());
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
     return out;
   }
 

--- a/src/lib/serviceRoutinesV2/logLevelTreat.cpp
+++ b/src/lib/serviceRoutinesV2/logLevelTreat.cpp
@@ -28,6 +28,8 @@
 #include "logMsg/logMsg.h"
 #include "logMsg/traceLevels.h"
 
+#include "orionld/common/orionldState.h"                         // orionldState
+
 #include "common/statistics.h"
 #include "common/clockFunctions.h"
 
@@ -52,40 +54,35 @@ std::string changeLogLevel
   ParseData*                 parseDataP
 )
 {
-  std::string  level   = ciP->uriParam[URI_PARAM_LEVEL];
-  const char*  levelP  = level.c_str();
-
-  if (level == "")
+  if (orionldState.uriParams.level == NULL)
   {
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
     alarmMgr.badInput(clientIp, "no log level in URI param");
     return "{\"error\":\"log level missing\"}";
   }
 
   //
   // Internally, the broker does not support "warn", nor "fatal".
-  // However, to easy the task for our users, the broker accepts both of them:
+  // However, to ease the task for our users, the broker accepts both of them:
   //  - "fatal" is translated into the internal "None", meaning complete silence.
   //  - "warn" is translated into "Warning" which is accepted internally.
   //
-  if ((strcasecmp(levelP, "none")    == 0) ||
-      (strcasecmp(levelP, "fatal")   == 0) ||
-      (strcasecmp(levelP, "error")   == 0) ||
-      (strcasecmp(levelP, "warning") == 0) ||
-      (strcasecmp(levelP, "warn")    == 0) ||
-      (strcasecmp(levelP, "info")    == 0) ||
-      (strcasecmp(levelP, "debug")   == 0))
+  if ((strcasecmp(orionldState.uriParams.level, "none")    == 0) ||
+      (strcasecmp(orionldState.uriParams.level, "fatal")   == 0) ||
+      (strcasecmp(orionldState.uriParams.level, "error")   == 0) ||
+      (strcasecmp(orionldState.uriParams.level, "warning") == 0) ||
+      (strcasecmp(orionldState.uriParams.level, "warn")    == 0) ||
+      (strcasecmp(orionldState.uriParams.level, "info")    == 0) ||
+      (strcasecmp(orionldState.uriParams.level, "debug")   == 0))
   {
-    if (strcasecmp(levelP, "warning") == 0)
-    {
-      level = "WARN";
-    }
+    if (strcasecmp(orionldState.uriParams.level, "warning") == 0)
+      orionldState.uriParams.level = (char*) "WARN";
 
-    lmLevelMaskSetString((char*) level.c_str());
+    lmLevelMaskSetString(orionldState.uriParams.level);
   }
   else
   {
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
     alarmMgr.badInput(clientIp, "invalid log level in URI param");
     return "{\"error\":\"invalid log level\"}";
   }

--- a/src/lib/serviceRoutinesV2/optionsAllNotDelete.cpp
+++ b/src/lib/serviceRoutinesV2/optionsAllNotDelete.cpp
@@ -25,6 +25,8 @@
 #include <string>
 #include <vector>
 
+#include "orionld/common/orionldState.h"             // orionldState
+
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
 #include "rest/HttpHeaders.h"
@@ -52,7 +54,7 @@ std::string optionsAllNotDelete
     ciP->httpHeader.push_back(HTTP_ACCESS_CONTROL_ALLOW_METHODS);
     ciP->httpHeaderValue.push_back("GET, PATCH, POST, PUT, OPTIONS");
   }
-  ciP->httpStatusCode = SccOk;
+  orionldState.httpStatusCode = SccOk;
 
   return "";
 }

--- a/src/lib/serviceRoutinesV2/optionsGetDeleteOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsGetDeleteOnly.cpp
@@ -25,6 +25,8 @@
 #include <string>
 #include <vector>
 
+#include "orionld/common/orionldState.h"             // orionldState
+
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
 #include "rest/HttpHeaders.h"
@@ -52,7 +54,7 @@ std::string optionsGetDeleteOnly
     ciP->httpHeader.push_back(HTTP_ACCESS_CONTROL_ALLOW_METHODS);
     ciP->httpHeaderValue.push_back("GET, DELETE, OPTIONS");
   }
-  ciP->httpStatusCode = SccOk;
+  orionldState.httpStatusCode = SccOk;
 
   return "";
 }

--- a/src/lib/serviceRoutinesV2/optionsGetDeletePatchOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsGetDeletePatchOnly.cpp
@@ -25,6 +25,8 @@
 #include <string>
 #include <vector>
 
+#include "orionld/common/orionldState.h"             // orionldState
+
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
 #include "rest/HttpHeaders.h"
@@ -52,7 +54,7 @@ std::string optionsGetDeletePatchOnly
     ciP->httpHeader.push_back(HTTP_ACCESS_CONTROL_ALLOW_METHODS);
     ciP->httpHeaderValue.push_back("GET, DELETE, PATCH, OPTIONS");
   }
-  ciP->httpStatusCode = SccOk;
+  orionldState.httpStatusCode = SccOk;
 
   return "";
 }

--- a/src/lib/serviceRoutinesV2/optionsGetOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsGetOnly.cpp
@@ -25,6 +25,8 @@
 #include <string>
 #include <vector>
 
+#include "orionld/common/orionldState.h"             // orionldState
+
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
 #include "rest/HttpHeaders.h"
@@ -52,7 +54,7 @@ std::string optionsGetOnly
     ciP->httpHeader.push_back(HTTP_ACCESS_CONTROL_ALLOW_METHODS);
     ciP->httpHeaderValue.push_back("GET, OPTIONS");
   }
-  ciP->httpStatusCode = SccOk;
+  orionldState.httpStatusCode = SccOk;
 
   return "";
 }

--- a/src/lib/serviceRoutinesV2/optionsGetPostOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsGetPostOnly.cpp
@@ -25,6 +25,8 @@
 #include <string>
 #include <vector>
 
+#include "orionld/common/orionldState.h"             // orionldState
+
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
 #include "rest/HttpHeaders.h"
@@ -52,7 +54,7 @@ std::string optionsGetPostOnly
     ciP->httpHeader.push_back(HTTP_ACCESS_CONTROL_ALLOW_METHODS);
     ciP->httpHeaderValue.push_back("GET, POST, OPTIONS");
   }
-  ciP->httpStatusCode = SccOk;
+  orionldState.httpStatusCode = SccOk;
 
   return "";
 }

--- a/src/lib/serviceRoutinesV2/optionsGetPutDeleteOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsGetPutDeleteOnly.cpp
@@ -25,6 +25,8 @@
 #include <string>
 #include <vector>
 
+#include "orionld/common/orionldState.h"             // orionldState
+
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
 #include "rest/HttpHeaders.h"
@@ -52,7 +54,7 @@ std::string optionsGetPutDeleteOnly
     ciP->httpHeader.push_back(HTTP_ACCESS_CONTROL_ALLOW_METHODS);
     ciP->httpHeaderValue.push_back("GET, PUT, DELETE, OPTIONS");
   }
-  ciP->httpStatusCode = SccOk;
+  orionldState.httpStatusCode = SccOk;
 
   return "";
 }

--- a/src/lib/serviceRoutinesV2/optionsGetPutOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsGetPutOnly.cpp
@@ -25,6 +25,8 @@
 #include <string>
 #include <vector>
 
+#include "orionld/common/orionldState.h"             // orionldState
+
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
 #include "rest/HttpHeaders.h"
@@ -52,7 +54,7 @@ std::string optionsGetPutOnly
     ciP->httpHeader.push_back(HTTP_ACCESS_CONTROL_ALLOW_METHODS);
     ciP->httpHeaderValue.push_back("GET, PUT, OPTIONS");
   }
-  ciP->httpStatusCode = SccOk;
+  orionldState.httpStatusCode = SccOk;
 
   return "";
 }

--- a/src/lib/serviceRoutinesV2/optionsPostOnly.cpp
+++ b/src/lib/serviceRoutinesV2/optionsPostOnly.cpp
@@ -25,6 +25,8 @@
 #include <string>
 #include <vector>
 
+#include "orionld/common/orionldState.h"             // orionldState
+
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
 #include "rest/HttpHeaders.h"
@@ -52,7 +54,7 @@ std::string optionsPostOnly
     ciP->httpHeader.push_back(HTTP_ACCESS_CONTROL_ALLOW_METHODS);
     ciP->httpHeaderValue.push_back("POST, OPTIONS");
   }
-  ciP->httpStatusCode = SccOk;
+  orionldState.httpStatusCode = SccOk;
 
   return "";
 }

--- a/src/lib/serviceRoutinesV2/patchEntity.cpp
+++ b/src/lib/serviceRoutinesV2/patchEntity.cpp
@@ -71,12 +71,12 @@ std::string patchEntity
   Entity*      eP     = &parseDataP->ent.res;
 
   eP->id = compV[2];
-  eP->type = ciP->uriParam["type"];
+  eP->type = orionldState.uriParams.type;
 
   if (forbiddenIdChars(orionldState.apiVersion, eP->id.c_str() , NULL))
   {
     OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_URI, ERROR_BAD_REQUEST);
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
     return oe.toJson();
   }
 
@@ -91,12 +91,10 @@ std::string patchEntity
   if (parseDataP->upcrs.res.oe.code != SccNone )
   {
     TIMED_RENDER(answer = parseDataP->upcrs.res.oe.toJson());
-    ciP->httpStatusCode = parseDataP->upcrs.res.oe.code;
+    orionldState.httpStatusCode = parseDataP->upcrs.res.oe.code;
   }
   else
-  {
-    ciP->httpStatusCode = SccNoContent;
-  }
+    orionldState.httpStatusCode = SccNoContent;
 
   // 05. Cleanup and return result
   eP->release();

--- a/src/lib/serviceRoutinesV2/patchEntity.cpp
+++ b/src/lib/serviceRoutinesV2/patchEntity.cpp
@@ -70,8 +70,8 @@ std::string patchEntity
   std::string  answer = "";
   Entity*      eP     = &parseDataP->ent.res;
 
-  eP->id = compV[2];
-  eP->type = orionldState.uriParams.type;
+  eP->id   = compV[2];
+  eP->type = (orionldState.uriParams.type != NULL)? orionldState.uriParams.type : (char*) "";
 
   if (forbiddenIdChars(orionldState.apiVersion, eP->id.c_str() , NULL))
   {

--- a/src/lib/serviceRoutinesV2/patchSubscription.cpp
+++ b/src/lib/serviceRoutinesV2/patchSubscription.cpp
@@ -82,12 +82,10 @@ std::string patchSubscription
   if (beError.code != SccNone)
   {
     TIMED_RENDER(answer = beError.toJson());
-    ciP->httpStatusCode = beError.code;
+    orionldState.httpStatusCode = beError.code;
   }
   else
-  {
-    ciP->httpStatusCode = SccNoContent;
-  }
+    orionldState.httpStatusCode = SccNoContent;
 
   return answer;
 }

--- a/src/lib/serviceRoutinesV2/postBatchQuery.cpp
+++ b/src/lib/serviceRoutinesV2/postBatchQuery.cpp
@@ -88,7 +88,7 @@ std::string postBatchQuery
 
   answer = postQueryContext(ciP, components, compV, parseDataP);
 
-  if (ciP->httpStatusCode != SccOk)
+  if (orionldState.httpStatusCode != SccOk)
   {
     parseDataP->qcr.res.release();
     return answer;
@@ -97,7 +97,7 @@ std::string postBatchQuery
   // 03. Render Entities response
   if (parseDataP->qcrs.res.contextElementResponseVector.size() == 0)
   {
-    ciP->httpStatusCode = SccOk;
+    orionldState.httpStatusCode = SccOk;
     answer = "[]";
   }
   else

--- a/src/lib/serviceRoutinesV2/postBatchUpdate.cpp
+++ b/src/lib/serviceRoutinesV2/postBatchUpdate.cpp
@@ -27,6 +27,8 @@
 
 #include "logMsg/logMsg.h"
 
+#include "orionld/common/orionldState.h"                         // orionldState
+
 #include "common/statistics.h"
 #include "common/clockFunctions.h"
 #include "common/errorMessages.h"
@@ -79,7 +81,7 @@ std::string postBatchUpdate
     alarmMgr.badInput(clientIp, ERROR_DESC_BAD_REQUEST_EMPTY_ENTITIES_VECTOR);
 
     TIMED_RENDER(answer = oe.smartRender(V2));
-    ciP->httpStatusCode = SccBadRequest;
+    orionldState.httpStatusCode = SccBadRequest;
 
     return answer;
   }
@@ -90,12 +92,10 @@ std::string postBatchUpdate
   if (parseDataP->upcrs.res.oe.code != SccNone )
   {
     TIMED_RENDER(answer = parseDataP->upcrs.res.oe.toJson());
-    ciP->httpStatusCode = parseDataP->upcrs.res.oe.code;
+    orionldState.httpStatusCode = parseDataP->upcrs.res.oe.code;
   }
   else
-  {
-    ciP->httpStatusCode = SccNoContent;
-  }
+    orionldState.httpStatusCode = SccNoContent;
 
   // Cleanup and return result
   entities.release();

--- a/src/lib/serviceRoutinesV2/postEntities.cpp
+++ b/src/lib/serviceRoutinesV2/postEntities.cpp
@@ -25,6 +25,8 @@
 #include <string>
 #include <vector>
 
+#include "orionld/common/orionldState.h"                        // orionldState
+
 #include "common/statistics.h"
 #include "common/clockFunctions.h"
 
@@ -81,8 +83,7 @@ std::string postEntities
   ParseData*                 parseDataP
 )
 {
-  Entity*   eP = &parseDataP->ent.res;
-  bool  upsert = ciP->uriParamOptions[OPT_UPSERT];
+  Entity* eP = &parseDataP->ent.res;
 
   if (!legalEntityLength(eP, ciP->httpHeaders.servicePath))
   {
@@ -91,7 +92,7 @@ std::string postEntities
 
     std::string out;
     TIMED_RENDER(out = oe.toJson());
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
 
     return out;
   }
@@ -100,7 +101,8 @@ std::string postEntities
   ActionType      actionType;
   Ngsiv2Flavour   ngsiv2flavour;
   HttpStatusCode  sccCodeOnSuccess;
-  if (upsert)
+
+  if (orionldState.uriParamOptions.upsert)
   {
     actionType       = ActionTypeAppend;
     ngsiv2flavour    = NGSIV2_NO_FLAVOUR;
@@ -127,11 +129,11 @@ std::string postEntities
   if (parseDataP->upcrs.res.oe.code != SccNone)
   {
     TIMED_RENDER(answer = parseDataP->upcrs.res.oe.toJson());
-    ciP->httpStatusCode = parseDataP->upcrs.res.oe.code;
+    orionldState.httpStatusCode = parseDataP->upcrs.res.oe.code;
   }
   else if (parseDataP->upcrs.res.errorCode.code != SccOk)
   {
-    ciP->httpStatusCode = parseDataP->upcrs.res.errorCode.code;
+    orionldState.httpStatusCode = parseDataP->upcrs.res.errorCode.code;
     TIMED_RENDER(answer = parseDataP->upcrs.res.errorCode.toJson(true));
     ciP->answer         = answer;
   }
@@ -150,7 +152,7 @@ std::string postEntities
 
     ciP->httpHeader.push_back(HTTP_RESOURCE_LOCATION);
     ciP->httpHeaderValue.push_back(location);
-    ciP->httpStatusCode = sccCodeOnSuccess;
+    orionldState.httpStatusCode = sccCodeOnSuccess;
   }
 
   // 04. Cleanup and return result

--- a/src/lib/serviceRoutinesV2/postEntity.cpp
+++ b/src/lib/serviceRoutinesV2/postEntity.cpp
@@ -70,7 +70,7 @@ std::string postEntity
   Ngsiv2Flavour  flavor;
 
   eP->id   = compV[2];
-  eP->type = orionldState.uriParams.type;
+  eP->type = (orionldState.uriParams.type == NULL)? "" : orionldState.uriParams.type;
 
   if (forbiddenIdChars(orionldState.apiVersion, compV[2].c_str() , NULL))
   {

--- a/src/lib/serviceRoutinesV2/postEntity.cpp
+++ b/src/lib/serviceRoutinesV2/postEntity.cpp
@@ -70,12 +70,12 @@ std::string postEntity
   Ngsiv2Flavour  flavor;
 
   eP->id   = compV[2];
-  eP->type = ciP->uriParam["type"];
+  eP->type = orionldState.uriParams.type;
 
   if (forbiddenIdChars(orionldState.apiVersion, compV[2].c_str() , NULL))
   {
     OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_URI, ERROR_BAD_REQUEST);
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
     return oe.toJson();
   }
 
@@ -102,12 +102,10 @@ std::string postEntity
   if (parseDataP->upcrs.res.oe.code != SccNone)
   {
     TIMED_RENDER(answer = parseDataP->upcrs.res.oe.toJson());
-    ciP->httpStatusCode = parseDataP->upcrs.res.oe.code;
+    orionldState.httpStatusCode = parseDataP->upcrs.res.oe.code;
   }
   else
-  {
-    ciP->httpStatusCode = SccNoContent;
-  }
+    orionldState.httpStatusCode = SccNoContent;
 
   // Cleanup and return result
   eP->release();

--- a/src/lib/serviceRoutinesV2/postRegistration.cpp
+++ b/src/lib/serviceRoutinesV2/postRegistration.cpp
@@ -74,7 +74,7 @@ std::string postRegistration
   if (parseDataP->reg.provider.legacyForwardingMode == false)
   {
     oe.fill(SccNotImplemented, "Only NGSIv1-based forwarding supported at the present moment. Set explictely legacyForwarding to true");
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
     TIMED_RENDER(answer = oe.smartRender(orionldState.apiVersion));
     return answer;
   }
@@ -85,13 +85,13 @@ std::string postRegistration
   if (parseDataP->reg.provider.supportedForwardingMode != ngsiv2::ForwardAll)
   {
     oe.fill(SccNotImplemented, "non-supported Forwarding Mode");
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
     TIMED_RENDER(answer = oe.smartRender(orionldState.apiVersion));
     return answer;
   }
 
   TIMED_MONGO(mongoRegistrationCreate(&parseDataP->reg, orionldState.tenantP, servicePath, &regId, &oe));
-  ciP->httpStatusCode = oe.code;
+  orionldState.httpStatusCode = oe.code;
 
   if (oe.code != SccOk)
   {
@@ -104,7 +104,7 @@ std::string postRegistration
     ciP->httpHeader.push_back(HTTP_RESOURCE_LOCATION);
     ciP->httpHeaderValue.push_back(location);
 
-    ciP->httpStatusCode = SccCreated;
+    orionldState.httpStatusCode = SccCreated;
   }
 
   return answer;

--- a/src/lib/serviceRoutinesV2/postSubscriptions.cpp
+++ b/src/lib/serviceRoutinesV2/postSubscriptions.cpp
@@ -57,7 +57,7 @@ extern std::string postSubscriptions
   {
     const size_t  MSG_SIZE        = 96;  // strlen(msg) + enough room for digits
     char          errMsg[MSG_SIZE];
-    ciP->httpStatusCode           = SccBadRequest;
+    orionldState.httpStatusCode           = SccBadRequest;
 
     snprintf(errMsg, MSG_SIZE, "max *one* service-path allowed for subscriptions (%lu given)",
              (unsigned long) ciP->servicePathV.size());
@@ -83,7 +83,7 @@ extern std::string postSubscriptions
   if (beError.code != SccNone)
   {
     TIMED_RENDER(answer = beError.toJson());
-    ciP->httpStatusCode = beError.code;
+    orionldState.httpStatusCode = beError.code;
   }
   else
   {
@@ -91,7 +91,7 @@ extern std::string postSubscriptions
     ciP->httpHeader.push_back(HTTP_RESOURCE_LOCATION);
     ciP->httpHeaderValue.push_back(location);
 
-    ciP->httpStatusCode = SccCreated;
+    orionldState.httpStatusCode = SccCreated;
   }
 
   return answer;

--- a/src/lib/serviceRoutinesV2/putEntity.cpp
+++ b/src/lib/serviceRoutinesV2/putEntity.cpp
@@ -71,7 +71,7 @@ std::string putEntity
   Entity*     eP     = &parseDataP->ent.res;
 
   eP->id   = compV[2];
-  eP->type = orionldState.uriParams.type;
+  eP->type = (orionldState.uriParams.type != NULL)? orionldState.uriParams.type : (char*) "";
 
   if (forbiddenIdChars(orionldState.apiVersion, compV[2].c_str() , NULL))
   {

--- a/src/lib/serviceRoutinesV2/putEntity.cpp
+++ b/src/lib/serviceRoutinesV2/putEntity.cpp
@@ -71,12 +71,12 @@ std::string putEntity
   Entity*     eP     = &parseDataP->ent.res;
 
   eP->id   = compV[2];
-  eP->type = ciP->uriParam["type"];
+  eP->type = orionldState.uriParams.type;
 
   if (forbiddenIdChars(orionldState.apiVersion, compV[2].c_str() , NULL))
   {
     OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_URI, ERROR_BAD_REQUEST);
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
     return oe.toJson();
   }
 
@@ -92,12 +92,10 @@ std::string putEntity
   if (parseDataP->upcrs.res.oe.code != SccNone )
   {
     TIMED_RENDER(answer = parseDataP->upcrs.res.oe.toJson());
-    ciP->httpStatusCode = parseDataP->upcrs.res.oe.code;
+    orionldState.httpStatusCode = parseDataP->upcrs.res.oe.code;
   }
   else
-  {
-    ciP->httpStatusCode = SccNoContent;
-  }
+    orionldState.httpStatusCode = SccNoContent;
 
   // 04. Cleanup and return result
   eP->release();

--- a/src/lib/serviceRoutinesV2/putEntityAttribute.cpp
+++ b/src/lib/serviceRoutinesV2/putEntityAttribute.cpp
@@ -67,7 +67,7 @@ std::string putEntityAttribute
 {
   std::string  entityId       = compV[2];
   std::string  attributeName  = compV[4];
-  char*        type           = orionldState.uriParams.type;
+  char*        type           = (orionldState.uriParams.type == NULL)? (char*) "" : orionldState.uriParams.type;
 
   if (forbiddenIdChars(orionldState.apiVersion,  entityId.c_str(),      NULL) ||
       (forbiddenIdChars(orionldState.apiVersion, attributeName.c_str(), NULL)))

--- a/src/lib/serviceRoutinesV2/putEntityAttribute.cpp
+++ b/src/lib/serviceRoutinesV2/putEntityAttribute.cpp
@@ -67,13 +67,13 @@ std::string putEntityAttribute
 {
   std::string  entityId       = compV[2];
   std::string  attributeName  = compV[4];
-  std::string  type           = ciP->uriParam["type"];
+  char*        type           = orionldState.uriParams.type;
 
   if (forbiddenIdChars(orionldState.apiVersion,  entityId.c_str(),      NULL) ||
       (forbiddenIdChars(orionldState.apiVersion, attributeName.c_str(), NULL)))
   {
     OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_URI, ERROR_BAD_REQUEST);
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
     return oe.toJson();
   }
 
@@ -90,12 +90,12 @@ std::string putEntityAttribute
   if (parseDataP->upcrs.res.oe.code != SccNone )
   {
     TIMED_RENDER(answer = parseDataP->upcrs.res.oe.toJson());
-    ciP->httpStatusCode = parseDataP->upcrs.res.oe.code;
+    orionldState.httpStatusCode = parseDataP->upcrs.res.oe.code;
   }
   else
   {
-    answer = "";
-    ciP->httpStatusCode = SccNoContent;
+    answer                      = "";
+    orionldState.httpStatusCode = SccNoContent;
   }
 
   // 05. Cleanup and return result

--- a/src/lib/serviceRoutinesV2/putEntityAttributeValue.cpp
+++ b/src/lib/serviceRoutinesV2/putEntityAttributeValue.cpp
@@ -86,7 +86,9 @@ std::string putEntityAttributeValue
     orionldState.httpStatusCode = oe.code;
     return oe.toJson();
   }
-  parseDataP->upcr.res.fill(entityId, &parseDataP->av.attribute, ActionTypeUpdate, orionldState.uriParams.type);
+
+  char* entityType = (orionldState.uriParams.type != NULL)? orionldState.uriParams.type : (char*) "";
+  parseDataP->upcr.res.fill(entityId, &parseDataP->av.attribute, ActionTypeUpdate, entityType);
 
 
   // 02. Call standard op postUpdateContext

--- a/src/lib/serviceRoutinesV2/putEntityAttributeValue.cpp
+++ b/src/lib/serviceRoutinesV2/putEntityAttributeValue.cpp
@@ -65,13 +65,12 @@ std::string putEntityAttributeValue
 {
   std::string  entityId       = compV[2];
   std::string  attributeName  = compV[4];
-  std::string  type           = ciP->uriParam["type"];
 
   if (forbiddenIdChars(orionldState.apiVersion, entityId.c_str(),      NULL) ||
       forbiddenIdChars(orionldState.apiVersion, attributeName.c_str(), NULL))
   {
     OrionError oe(SccBadRequest, ERROR_DESC_BAD_REQUEST_INVALID_CHAR_URI, ERROR_BAD_REQUEST);
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
     return oe.toJson();
   }
 
@@ -84,10 +83,10 @@ std::string putEntityAttributeValue
   if (err != "OK")
   {
     OrionError oe(SccBadRequest, err, "BadRequest");
-    ciP->httpStatusCode = oe.code;
+    orionldState.httpStatusCode = oe.code;
     return oe.toJson();
   }
-  parseDataP->upcr.res.fill(entityId, &parseDataP->av.attribute, ActionTypeUpdate, type);
+  parseDataP->upcr.res.fill(entityId, &parseDataP->av.attribute, ActionTypeUpdate, orionldState.uriParams.type);
 
 
   // 02. Call standard op postUpdateContext
@@ -98,12 +97,10 @@ std::string putEntityAttributeValue
   if (parseDataP->upcrs.res.oe.code != SccNone)
   {
     TIMED_RENDER(answer = parseDataP->upcrs.res.oe.toJson());
-    ciP->httpStatusCode = parseDataP->upcrs.res.oe.code;
+    orionldState.httpStatusCode = parseDataP->upcrs.res.oe.code;
   }
   else
-  {
-    ciP->httpStatusCode = SccNoContent;
-  }
+    orionldState.httpStatusCode = SccNoContent;
 
   // 05. Cleanup and return result
   parseDataP->upcr.res.release();

--- a/test/functionalTest/cases/0000_ngsild/ngsild_empty-uri-param-crashes-broker.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_empty-uri-param-crashes-broker.test
@@ -33,7 +33,8 @@ brokerStart CB 212-249
 #
 # 01. Create Entity with an attribute P100 having a property P1=2 and a compound value containing a top level field P1=1
 # 02. Query the property P100 giving an empty coords URI param, make sure the broker doesn't crash - see error
-# 03. Get the entity to make sure all is good
+# 03. Query the property P100 without coords URI param, make sure the broker doesn't crash - see error
+# 04. Get the entity to make sure all is good
 #
 
 echo "01. Create Entity with an attribute P100 having a property P1=2 and a compound value containing a top level field P1=1"
@@ -62,7 +63,14 @@ echo
 echo
 
 
-echo "03. Get the entity to make sure all is good"
+echo "03. Query the property P100 without coords URI param, make sure the broker doesn't crash - see error"
+echo "===================================================================================================="
+orionCurl --url '/ngsi-ld/v1/entities?geometry=Point&geometry=Point&georel=near;maxDistance==10&type=Building&options=keyValues'
+echo
+echo
+
+
+echo "04. Get the entity to make sure all is good"
 echo "==========================================="
 orionCurl --url /ngsi-ld/v1/entities?type=T_Query
 echo
@@ -82,6 +90,20 @@ Date: REGEX(.*)
 02. Query the property P100 giving an empty coords URI param, make sure the broker doesn't crash - see error
 ============================================================================================================
 HTTP/1.1 400 Bad Request
+Content-Length: 151
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "Empty right-hand-side for URI param /coordinates/",
+    "title": "Error in URI param",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+03. Query the property P100 without coords URI param, make sure the broker doesn't crash - see error
+====================================================================================================
+HTTP/1.1 400 Bad Request
 Content-Length: 156
 Content-Type: application/json
 Date: REGEX(.*)
@@ -93,7 +115,7 @@ Date: REGEX(.*)
 }
 
 
-03. Get the entity to make sure all is good
+04. Get the entity to make sure all is good
 ===========================================
 HTTP/1.1 200 OK
 Content-Length: 152

--- a/test/functionalTest/cases/0000_ngsild/ngsild_registration_get_with_URI_param_queries_error_messages.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_registration_get_with_URI_param_queries_error_messages.test
@@ -70,14 +70,14 @@ echo
 01. Get error message from query by id URI param
 ================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 132
+Content-Length: 156
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
   "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData",
-  "title": "Bad Request",
-  "detail": "URI Param /id/ is empty"
+  "title": "Error in URI param",
+  "detail": "Empty right-hand-side for URI param /id/"
 }
 
 
@@ -85,14 +85,14 @@ Date: REGEX(.*)
 02. Get error message from query by type URI param
 ==================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 134
+Content-Length: 158
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
   "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData",
-  "title": "Bad Request",
-  "detail": "URI Param /type/ is empty"
+  "title": "Error in URI param",
+  "detail": "Empty right-hand-side for URI param /type/"
 }
 
 
@@ -100,14 +100,14 @@ Date: REGEX(.*)
 03. Get error message from query by idPattern URI param
 =======================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 139
+Content-Length: 163
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
   "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData",
-  "title": "Bad Request",
-  "detail": "URI Param /idPattern/ is empty"
+  "title": "Error in URI param",
+  "detail": "Empty right-hand-side for URI param /idPattern/"
 }
 
 
@@ -115,14 +115,14 @@ Date: REGEX(.*)
 04. Get error message from query by attrs URI param
 ===================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 135
+Content-Length: 159
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
   "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData",
-  "title": "Bad Request",
-  "detail": "URI Param /attrs/ is empty"
+  "title": "Error in URI param",
+  "detail": "Empty right-hand-side for URI param /attrs/"
 }
 
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_uri_params_in_orionldState.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_uri_params_in_orionldState.test
@@ -36,6 +36,7 @@ brokerStart CB 31
 #
 # 01. GET Entity with four URI Params: id, type, idPattern, and attrs, all four with valid values
 # 02. GET Entity with 'id=' - no value for id
+# 03. GET Entities without URI params - too broad request
 #
 
 echo "01. GET Entity with four URI Params: id, type, idPattern, and attrs, all four with valid values"
@@ -49,6 +50,13 @@ echo
 echo "02. GET Entity with 'id=' - no value for id"
 echo "==========================================="
 orionCurl --url "/ngsi-ld/v1/entities?id="
+echo
+echo
+
+
+echo "03. GET Entities without URI params - too broad request"
+echo "======================================================="
+orionCurl --url /ngsi-ld/v1/entities
 echo
 echo
 
@@ -70,6 +78,20 @@ Date: REGEX(.*)
 
 02. GET Entity with 'id=' - no value for id
 ===========================================
+HTTP/1.1 400 Bad Request
+Content-Length: 142
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "Empty right-hand-side for URI param /id/",
+    "title": "Error in URI param",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+03. GET Entities without URI params - too broad request
+=======================================================
 HTTP/1.1 400 Bad Request
 Content-Length: 183
 Content-Type: application/json

--- a/test/functionalTest/cases/0725_multiservice_ignore/service_ignore_without_multiservice.test
+++ b/test/functionalTest/cases/0725_multiservice_ignore/service_ignore_without_multiservice.test
@@ -35,7 +35,6 @@ brokerStart CB 0-255 IPV4
 --SHELL--
 echo "01. Create an entity using foo as tenant"
 echo "========================================"
-url="/v1/updateContext"
 payload='{
   "contextElements": [
   {
@@ -53,7 +52,7 @@ payload='{
   ],
   "updateAction": "APPEND"
 }'
-orionCurl --url "$url" --payload "$payload" --tenant "foo"
+orionCurl --url /v1/updateContext --payload "$payload" --tenant "foo"
 echo
 echo
 

--- a/test/functionalTest/harnessFunctions.sh
+++ b/test/functionalTest/harnessFunctions.sh
@@ -1270,12 +1270,13 @@ function orionCurl()
   fi
 
   # Note that payloadCheckFormat is also json in the case of --in xml, as the CB also returns error in JSON in this case
-  if   [ "$_out" == "xml" ];   then _outFormat='--header "Accept: application/xml"'; payloadCheckFormat='json'
-  elif [ "$_out" == "json" ];  then _outFormat='--header "Accept: application/json"'; payloadCheckFormat='json'
-  elif [ "$_out" == "text" ];  then _outFormat='--header "Accept: text/plain"'; _noPayloadCheck='on'
-  elif [ "$_out" == "any" ];   then _outFormat='--header "Accept: */*"'; _noPayloadCheck='on'
-  elif [ "$_out" == "EMPTY" ]; then _outFormat='--header "Accept:"'
-  elif [ "$_out" != "" ];      then _outFormat='--header "Accept: '${_out}'"'; _noPayloadCheck='off'
+  if   [ "$_out" == "xml" ];    then _outFormat='--header "Accept: application/xml"'; payloadCheckFormat='json'
+  elif [ "$_out" == "json" ];   then _outFormat='--header "Accept: application/json"'; payloadCheckFormat='json'
+  elif [ "$_out" == "jsonld" ]; then _outFormat='--header "Accept: application/ld+json"'; payloadCheckFormat='json'
+  elif [ "$_out" == "text" ];   then _outFormat='--header "Accept: text/plain"'; _noPayloadCheck='on'
+  elif [ "$_out" == "any" ];    then _outFormat='--header "Accept: */*"'; _noPayloadCheck='on'
+  elif [ "$_out" == "EMPTY" ];  then _outFormat='--header "Accept:"'
+  elif [ "$_out" != "" ];       then _outFormat='--header "Accept: '${_out}'"'; _noPayloadCheck='off'
   fi
 
   if [ "$_payloadCheck" != "" ]


### PR DESCRIPTION
Cleanup (and performance as an extra):
* Moved httpStatusCode from ConnectionInfo to orionldState.
* Moved a number of ciP::uriParam variables to orionldState.uriParams


 --- 


 [![SF|](https://static.softacheck.com/softacheck.png)](https://softacheck.com)


 [Check out the detailed analysis on softacheck](https://softacheck.com/app/repository/FIWARE/context.Orion-LD/issues)