### PR TITLE
Bug/iso8601 parse

### DIFF
--- a/src/lib/common/globals.cpp
+++ b/src/lib/common/globals.cpp
@@ -497,7 +497,7 @@ static int timezoneOffset(const char* tz)
 * Based in http://stackoverflow.com/questions/26895428/how-do-i-parse-an-iso-8601-date-with-optional-milliseconds-to-a-struct-tm-in-c
 *
 */
-double parse8601Time(const std::string& ss)
+double parse8601Time(char* ss)
 {
   int    y = 0;
   int    M = 0;
@@ -505,13 +505,13 @@ double parse8601Time(const std::string& ss)
   int    h = 0;
   int    m = 0;
   double s = 0;
-  char   tz[10];
+  char   tz[32];
 
   // Length check, to avoid buffer overflow in tz[]. Calculation is as follows:
   //
   //  5 (year with "-") + 3 * 2 (day and month with "-" or "T")
-  //  3 * 3 (hour/minute/second with ":" or ".") + 3 (miliseconds) + 6 (worst case timezone: "+01:00" = 29
-  if (ss.length() > 29)
+  //  3 * 3 (hour/minute/second with ":" or ".") + 9 (nanosecs) + 6 (worst case timezone: "+01:00" = 41
+  if (strlen(ss) > 41)
   {
     return -1;
   }
@@ -531,21 +531,23 @@ double parse8601Time(const std::string& ss)
   tz[0] = 'Z';
   tz[1] = 0;
 
-  bool validDate = ((sscanf(ss.c_str(), "%4d-%2d-%2dT%2d:%2d:%lf%s", &y, &M, &d, &h, &m, &s, tz) >= 6)  ||  // Trying hh:mm:ss.sss or hh:mm:ss
-                    (sscanf(ss.c_str(), "%4d-%2d-%2dT%2d%2d%lf%s", &y, &M, &d, &h, &m, &s, tz) >= 6)    ||  // Trying hhmmss.sss or hhmmss
-                    (sscanf(ss.c_str(), "%4d-%2d-%2dT%2d:%2d%s", &y, &M, &d, &h, &m, tz) >= 5)          ||  // Trying hh:mm
-                    (sscanf(ss.c_str(), "%4d-%2d-%2dT%2d%2d%s", &y, &M, &d, &h, &m, tz) >= 5)           ||  // Trying hhmm
-                    (sscanf(ss.c_str(), "%4d-%2d-%2dT%2d%s", &y, &M, &d, &h, tz) >= 4)                  ||  // Trying hh
-                    (sscanf(ss.c_str(), "%4d-%2d-%2d%s", &y, &M, &d, tz) == 3));                            // Trying just date (in this case tz is not allowed)
+  bool validDate = ((sscanf(ss, "%4d-%2d-%2dT%2d:%2d:%lf%s", &y, &M, &d, &h, &m, &s, tz) >= 6)  ||  // Trying hh:mm:ss.sss or hh:mm:ss
+                    (sscanf(ss, "%4d-%2d-%2dT%2d%2d%lf%s", &y, &M, &d, &h, &m, &s, tz) >= 6)    ||  // Trying hhmmss.sss or hhmmss
+                    (sscanf(ss, "%4d-%2d-%2dT%2d:%2d%s", &y, &M, &d, &h, &m, tz) >= 5)          ||  // Trying hh:mm
+                    (sscanf(ss, "%4d-%2d-%2dT%2d%2d%s", &y, &M, &d, &h, &m, tz) >= 5)           ||  // Trying hhmm
+                    (sscanf(ss, "%4d-%2d-%2dT%2d%s", &y, &M, &d, &h, tz) >= 4)                  ||  // Trying hh
+                    (sscanf(ss, "%4d-%2d-%2d%s", &y, &M, &d, tz) == 3));                            // Trying just date (in this case tz is not allowed)
 
   if (!validDate)
   {
+    LM_E(("Not a valid date: %s", ss));
     return -1;
   }
 
   int offset = timezoneOffset(tz);
   if (offset == -1)
   {
+    LM_E(("invalid timezone: %s", ss));
     return -1;
   }
 

--- a/src/lib/common/globals.h
+++ b/src/lib/common/globals.h
@@ -312,7 +312,7 @@ extern int64_t parse8601(const std::string& s);
 * This is common code for Duration and Throttling (at least)
 *
 */
-extern double parse8601Time(const std::string& s);
+extern double parse8601Time(char* ss);
 
 
 

--- a/src/lib/jsonParseV2/parseContextAttribute.cpp
+++ b/src/lib/jsonParseV2/parseContextAttribute.cpp
@@ -159,7 +159,7 @@ static std::string parseContextAttributeObject
   // Is it a date?
   if ((caP->type == DATE_TYPE) || (caP->type == DATE_TYPE_ALT))
   {
-    caP->numberValue =  parse8601Time(caP->stringValue);
+    caP->numberValue =  parse8601Time((char*) caP->stringValue.c_str());
 
     if (caP->numberValue == -1)
     {

--- a/src/lib/jsonParseV2/parseMetadata.cpp
+++ b/src/lib/jsonParseV2/parseMetadata.cpp
@@ -123,7 +123,7 @@ static std::string parseMetadataObject(const rapidjson::Value& start, Metadata* 
   // Is it a date?
   if ((mdP->type == DATE_TYPE) || (mdP->type == DATE_TYPE_ALT))
   {
-    mdP->numberValue =  parse8601Time(mdP->stringValue);
+    mdP->numberValue =  parse8601Time((char*) mdP->stringValue.c_str());
 
     if (mdP->numberValue == -1)
     {

--- a/src/lib/jsonParseV2/parseRegistration.cpp
+++ b/src/lib/jsonParseV2/parseRegistration.cpp
@@ -341,7 +341,7 @@ std::string parseRegistration(ConnectionInfo* ciP, ngsiv2::Registration* regP)
 
     if (!expires.empty())
     {
-      expiresValue = parse8601Time(expires);
+      expiresValue = parse8601Time((char*) expires.c_str());
       if (expiresValue == -1)
       {
         return badInput(ciP, "the field /expires/ has an invalid format");

--- a/src/lib/jsonParseV2/parseSubscription.cpp
+++ b/src/lib/jsonParseV2/parseSubscription.cpp
@@ -194,7 +194,7 @@ std::string parseSubscription(ConnectionInfo* ciP, SubscriptionUpdate* subsP, bo
     }
     else
     {
-      eT = (uint64_t) parse8601Time(expires);
+      eT = (uint64_t) parse8601Time((char*) expires.c_str());
       if (eT == -1)
       {
         return badInput(ciP, "expires has an invalid format");

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -61,7 +61,7 @@ using namespace orion;
 */
 void ContextAttribute::bsonAppendAttrValue(BSONObjBuilder& bsonAttr, const std::string& attrType, bool autocast) const
 {
-  std::string effectiveStringValue = stringValue;
+  char*       effectiveStringValue = (char*) stringValue.c_str();
   bool        effectiveBoolValue   = boolValue;
   double      effectiveNumberValue = numberValue;
   ValueType   effectiveValueType   = valueType;
@@ -72,7 +72,7 @@ void ContextAttribute::bsonAppendAttrValue(BSONObjBuilder& bsonAttr, const std::
     // Autocast only for selected attribute types
     if ((attrType == DEFAULT_ATTR_NUMBER_TYPE) || (attrType == NUMBER_TYPE_ALT))
     {
-      if (str2double(effectiveStringValue.c_str(), &effectiveNumberValue))
+      if (str2double(effectiveStringValue, &effectiveNumberValue))
       {
         effectiveValueType = ValueTypeNumber;
       }
@@ -82,12 +82,12 @@ void ContextAttribute::bsonAppendAttrValue(BSONObjBuilder& bsonAttr, const std::
     {
       // Note that we cannot use isTrue() or isFalse() functions, as they consider also 0 and 1 as
       // valid true/false values and JSON spec mandates exactly true or false
-      if (effectiveStringValue == "true")
+      if (strcmp(effectiveStringValue, "true") == 0)
       {
         effectiveBoolValue = true;
         effectiveValueType = ValueTypeBoolean;
       }
-      else if (effectiveStringValue == "false")
+      else if (strcmp(effectiveStringValue, "false") == 0)
       {
         effectiveBoolValue = false;
         effectiveValueType = ValueTypeBoolean;

--- a/test/functionalTest/cases/0000_ngsild/ngsild_observedAt.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_observedAt.test
@@ -34,6 +34,8 @@ brokerStart CB 0-255
 # 01. Create an entity with an attribute 'speed' that has an 'observedAt'
 # 02. Get the entity from broker, see speed::observedAt as a string
 # 03. Get the entity with attrList, see speed::observedAt as a string
+# 04. Create another entity with an attribute 'speed' that has an 'observedAt' with 10 decimals
+# 05. Get the new entity and see only 3 decimals (correctly rounded) for speed::observedAt
 #
 
 
@@ -63,6 +65,29 @@ echo
 echo "03. Get the entity with attrList, see speed::observedAt as a string"
 echo "==================================================================="
 orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:T:E1a?attrs=speed&prettyPrint=yes' --noPayloadCheck
+echo
+echo
+
+
+echo "04. Create another entity with an attribute 'speed' that has an 'observedAt' with 10 decimals"
+echo "============================================================================================="
+payload='{
+  "id": "urn:ngsi-ld:T:E2",
+  "type": "T",
+  "speed": {
+    "type": "Property",
+    "value": 22,
+    "observedAt": "2022-01-31T13:14:15.0123456789Z"
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities -X POST --payload "$payload"
+echo
+echo
+
+
+echo "05. Get the new entity and see only 3 decimals (correctly rounded) for speed::observedAt"
+echo "========================================================================================"
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:T:E2
 echo
 echo
 
@@ -117,6 +142,34 @@ Date: REGEX(.*)
   }
 }
 
+
+
+04. Create another entity with an attribute 'speed' that has an 'observedAt' with 10 decimals
+=============================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:T:E2
+Date: REGEX(.*)
+
+
+
+05. Get the new entity and see only 3 decimals (correctly rounded) for speed::observedAt
+========================================================================================
+HTTP/1.1 200 OK
+Content-Length: 115
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+{
+    "id": "urn:ngsi-ld:T:E2",
+    "speed": {
+        "observedAt": "2022-01-31T13:14:15.012Z",
+        "type": "Property",
+        "value": 22
+    },
+    "type": "T"
+}
 
 
 --TEARDOWN--


### PR DESCRIPTION
## Proposed changes
Fix for issue #1010 .
The function parse8601Time only supported a maximum of three decimals for seconds - reported an error for more.
Made it support 9 decimals (and cut it to three afterwards).
Also, made it a little less C++ and a little more C - thus saving some execution time and some RAM.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/FIWARE/context.Orion-LD/blob/master/CONTRIBUTING.md) doc
-   [x] I have signed the [CLA](https://fiware.github.io/contribution-requirements/individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...
