### PR TITLE
Less use of ConnectionInfo

### DIFF
--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -223,6 +223,7 @@ typedef struct OrionldStateIn
 
   // Meta info for URL parameters
   bool      attributeFormatAsObject;
+  bool      entityTypeDoesNotExist;
 } OrionldStateIn;
 
 

--- a/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
@@ -610,6 +610,9 @@ MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* 
   {
     orionldState.uriParams.notExists = (char*) value;
     orionldState.uriParams.mask  |= ORIONLD_URIPARAM_NOTEXISTS;
+
+    if (strcmp(value, "entity::type") == 0)
+      orionldState.in.entityTypeDoesNotExist = true;
   }
   else if (strcmp(key, "metadata") == 0)
   {
@@ -642,7 +645,7 @@ MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* 
   {
     orionldState.uriParams.level = (char*) value;
   }
-  else if (strcmp(key, "entity::type") == 0)
+  else if (strcmp(key, "entity::type") == 0)  // Is NGSIv1 ?entity::type=X the same as NGSIv2 ?type=X ?
   {
     orionldState.uriParams.type = (char*) value;
   }

--- a/src/lib/rest/RestService.cpp
+++ b/src/lib/rest/RestService.cpp
@@ -279,7 +279,7 @@ static void commonFilters
   //
   // 1. ?!exist=entity::type
   //
-  if (ciP->uriParam[URI_PARAM_NOT_EXIST] == SCOPE_VALUE_ENTITY_TYPE)
+  if (orionldState.in.entityTypeDoesNotExist == true)
   {
     Restriction* restrictionP = NULL;
 

--- a/src/lib/serviceRoutines/deleteAllEntitiesWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/deleteAllEntitiesWithTypeAndId.cpp
@@ -28,6 +28,8 @@
 #include "logMsg/logMsg.h"
 #include "logMsg/traceLevels.h"
 
+#include "orionld/common/orionldState.h"             // orionldState
+
 #include "common/statistics.h"
 #include "common/clockFunctions.h"
 #include "alarmMgr/alarmMgr.h"
@@ -80,7 +82,7 @@ std::string deleteAllEntitiesWithTypeAndId
   StatusCode      response;
 
   // 01. Get values from URL (+ entityId::type, exist, !exist)
-  if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
+  if (orionldState.in.entityTypeDoesNotExist == true)
   {
     typeInfo = EntityTypeEmpty;
   }

--- a/src/lib/serviceRoutines/deleteIndividualContextEntityAttributeWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/deleteIndividualContextEntityAttributeWithTypeAndId.cpp
@@ -28,6 +28,8 @@
 #include "logMsg/logMsg.h"
 #include "logMsg/traceLevels.h"
 
+#include "orionld/common/orionldState.h"             // orionldState
+
 #include "common/statistics.h"
 #include "common/clockFunctions.h"
 #include "alarmMgr/alarmMgr.h"
@@ -80,7 +82,7 @@ std::string deleteIndividualContextEntityAttributeWithTypeAndId
   StatusCode      response;
 
   // 01. Get values from URL (+ entityId::type, exist, !exist)
-  if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
+  if (orionldState.in.entityTypeDoesNotExist == true)
   {
     typeInfo = EntityTypeEmpty;
   }

--- a/src/lib/serviceRoutines/getAllContextEntities.cpp
+++ b/src/lib/serviceRoutines/getAllContextEntities.cpp
@@ -25,6 +25,8 @@
 #include <string>
 #include <vector>
 
+#include "orionld/common/orionldState.h"             // orionldState
+
 #include "ngsi/ParseData.h"
 #include "ngsi/EntityId.h"
 #include "ngsi10/QueryContextRequest.h"
@@ -73,7 +75,7 @@ std::string getAllContextEntities
 
 
   // 01. Get values from URL (entityId::type, exist, !exist)
-  if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
+  if (orionldState.in.entityTypeDoesNotExist == true)
   {
     typeInfo = EntityTypeEmpty;
   }

--- a/src/lib/serviceRoutines/getAllEntitiesWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/getAllEntitiesWithTypeAndId.cpp
@@ -92,7 +92,7 @@ std::string getAllEntitiesWithTypeAndId
 
 
   // 01. Get values from URL (entityId::type, exist, !exist)
-  if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
+  if (orionldState.in.entityTypeDoesNotExist == true)
   {
     typeInfo = EntityTypeEmpty;
   }

--- a/src/lib/serviceRoutines/getAttributeValueInstance.cpp
+++ b/src/lib/serviceRoutines/getAttributeValueInstance.cpp
@@ -91,7 +91,7 @@ std::string getAttributeValueInstance
   bool asJsonObject = (orionldState.in.attributeFormatAsObject == true) && (orionldState.out.contentType == JSON);
 
   // 0. Take care of URI params
-  if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
+  if (orionldState.in.entityTypeDoesNotExist == true)
   {
     typeInfo = EntityTypeEmpty;
   }

--- a/src/lib/serviceRoutines/getAttributeValueInstanceWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/getAttributeValueInstanceWithTypeAndId.cpp
@@ -91,7 +91,7 @@ std::string getAttributeValueInstanceWithTypeAndId
 
 
   // 01. Get values from URL (entityId::type, exist, !exist)
-  if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
+  if (orionldState.in.entityTypeDoesNotExist == true)
   {
     typeInfo = EntityTypeEmpty;
   }

--- a/src/lib/serviceRoutines/getContextEntitiesByEntityIdAndType.cpp
+++ b/src/lib/serviceRoutines/getContextEntitiesByEntityIdAndType.cpp
@@ -29,6 +29,8 @@
 #include "logMsg/logMsg.h"
 #include "logMsg/traceLevels.h"
 
+#include "orionld/common/orionldState.h"             // orionldState
+
 #include "common/statistics.h"
 #include "common/clockFunctions.h"
 #include "alarmMgr/alarmMgr.h"
@@ -77,7 +79,7 @@ std::string getContextEntitiesByEntityIdAndType
 
 
   // 01. Get values from URL (entityId::type, esist, !exist)
-  if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
+  if (orionldState.in.entityTypeDoesNotExist == true)
   {
     typeInfo = EntityTypeEmpty;
   }

--- a/src/lib/serviceRoutines/getEntityByIdAttributeByNameWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/getEntityByIdAttributeByNameWithTypeAndId.cpp
@@ -28,6 +28,8 @@
 #include "logMsg/logMsg.h"
 #include "logMsg/traceLevels.h"
 
+#include "orionld/common/orionldState.h"             // orionldState
+
 #include "common/statistics.h"
 #include "common/clockFunctions.h"
 #include "alarmMgr/alarmMgr.h"
@@ -80,7 +82,7 @@ std::string getEntityByIdAttributeByNameWithTypeAndId
 
 
   // 01. Get values from URL (entityId::type, exist, !exist)
-  if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
+  if (orionldState.in.entityTypeDoesNotExist == true)
   {
     typeInfo = EntityTypeEmpty;
   }

--- a/src/lib/serviceRoutines/getIndividualContextEntity.cpp
+++ b/src/lib/serviceRoutines/getIndividualContextEntity.cpp
@@ -84,7 +84,7 @@ std::string getIndividualContextEntity
   bool asJsonObject = (orionldState.in.attributeFormatAsObject == true) && (orionldState.out.contentType == JSON);
 
   // 0. Take care of URI params
-  if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
+  if (orionldState.in.entityTypeDoesNotExist == true)
   {
     typeInfo = EntityTypeEmpty;
   }

--- a/src/lib/serviceRoutines/getIndividualContextEntityAttribute.cpp
+++ b/src/lib/serviceRoutines/getIndividualContextEntityAttribute.cpp
@@ -85,7 +85,7 @@ std::string getIndividualContextEntityAttribute
   bool asJsonObject = (orionldState.in.attributeFormatAsObject == true) && (orionldState.out.contentType == JSON);
 
   // 0. Take care of URI params
-  if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
+  if (orionldState.in.entityTypeDoesNotExist == true)
   {
     typeInfo = EntityTypeEmpty;
   }

--- a/src/lib/serviceRoutines/getIndividualContextEntityAttributeWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/getIndividualContextEntityAttributeWithTypeAndId.cpp
@@ -87,7 +87,7 @@ std::string getIndividualContextEntityAttributeWithTypeAndId
 
 
   // 01. Get values from URL (entityId::type, esist, !exist)
-  if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
+  if (orionldState.in.entityTypeDoesNotExist == true)
   {
     typeInfo = EntityTypeEmpty;
   }

--- a/src/lib/serviceRoutines/getNgsi10ContextEntityTypes.cpp
+++ b/src/lib/serviceRoutines/getNgsi10ContextEntityTypes.cpp
@@ -83,7 +83,7 @@ std::string getNgsi10ContextEntityTypes
 
 
   // 01. Get values from URL (entityId::type, esist, !exist)
-  if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
+  if (orionldState.in.entityTypeDoesNotExist == true)
   {
     typeInfo = EntityTypeEmpty;
   }

--- a/src/lib/serviceRoutines/getNgsi10ContextEntityTypesAttribute.cpp
+++ b/src/lib/serviceRoutines/getNgsi10ContextEntityTypesAttribute.cpp
@@ -84,7 +84,7 @@ std::string getNgsi10ContextEntityTypesAttribute
 
 
   // 01. Get values from URL (entityId::type, esist, !exist)
-  if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
+  if (orionldState.in.entityTypeDoesNotExist == true)
   {
     typeInfo = EntityTypeEmpty;
   }

--- a/src/lib/serviceRoutines/postAllEntitiesWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/postAllEntitiesWithTypeAndId.cpp
@@ -95,7 +95,7 @@ std::string postAllEntitiesWithTypeAndId
 
 
   // 01. Get values from URL (entityId::type, esist, !exist)
-  if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
+  if (orionldState.in.entityTypeDoesNotExist == true)
   {
     typeInfo = EntityTypeEmpty;
   }

--- a/src/lib/serviceRoutines/postContextEntitiesByEntityIdAndType.cpp
+++ b/src/lib/serviceRoutines/postContextEntitiesByEntityIdAndType.cpp
@@ -28,6 +28,8 @@
 #include "logMsg/logMsg.h"
 #include "logMsg/traceLevels.h"
 
+#include "orionld/common/orionldState.h"             // orionldState
+
 #include "common/statistics.h"
 #include "common/clockFunctions.h"
 #include "alarmMgr/alarmMgr.h"
@@ -78,7 +80,7 @@ std::string postContextEntitiesByEntityIdAndType
   RegisterContextResponse  response;
 
   // 01. Get values from URL (entityId::type, exist, !exist)
-  if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
+  if (orionldState.in.entityTypeDoesNotExist == true)
   {
     typeInfo = EntityTypeEmpty;
   }

--- a/src/lib/serviceRoutines/postEntityByIdAttributeByNameWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/postEntityByIdAttributeByNameWithTypeAndId.cpp
@@ -28,6 +28,8 @@
 #include "logMsg/logMsg.h"
 #include "logMsg/traceLevels.h"
 
+#include "orionld/common/orionldState.h"             // orionldState
+
 #include "common/statistics.h"
 #include "common/clockFunctions.h"
 #include "alarmMgr/alarmMgr.h"
@@ -79,7 +81,7 @@ std::string postEntityByIdAttributeByNameWithTypeAndId
 
 
   // 01. Get values from URL (entityId::type, exist, !exist)
-  if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
+  if (orionldState.in.entityTypeDoesNotExist == true)
   {
     typeInfo = EntityTypeEmpty;
   }

--- a/src/lib/serviceRoutines/postIndividualContextEntityAttributeWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/postIndividualContextEntityAttributeWithTypeAndId.cpp
@@ -28,6 +28,8 @@
 #include "logMsg/logMsg.h"
 #include "logMsg/traceLevels.h"
 
+#include "orionld/common/orionldState.h"             // orionldState
+
 #include "common/statistics.h"
 #include "common/clockFunctions.h"
 #include "alarmMgr/alarmMgr.h"
@@ -81,7 +83,7 @@ std::string postIndividualContextEntityAttributeWithTypeAndId
   StatusCode      response;
 
   // 01. Get values from URL (entityId::type, esist, !exist)
-  if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
+  if (orionldState.in.entityTypeDoesNotExist == true)
   {
     typeInfo = EntityTypeEmpty;
   }

--- a/src/lib/serviceRoutines/postSubscribeContextAvailabilityConvOp.cpp
+++ b/src/lib/serviceRoutines/postSubscribeContextAvailabilityConvOp.cpp
@@ -27,6 +27,8 @@
 
 #include "logMsg/logMsg.h"
 
+#include "orionld/common/orionldState.h"             // orionldState
+
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
 #include "rest/uriParamNames.h"
@@ -64,7 +66,7 @@ std::string postSubscribeContextAvailabilityConvOp
 
 
   // 01. Take care of URI params
-  if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
+  if (orionldState.in.entityTypeDoesNotExist == true)
   {
     typeInfo = EntityTypeEmpty;
   }

--- a/src/lib/serviceRoutines/postSubscribeContextConvOp.cpp
+++ b/src/lib/serviceRoutines/postSubscribeContextConvOp.cpp
@@ -27,6 +27,8 @@
 
 #include "logMsg/logMsg.h"
 
+#include "orionld/common/orionldState.h"             // orionldState
+
 #include "ngsi/ParseData.h"
 #include "rest/ConnectionInfo.h"
 #include "rest/uriParamNames.h"
@@ -64,7 +66,7 @@ std::string postSubscribeContextConvOp
 
 
   // 01. Take care of URI params
-  if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
+  if (orionldState.in.entityTypeDoesNotExist == true)
   {
     typeInfo = EntityTypeEmpty;
   }

--- a/src/lib/serviceRoutines/putAllEntitiesWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/putAllEntitiesWithTypeAndId.cpp
@@ -88,7 +88,7 @@ extern std::string putAllEntitiesWithTypeAndId
 
 
   // 01. Get values from URL (entityId::type, esist, !exist)
-  if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
+  if (orionldState.in.entityTypeDoesNotExist == true)
   {
     typeInfo = EntityTypeEmpty;
   }

--- a/src/lib/serviceRoutines/putIndividualContextEntityAttributeWithTypeAndId.cpp
+++ b/src/lib/serviceRoutines/putIndividualContextEntityAttributeWithTypeAndId.cpp
@@ -28,6 +28,8 @@
 #include "logMsg/logMsg.h"
 #include "logMsg/traceLevels.h"
 
+#include "orionld/common/orionldState.h"             // orionldState
+
 #include "common/statistics.h"
 #include "common/clockFunctions.h"
 #include "alarmMgr/alarmMgr.h"
@@ -75,7 +77,7 @@ std::string putIndividualContextEntityAttributeWithTypeAndId
   StatusCode      response;
 
   // 01. Get values from URL (entityId::type, esist, !exist)
-  if (ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE)
+  if (orionldState.in.entityTypeDoesNotExist == true)
   {
     typeInfo = EntityTypeEmpty;
   }


### PR DESCRIPTION
## Proposed changes
Refactor/Performance:

Getting rid of ConnectionInfo:
No longer using 
    `ciP->uriParam[URI_PARAM_NOT_EXIST] == URI_PARAM_ENTITY_TYPE`

`orionldState.in.entityTypeDoesNotExist` is used instead

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/FIWARE/context.Orion-LD/blob/master/CONTRIBUTING.md) doc
-   [x] I have signed the [CLA](https://fiware.github.io/contribution-requirements/individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments