### PR TITLE
Removed acceptHeaderError from ConnectionInfo

### DIFF
--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -194,6 +194,9 @@ typedef struct OrionldStateOut
   // Outgoing HTTP headers
   MimeType  contentType;
 
+  // Errors
+  char*     acceptErrorDetail;  // FIXME: Use OrionldProblemDetails for this
+
 #if 0
   char*     httpHeaderV[10];    // Buffer to be used if less than 10 headers
   char**    httpHeader;         // Points to httpHeaderV, reallocated if necessary

--- a/src/lib/rest/ConnectionInfo.h
+++ b/src/lib/rest/ConnectionInfo.h
@@ -76,7 +76,6 @@ public:
   std::vector<std::string>   servicePathV;
   HttpHeaders                httpHeaders;
   std::string                answer;
-  std::string                acceptHeaderError;
   struct timeval             transactionStart;  // For metrics
 
   std::map<std::string, std::string>   uriParam;


### PR DESCRIPTION
Moved acceptHeaderError from ConnectionInfo to orionldState.out.acceptErrorDetail



 --- 


 [![SF|](https://static.softacheck.com/softacheck.png)](https://softacheck.com)


 [Check out the detailed analysis on softacheck](https://softacheck.com/app/repository/FIWARE/context.Orion-LD/issues)