### PR TITLE
patchEntity/observedAt

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -13,6 +13,8 @@
 * Issue #1033  Fixed a bug about Concise GeoJSON returning an Invalid Geometry
 * Issue #1034  Fixed a bug about Array Reduction and Concise Attribute Format
 * Issue #280   Implemented the new PATCH /entities/{entityId} - it's "experimental" - still doesn't do notifications, datasetId, TRoE, nor Forwarding
+* Issue #280   URI parameter options=simplified as an alias to options=keyValues
+* Issue #280   Support for URI parameter 'observedAt' for PATCH /entities/{entityId} in combination with options=keyValues - update existing observedAt sub-attributes
 * Issue #280   Implemented support for the OPTIONS method for all NGSI-LD API endpoints
 * Issue #1045  Fixed bug related to TRoE and creation of entity without attributes
 * Issue #280   TRoE support for PATCH /entities/{entityId} - quite untested

--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -164,6 +164,8 @@ typedef struct OrionldUriParams
   char*     relationships;
   char*     geoproperties;
   char*     languageproperties;
+  char*     observedAt;
+  double    observedAtAsDouble;
   uint64_t  mask;
 } OrionldUriParams;
 

--- a/src/lib/orionld/rest/OrionLdRestService.h
+++ b/src/lib/orionld/rest/OrionLdRestService.h
@@ -146,6 +146,7 @@ typedef struct OrionLdRestServiceSimplifiedVector
 #define ORIONLD_URIPARAM_RELATIONSHIPS        (1 << 30)
 #define ORIONLD_URIPARAM_GEOPROPERTIES        (1 << 31)
 #define ORIONLD_URIPARAM_LANGUAGEPROPERTIES   (1UL << 32)
+#define ORIONLD_URIPARAM_OBSERVEDAT           (1UL << 33)
 
 
 

--- a/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
@@ -36,6 +36,7 @@ extern "C"
 #include "common/wsStrip.h"                                      // wsStrip
 #include "common/MimeType.h"                                     // MimeType
 #include "common/string.h"                                       // toLowercase
+#include "common/globals.h"                                      // parse8601Time
 #include "alarmMgr/alarmMgr.h"                                   // alarmMgr
 #include "rest/Verb.h"                                           // Verb
 #include "rest/OrionError.h"                                     // OrionError
@@ -189,6 +190,7 @@ static void optionsParse(const char* options)
       else if (strcmp(optionStart, "replace")       == 0)  orionldState.uriParamOptions.replace       = true;
       else if (strcmp(optionStart, "noOverwrite")   == 0)  orionldState.uriParamOptions.noOverwrite   = true;
       else if (strcmp(optionStart, "keyValues")     == 0)  orionldState.uriParamOptions.keyValues     = true;
+      else if (strcmp(optionStart, "simplified")    == 0)  orionldState.uriParamOptions.keyValues     = true;
       else if (strcmp(optionStart, "concise")       == 0)  orionldState.uriParamOptions.concise       = true;
       else if (strcmp(optionStart, "normalized")    == 0)  orionldState.uriParamOptions.normalized    = true;
       else if (strcmp(optionStart, "sysAttrs")      == 0)  orionldState.uriParamOptions.sysAttrs      = true;
@@ -737,6 +739,21 @@ MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* 
   {
     orionldState.uriParams.url   = (char*) value;
     orionldState.uriParams.mask |= ORIONLD_URIPARAM_URL;
+  }
+  else if (strcmp(key, "observedAt") == 0)
+  {
+    orionldState.uriParams.observedAtAsDouble = parse8601Time((char*) value);
+
+    if (orionldState.uriParams.observedAtAsDouble == -1)
+    {
+      orionldError(OrionldBadRequestData, "Invalid value for uri parameter /observedAt/ (not a valid ISO8601 timestamp)", value, 400);
+      return MHD_YES;
+    }
+    else
+    {
+      orionldState.uriParams.observedAt  = (char*) value;
+      orionldState.uriParams.mask       |= ORIONLD_URIPARAM_OBSERVEDAT;
+    }
   }
   else if (strcmp(key, "reload") == 0)
   {

--- a/src/lib/orionld/rest/orionldServiceInit.cpp
+++ b/src/lib/orionld/rest/orionldServiceInit.cpp
@@ -300,6 +300,7 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
     serviceP->options   |= ORIONLD_SERVICE_OPTION_CLONE_PAYLOAD;
     serviceP->options   |= ORIONLD_SERVICE_OPTION_ACCEPT_JSONLD_NULL;
     serviceP->uriParams |= ORIONLD_URIPARAM_OPTIONS;
+    serviceP->uriParams |= ORIONLD_URIPARAM_OBSERVEDAT;
   }
   else if (serviceP->serviceRoutine == orionldDeleteAttribute)
   {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_patch_entity2-with-keyValues-and-observedAt.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_patch_entity2-with-keyValues-and-observedAt.test
@@ -1,0 +1,142 @@
+# Copyright 2022 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Update an entity using Real PATCH - non-existing attribute is null
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+brokerStart CB 0 IPv4 -experimental
+
+--SHELL--
+#
+# 01. Create an entity E1 with a mix of attrs/sub-attrs with/without observedAt
+# 02. PATCH E1, with key-values and observedAt as URL params
+# 03. GET E1, see the new observedAt in 'Rwith-with'
+# 04. PATCH E1, with key-values and an INVALID observedAt as URL params - see error
+#
+
+echo "01. Create an entity E1 with a mix of attrs/sub-attrs with/without observedAt"
+echo "============================================================================="
+payload='{
+  "id": "urn:E1",
+  "type": "T",
+  "Rwith": {
+    "object": "urn:ngsi-ld:Building:R1",
+    "observedAt": "2022-04-01T12:47:00.123Z"
+  },
+  "Rwithout": {
+    "object": "urn:ngsi-ld:Building:R1"
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "02. PATCH E1, with key-values and observedAt as URL params"
+echo "=========================================================="
+payload='{
+  "Rwith":    "urn:ngsi-ld:Building:R2",
+  "Rwithout": "urn:ngsi-ld:Building:R2"
+}'
+orionCurl --url '/ngsi-ld/v1/entities/urn:E1?options=simplified&observedAt=2022-04-01T12:47:00.456Z' -X PATCH --payload "$payload"
+echo
+echo
+
+
+echo "03. GET E1, see the new observedAt in 'Rwith-with'"
+echo "=================================================="
+orionCurl --url /ngsi-ld/v1/entities/urn:E1
+echo
+echo
+
+
+echo "04. PATCH E1, with key-values and an INVALID observedAt as URL params - see error"
+echo "================================================================================="
+payload='{
+  "Rwith":    "urn:ngsi-ld:Building:R2",
+  "Rwithout": "urn:ngsi-ld:Building:R2"
+}'
+orionCurl --url '/ngsi-ld/v1/entities/urn:E1?options=simplified&observedAt=2022' -X PATCH --payload "$payload"
+echo
+echo
+
+
+--REGEXPECT--
+01. Create an entity E1 with a mix of attrs/sub-attrs with/without observedAt
+=============================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/entities/urn:E1
+Date: REGEX(.*)
+
+
+
+02. PATCH E1, with key-values and observedAt as URL params
+==========================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+03. GET E1, see the new observedAt in 'Rwith-with'
+==================================================
+HTTP/1.1 200 OK
+Content-Length: 203
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+{
+    "Rwith": {
+        "object": "urn:ngsi-ld:Building:R2",
+        "observedAt": "2022-04-01T12:47:00.456Z",
+        "type": "Relationship"
+    },
+    "Rwithout": {
+        "object": "urn:ngsi-ld:Building:R2",
+        "type": "Relationship"
+    },
+    "id": "urn:E1",
+    "type": "T"
+}
+
+
+04. PATCH E1, with key-values and an INVALID observedAt as URL params - see error
+=================================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 164
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "2022",
+    "title": "Invalid value for uri parameter /observedAt/ (not a valid ISO8601 timestamp)",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
## Proposed changes
* observedAt URI param for PATCH /entities/EID
* simplified accepted as alias for keyValues for options URI param

A PATCH /entities/{entityId} with both `options=keyValues` (or `options=simplified`)  and `observedAt=<ISO8601 timestamp>` URI parameters set make the PATCH modify not only the **value** of the patched attributes, but also (if previously present as sub-attribute), the sub-attr **observedAt** to the value of the URI parameter `observedAt`.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/FIWARE/context.Orion-LD/blob/master/CONTRIBUTING.md) doc
-   [x] I have signed the [CLA](https://fiware.github.io/contribution-requirements/individual-cla.pdf)
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
