### PR TITLE
Revert/jsonld doesnt allow payload body not to be compound

### DIFF
--- a/src/lib/orionld/payloadCheck/CMakeLists.txt
+++ b/src/lib/orionld/payloadCheck/CMakeLists.txt
@@ -56,6 +56,7 @@ SET (SOURCES
      pCheckGeoPropertyCoordinates.cpp
      pCheckGeoPropertyType.cpp
      pCheckGeoPropertyValue.cpp
+     pCheckAttributeType.cpp
 )
 
 # Include directories

--- a/src/lib/orionld/payloadCheck/pCheckAttributeType.cpp
+++ b/src/lib/orionld/payloadCheck/pCheckAttributeType.cpp
@@ -1,0 +1,95 @@
+/*
+*
+* Copyright 2022 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+#include <unistd.h>                                              // NULL
+
+extern "C"
+{
+#include "kjson/KjNode.h"                                        // KjNode
+#include "kjson/kjLookup.h"                                      // kjLookup
+}
+
+#include "orionld/common/orionldError.h"                         // orionldError
+#include "orionld/payloadCheck/pCheckAttributeType.h"            // Own interface
+
+
+
+// -----------------------------------------------------------------------------
+//
+// pCheckAttributeType -
+//
+bool pCheckAttributeType(KjNode* attrP, KjNode** typePP, bool mandatory)
+{
+  KjNode* typeP   = kjLookup(attrP, "type");
+  KjNode* atTypeP = kjLookup(attrP, "@type");
+
+  *typePP = NULL;
+
+  //
+  // It's allowed to use either "type" or "@type" but not both
+  //
+  if ((typeP != NULL) && (atTypeP != NULL))
+  {
+    orionldError(OrionldBadRequestData, "Duplicate Fields in payload body", "type and @type", 400);
+    return false;
+  }
+
+  //
+  // If "type" is absent, perhaps "@type" is present?
+  //
+  if (typeP == NULL)
+    typeP = atTypeP;
+
+  //
+  // If "type" is mandatory but absent - error
+  //
+  if (typeP == NULL)
+  {
+    if (mandatory == true)
+    {
+      orionldError(OrionldBadRequestData, "Missing /type/ field for an attribute", attrP->name, 400);
+      return false;
+    }
+
+    // If "type" not present, no more checks necessary
+    return true;
+  }
+
+
+  //
+  // The type field MUST be a string
+  //
+  if (typeP->type != KjString)
+  {
+    orionldError(OrionldBadRequestData, "Invalid JSON type for /type/ field of an Attribute (not a JSON String)", attrP->name, 400);
+    return false;
+  }
+
+  //
+  // Save the pointer to the type for later use
+  //
+  *typePP = typeP;
+
+  return true;
+}

--- a/src/lib/orionld/payloadCheck/pCheckAttributeType.h
+++ b/src/lib/orionld/payloadCheck/pCheckAttributeType.h
@@ -1,0 +1,43 @@
+#ifndef SRC_LIB_ORIONLD_PAYLOADCHECK_PCHECKATTRIBUTETYPE_H_
+#define SRC_LIB_ORIONLD_PAYLOADCHECK_PCHECKATTRIBUTETYPE_H_
+
+/*
+*
+* Copyright 2022 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+extern "C"
+{
+#include "kjson/KjNode.h"                                     // KjNode
+}
+
+#include "orionld/types/OrionldAttributeType.h"               // OrionldAttributeType
+
+
+
+// -----------------------------------------------------------------------------
+//
+// pCheckAttributeType -
+//
+extern bool pCheckAttributeType(KjNode* attrP, KjNode** typePP, bool mandatory);
+
+#endif  // SRC_LIB_ORIONLD_PAYLOADCHECK_PCHECKATTRIBUTETYPE_H_

--- a/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionTreat.cpp
@@ -229,17 +229,13 @@ static bool payloadParseAndExtractSpecialFields(bool* contextToBeCashedP)
   }
 
   //
-  // Most requests are either arrays or objects
-  // PATCH Attribute can have a payload body of any JSON type
+  // All requests are either arrays or objects
   //
-  if (orionldState.serviceP->serviceRoutine != orionldPatchAttribute)
+  if ((orionldState.requestTree->type != KjArray) && (orionldState.requestTree->type != KjObject))
   {
-    if ((orionldState.requestTree->type != KjArray) && (orionldState.requestTree->type != KjObject))
-    {
-      orionldErrorResponseCreate(OrionldInvalidRequest, "Invalid Payload", "The payload data must be either a JSON Array or a JSON Object");
-      orionldState.httpStatusCode = 400;
-      return false;
-    }
+    orionldErrorResponseCreate(OrionldInvalidRequest, "Invalid Payload", "The payload data must be either a JSON Array or a JSON Object");
+    orionldState.httpStatusCode = 400;
+    return false;
   }
 
   //

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0504.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0504.test
@@ -1,0 +1,61 @@
+# Copyright 2019 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Issue 504
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+brokerStart CB 0-255
+
+--SHELL--
+
+#
+# 01. Send a PATCH request with Content-Type app/json and a simple integer as payload data
+#
+
+echo "01. Send a PATCH request with Content-Type app/json and a simple integer as payload data"
+echo "========================================================================================"
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:Product:001/attrs/price/value --payload "87" -X PATCH
+echo
+echo
+
+
+--REGEXPECT--
+01. Send a PATCH request with Content-Type app/json and a simple integer as payload data
+========================================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 160
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "The payload data must be either a JSON Array or a JSON Object",
+    "title": "Invalid Payload",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/InvalidRequest"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/0000_ngsild/ngsild_patch_entity_attr_with_subattr.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_patch_entity_attr_with_subattr.test
@@ -442,13 +442,13 @@ bye
 03. Attempt to PATCH E1/P1 by changing the type of E1/P1 to Relationship - see error
 ====================================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 128
+Content-Length: 137
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "detail": "P1",
-    "title": "Attempt to change the Type of an Attribute",
+    "title": "Attempt to transform a Property into a Relationship",
     "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_smart-payload_for_PATCH_Attribute.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_smart-payload_for_PATCH_Attribute.test
@@ -31,6 +31,10 @@ brokerStart CB
 --SHELL--
 
 #
+# We learnt that JSON-LD doesn't allow for the payloadbody to be just a simple type, like String or Bool.
+# This is OK in JSON, but not in JSON-LD.
+# So, those tests that use simple types as payload bidy are modified to use { "value": XXX }  instead of just XXX.
+#
 # Payloads to test ... there ara MANY !!!
 #
 # The entire payload is the "value", unless it's a JSON Object:
@@ -143,7 +147,7 @@ echo
 
 echo "02. PATCH the Property P with simplified format, setting it to the INTEGER 2"
 echo "============================================================================"
-payload=2
+payload='{"value": 2}'
 orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entities:T:E1/attrs/P -X PATCH --payload "$payload"
 echo
 echo
@@ -158,7 +162,7 @@ echo
 
 echo "04. PATCH the Property P with simplified format, setting it to the STRING 04"
 echo "============================================================================"
-payload='"04"'
+payload='{"value": "04"}'
 orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entities:T:E1/attrs/P -X PATCH --payload "$payload"
 echo
 echo
@@ -173,7 +177,7 @@ echo
 
 echo "06. PATCH the Property P with simplified format, setting it to the FLOAT 3.1416"
 echo "==============================================================================="
-payload=3.1416
+payload='{"value": 3.1416}'
 orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entities:T:E1/attrs/P -X PATCH --payload "$payload"
 echo
 echo
@@ -188,7 +192,7 @@ echo
 
 echo "08. PATCH the Property P with simplified format, setting it to the BOOL true"
 echo "============================================================================"
-payload=true
+payload='{"value": true}'
 orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entities:T:E1/attrs/P -X PATCH --payload "$payload"
 echo
 echo
@@ -252,7 +256,7 @@ echo
 
 echo '16. PATCH the Property G with simplified format, using "urn:ngsi-ld:step:16", trying to make it a Property - see error'
 echo '======================================================================================================================'
-payload='"urn:ngsi-ld:xxx"'
+payload='{"value": "urn:ngsi-ld:xxx"}'
 orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entities:T:E1/attrs/G -X PATCH --payload "$payload"
 echo
 echo
@@ -297,7 +301,7 @@ echo
 
 echo '22. PATCH the Property P with simplified format, using "urn:ngsi-lf:xxx" - not assumed a Relationship, so, OK, still a Property'
 echo '==============================================================================================================================='
-payload='"urn:ngsi-lf:xxx"'
+payload='{"value": "urn:ngsi-lf:xxx"}'
 orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entities:T:E1/attrs/P -X PATCH --payload "$payload"
 echo
 echo

--- a/test/functionalTest/cases/0000_ngsild/ngsild_smart-payload_for_PATCH_Entity.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_smart-payload_for_PATCH_Entity.test
@@ -498,7 +498,7 @@ Date: REGEX(.*)
 10. Attempt to turn the Relationship R1 into a Property using "R1": { "value": "10" } - see error
 =================================================================================================
 HTTP/1.1 207 Multi-Status
-Content-Length: 154
+Content-Length: 164
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -507,7 +507,7 @@ Date: REGEX(.*)
     "notUpdated": [
         {
             "attributeName": "R1",
-            "reason": "Forbidden field for a Relationship: value: https://uri.etsi.org/ngsi-ld/default-context/R1"
+            "reason": "Attempt to transform a Relationship into a Property: https://uri.etsi.org/ngsi-ld/default-context/R1"
         }
     ],
     "updated": []


### PR DESCRIPTION
## Proposed changes 
* Payload body must be a Compound again, so, putting back the check and the functest - fixing #504 
* This change required a modification in a functest, and this modification revealed a bug in pCheckAttribute()
 
## Types of `changes`

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/FIWARE/context.Orion-LD/blob/master/CONTRIBUTING.md) doc
-   [x] I have signed the [CLA](https://fiware.github.io/contribution-requirements/individual-cla.pdf)
-   [ x I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
O
