### PR TITLE
Issue/1050 part3 2 ignore deletion of non existing attributes

### DIFF
--- a/src/lib/orionld/db/dbModelFromApiAttribute.cpp
+++ b/src/lib/orionld/db/dbModelFromApiAttribute.cpp
@@ -64,7 +64,7 @@ extern "C"
 //   * "modDate"  is added
 //   * "creDate"  is added iff the attribute did not previously exist
 //
-bool dbModelFromApiAttribute(KjNode* attrP, KjNode* dbAttrsP, KjNode* attrAddedV, KjNode* attrRemovedV)
+bool dbModelFromApiAttribute(KjNode* attrP, KjNode* dbAttrsP, KjNode* attrAddedV, KjNode* attrRemovedV, bool* ignoreP)
 {
   KjNode* mdP         = NULL;
   char*   attrEqName  = kaStrdup(&orionldState.kalloc, attrP->name);
@@ -116,8 +116,9 @@ bool dbModelFromApiAttribute(KjNode* attrP, KjNode* dbAttrsP, KjNode* attrAddedV
   {
     if (attrP->type == KjNull)
     {
-      // Apparently this is OK
+      // Apparently it's OK to try to delete an attribute that does not exist
 #if 1
+      *ignoreP = true;
       return true;  // Just ignore it
 #else
       LM_W(("Attempt to DELETE an attribute that doesn't exist (%s)", attrEqName));

--- a/src/lib/orionld/db/dbModelFromApiAttribute.h
+++ b/src/lib/orionld/db/dbModelFromApiAttribute.h
@@ -52,6 +52,6 @@ extern "C"
 //   * "modDate"  is added
 //   * "creDate"  is added iff the attribute did not previously exist
 //
-extern bool dbModelFromApiAttribute(KjNode* attrP, KjNode* dbAttrsP, KjNode* attrAddedV, KjNode* attrRemovedV);
+extern bool dbModelFromApiAttribute(KjNode* attrP, KjNode* dbAttrsP, KjNode* attrAddedV, KjNode* attrRemovedV, bool* ignoreP);
 
 #endif  // SRC_LIB_ORIONLD_DB_DBMODELFROMAPIATTRIBUTE_H_

--- a/src/lib/orionld/db/dbModelFromApiEntity.cpp
+++ b/src/lib/orionld/db/dbModelFromApiEntity.cpp
@@ -117,13 +117,22 @@ bool dbModelFromApiEntity(KjNode* entityP, KjNode* dbAttrsP, KjNode* dbAttrNames
   //
   // Loop over the "attrs" member of entityP and call dbModelFromApiAttribute for every attribute
   //
-  for (KjNode* attrP = attrsP->value.firstChildP; attrP != NULL; attrP = attrP->next)
+  KjNode* attrP = attrsP->value.firstChildP;
+  KjNode* next;
+  while (attrP != NULL)
   {
-    if (dbModelFromApiAttribute(attrP, dbAttrsP, attrAddedV, attrRemovedV) == false)
+    bool ignore = false;
+
+    next = attrP->next;
+    if (dbModelFromApiAttribute(attrP, dbAttrsP, attrAddedV, attrRemovedV, &ignore) == false)
     {
-      LM_W(("dbModelFromApiAttribute: %s: %s", orionldState.pd.title, orionldState.pd.detail));
-      return false;
+      if (ignore == true)
+        kjChildRemove(attrsP, attrP);
+      else
+        return false;
     }
+
+    attrP = next;
   }
 
   return true;

--- a/src/lib/orionld/db/dbModelFromApiSubAttribute.cpp
+++ b/src/lib/orionld/db/dbModelFromApiSubAttribute.cpp
@@ -61,7 +61,7 @@ bool dbModelFromApiSubAttribute(KjNode* saP, KjNode* dbMdP, KjNode* mdAddedV, Kj
   {
     if (dbSubAttributeP == NULL)
     {
-      // Apparently this is OK
+      // Apparently it's OK to try to delete an attribute that does not exist (RFC 7396))
 #if 1
       *ignoreP = true;
       return true;  // Just ignore it

--- a/src/lib/orionld/serviceRoutines/orionldPatchEntity2.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchEntity2.cpp
@@ -50,7 +50,7 @@ extern "C"
 #include "orionld/kjTree/kjStringValueLookupInArray.h"           // kjStringValueLookupInArray
 #include "orionld/payloadCheck/pCheckEntity.h"                   // pCheckEntity
 #include "orionld/db/dbModelFromApiEntity.h"                     // dbModelFromApiEntity
-#include "orionld/serviceRoutines/orionldPatchEntity.h"          // Own Interface
+#include "orionld/serviceRoutines/orionldPatchEntity2.h"         // Own Interface
 
 
 
@@ -206,7 +206,10 @@ void orionldEntityPatchTree(KjNode* oldP, KjNode* newP, char* path, KjNode* patc
 
   if (oldP == NULL)  // It's NEW - doesn't exist in OLD - simply ADD
   {
-    patchTreeItemAdd(patchTree, path, newP, NULL);
+    // Except if it's a NULL. If NULL, then it is ignored
+    if (newP->type != KjNull)
+      patchTreeItemAdd(patchTree, path, newP, NULL);
+
     return;
   }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_patch_entity2-null-rhs-for-attribute.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_patch_entity2-null-rhs-for-attribute.test
@@ -1,0 +1,109 @@
+# Copyright 2022 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Update an entity using Real PATCH - non-existing attribute is null
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+brokerStart CB 0 IPv4 -experimental
+
+--SHELL--
+#
+# 01. Create an entity E1 with a Relationship R1
+# 02. PATCH E1, attempting to delete the Property P1 (that does not exist), also, set a new object for R1
+# 03. GET E1, see the new object for R1
+#
+
+echo "01. Create an entity E1 with a Relationship R1"
+echo "=============================================="
+payload='{
+  "id": "urn:E1",
+  "type": "T",
+  "R1": {
+    "object": "urn:ngsi-ld:Building:R1"
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "02. PATCH E1, attempting to delete the Property P1 (that does not exist), also, set a new object for R1"
+echo "======================================================================================================="
+payload='{
+  "P1": {"@type" :"@json", "@value" : null},
+  "R1": {
+    "object": "urn:ngsi-ld:Building:R2"
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities/urn:E1 -X PATCH --payload "$payload"
+echo
+echo
+
+
+echo "03. GET E1, see the new object for R1"
+echo "====================================="
+orionCurl --url /ngsi-ld/v1/entities/urn:E1
+echo
+echo
+
+
+--REGEXPECT--
+01. Create an entity E1 with a Relationship R1
+==============================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/entities/urn:E1
+Date: REGEX(.*)
+
+
+
+02. PATCH E1, attempting to delete the Property P1 (that does not exist), also, set a new object for R1
+=======================================================================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+03. GET E1, see the new object for R1
+=====================================
+HTTP/1.1 200 OK
+Content-Length: 90
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+{
+    "R1": {
+        "object": "urn:ngsi-ld:Building:R2",
+        "type": "Relationship"
+    },
+    "id": "urn:E1",
+    "type": "T"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
## Proposed changes

No longer giving error for attempts to delete an attribute that does not exist, in PATCH /entities/{entityId}.
While it makes a lot of sense to flag an error, the RFC (7396) says you shouldn't (can't).

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/FIWARE/context.Orion-LD/blob/master/CONTRIBUTING.md) doc
-   [x] I have signed the [CLA](https://fiware.github.io/contribution-requirements/individual-cla.pdf)
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
