### PR TITLE
Issue/992 mongo entity exists

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -3,4 +3,4 @@
 * Issue #986   Username and Password for the mongo C driver connection to the MongoDB server
 * Issue #990   mongo::Timestamp support
 * Issue #989   Deprecated bson_append_symbol still in use - change for bson_append_utf8
-
+* Issue #992   100% reliable implementation of existence check of entities (mongoEntityExists)

--- a/src/lib/orionld/mongoBackend/mongoEntityExists.cpp
+++ b/src/lib/orionld/mongoBackend/mongoEntityExists.cpp
@@ -37,6 +37,7 @@
 #include "mongoBackend/MongoGlobal.h"
 
 #include "orionld/types/OrionldTenant.h"                          // OrionldTenant
+#include "orionld/mongoCppLegacy/mongoCppLegacyDbFieldGet.h"      // mongoCppLegacyDbFieldGet
 #include "orionld/mongoBackend/mongoEntityExists.h"               // Own Interface
 
 
@@ -87,7 +88,22 @@ bool mongoEntityExists(const char* entityId, OrionldTenant* tenantP)
     try
     {
       bo = cursor->nextSafe();
-      ++docs;
+
+      mongo::BSONElement _id;
+
+      if (mongoCppLegacyDbFieldGet(&bo, "_id", &_id) == true)
+      {
+        mongo::BSONElement id;
+        mongo::BSONObj     obj = _id.Obj();
+
+        if (mongoCppLegacyDbFieldGet(&obj, "id", &id) == true)
+        {
+          const char* idString = id.valuestr();
+
+          if ((idString != NULL) && (strcmp(idString, entityId) == 0))
+            ++docs;
+        }
+      }
     }
     catch (...)
     {


### PR DESCRIPTION
## Proposed changes
Fix for issue #992 .
The function `mongoEntityExist` wasn't good enough.
It only made sure *some* result came from the query _id.id: "entity id".
NOW, the function enters the response and makes sure the correct entity id is part of it.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [ ] I have read the [CONTRIBUTING](https://github.com/FIWARE/context.Orion-LD/blob/master/CONTRIBUTING.md) doc
-   [ ] I have signed the [CLA](https://fiware.github.io/contribution-requirements/individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...
