### PR TITLE
Building QNode tree for cached subscription on demand

### DIFF
--- a/src/lib/mongoBackend/mongoSubCache.cpp
+++ b/src/lib/mongoBackend/mongoSubCache.cpp
@@ -31,7 +31,6 @@
 extern "C"
 {
 #include "kbase/kTime.h"                                       // kTimeGet
-#include "kalloc/kaStrdup.h"                                   // kaStrdup
 }
 
 #include "logMsg/logMsg.h"
@@ -154,10 +153,7 @@ int mongoSubCacheItemInsert(const char* tenant, const BSONObj& sub)
 
   if ((ldContext != NULL) && (ldContext[0] != 0))  // NGSI-LD subscription
   {
-    if (orionldStartup == false)
-      cSubP->ldContext = kaStrdup(&orionldState.kalloc, ldContext);
-    else
-      cSubP->ldContext = ldContext;
+    cSubP->ldContext = ldContext;
 
     if (renderFormat == NGSI_V2_NORMALIZED)
       renderFormat = NGSI_LD_V1_NORMALIZED;
@@ -228,7 +224,7 @@ int mongoSubCacheItemInsert(const char* tenant, const BSONObj& sub)
         {
           char* q = (char*) cSubP->expression.q.c_str();
 
-          LM_TMP(("QOR: q == '%s'", cSubP->expression.q.c_str()));
+          LM_TMP(("QOR: q == '%s'", q));
 
           if (strchr(q, '|') != NULL)
           {

--- a/src/lib/orionld/notifications/orionldAlterationsTreat.cpp
+++ b/src/lib/orionld/notifications/orionldAlterationsTreat.cpp
@@ -124,7 +124,7 @@ static int notificationResponseTreat(NotificationPending* npP, double timestamp)
 //
 void orionldAlterationsTreat(OrionldAlteration* altList)
 {
-  // <DEBUG>
+  // ----------------------------  <DEBUG>
   int alterations = 0;
   for (OrionldAlteration* aP = altList; aP != NULL; aP = aP->next)
   {
@@ -144,7 +144,7 @@ void orionldAlterationsTreat(OrionldAlteration* altList)
     ++alterations;
   }
   LM_TMP(("ALT: %d Alterations present", alterations));
-  // </DEBUG>
+  // ----------------------------  </DEBUG>
 
   OrionldAlterationMatch* matchList;
   int                     matches;

--- a/src/lib/orionld/notifications/subCacheAlterationMatch.cpp
+++ b/src/lib/orionld/notifications/subCacheAlterationMatch.cpp
@@ -35,6 +35,7 @@ extern "C"
 
 #include "orionld/common/orionldState.h"                       // orionldState
 #include "orionld/q/QNode.h"                                   // QNode, qNodeType
+#include "orionld/q/qBuild.h"                                  // qBuild
 #include "orionld/q/qPresent.h"                                // qPresent
 #include "orionld/common/pathComponentsSplit.h"                // pathComponentsSplit
 #include "orionld/common/eqForDot.h"                           // eqForDot
@@ -583,6 +584,7 @@ bool qMatch(QNode* qP, OrionldAlteration* altP)
 }
 
 
+
 // -----------------------------------------------------------------------------
 //
 // subCacheAlterationMatch -
@@ -641,6 +643,13 @@ OrionldAlterationMatch* subCacheAlterationMatch(OrionldAlteration* alterationLis
         if (entityTypeMatch(subP, altP->entityType, eItems) == false)
           continue;
       }
+
+      //
+      // Might be we come from a sub-cache-refresh, and the subscription has a "q" but its "qP" hasn't been built
+      // Only done if its an NGSI-LD operations AND if it's an NGSI-LD Subscription (has a contextP pointer)
+      //
+      if ((subP->qP == NULL) && (subP->ldContext != "") && (subP->expression.q != ""))
+        subP->qP = qBuild(subP->expression.q.c_str());
 
       if ((subP->qP != NULL) && (qMatch(subP->qP, altP) == false))
       {

--- a/src/lib/orionld/q/CMakeLists.txt
+++ b/src/lib/orionld/q/CMakeLists.txt
@@ -29,6 +29,7 @@ SET (SOURCES
     qAliasCompact.cpp
     qPresent.cpp
     qRelease.cpp
+    qBuild.cpp
 )
 
 # Include directories

--- a/src/lib/orionld/q/qBuild.cpp
+++ b/src/lib/orionld/q/qBuild.cpp
@@ -1,0 +1,85 @@
+/*
+*
+* Copyright 2022 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+#include <string.h>                                            // strlen, strncpy, strdup
+#include <stdlib.h>                                            // free
+
+#include "logMsg/logMsg.h"                                     // LM_*
+
+#include "orionld/common/orionldState.h"                       // orionldState
+#include "orionld/common/urlDecode.h"                          // urlDecode
+#include "orionld/q/QNode.h"                                   // QNode
+#include "orionld/q/qLex.h"                                    // qLex
+#include "orionld/q/qParse.h"                                  // qParse
+#include "orionld/q/qRelease.h"                                // qListRelease
+#include "orionld/q/qPresent.h"                                // qPresent
+#include "orionld/q/qBuild.h"                                  // Own interface
+
+
+
+// -----------------------------------------------------------------------------
+//
+// qBuild - build QNode tree
+//
+QNode* qBuild(const char* q)
+{
+  QNode*      qP        = NULL;
+  char*       title;
+  char*       detail;
+  QNode*      qList;
+
+  LM_TMP(("Got a 'q': %s", q));
+
+  // qLex destroys the input string, but we need it intact
+  char        buf[512];
+  char*       qString   = buf;
+
+  if (strlen(q) < sizeof(buf))
+    strncpy(buf, q, sizeof(buf) - 1);
+  else
+    qString = strdup(q);  // Freed after use - "if (qString != buf)"
+
+  urlDecode(qString);
+  orionldState.useMalloc = true;  // the Q-Tree needs real alloction for the sub-cache
+  LM_TMP(("LEAK: ***** Calling qLex *****"));
+  if ((qList = qLex(qString, &title, &detail)) == NULL)
+    LM_RE(NULL, ("Error (qLex: %s: %s)", title, detail));
+  else
+  {
+    LM_TMP(("LEAK: ***** Calling qParse *****"));
+    qP = qParse(qList, NULL, false, &title, &detail);
+    if (qP == NULL)
+      LM_RE(NULL, ("Error (qParse: %s: %s) - but, the subscription will be inserted in the sub-cache without 'q'", title, detail));
+
+    qPresent(qP, "LEAK", "Q-TREE");
+  }
+
+  if (qString != buf)
+    free(qString);
+
+  orionldState.useMalloc = false;
+  qListRelease(qList);
+
+  return qP;
+}

--- a/src/lib/orionld/q/qBuild.h
+++ b/src/lib/orionld/q/qBuild.h
@@ -1,0 +1,38 @@
+#ifndef SRC_LIB_ORIONLD_Q_QBUILD_H_
+#define SRC_LIB_ORIONLD_Q_QBUILD_H_
+
+/*
+*
+* Copyright 2022 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+#include "orionld/q/QNode.h"                                   // QNode
+
+
+
+// -----------------------------------------------------------------------------
+//
+// qBuild - build QNode tree
+//
+extern QNode* qBuild(const char* q);
+
+#endif  // SRC_LIB_ORIONLD_Q_QBUILD_H_

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_notification_with-q-and-subcache-refresh.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_notification_with-q-and-subcache-refresh.test
@@ -1,0 +1,189 @@
+# Copyright 2022 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+New subscription with q/qP and sub-cache-refresh
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+brokerStart CB 0 IPv4 -experimental -subCacheIval 2
+accumulatorStart --pretty-print 127.0.0.1 ${LISTENER_PORT}
+
+--SHELL--
+
+#
+# 01. Create a subscription S1 with q=A==0|B==0 - q-tree created by postSubscriptions
+# 02. Wait 2.1 seconds, to give the broker time to refresh its sub cache
+# 03. Create an Entity E1 with A==1 - no notification
+# 04. Create an Entity E2 with B==1 - no notification
+# 05. Create an Entity E3 with A==0 - notification
+# 06. Dump accumulator and see the notification for E3 only
+#
+
+echo "01. Create a subscription S1 with q=A==0|B==0 - q-tree created by postSubscriptions"
+echo "==================================================================================="
+payload='{
+  "id": "urn:ngsi-ld:subs:S1",
+  "type": "Subscription",
+  "entities": [
+    {
+      "type": "T"
+    }
+  ],
+  "q": "A==0|B==0",
+  "notification": {
+    "format": "simplified",
+    "endpoint": {
+      "uri": "http://127.0.0.1:'${LISTENER_PORT}'/notify"
+    }
+  }
+}'
+orionCurl --url /ngsi-ld/v1/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo "02. Wait 2.1 seconds, to give the broker time to refresh its sub cache"
+echo "======================================================================"
+sleep 2.1s
+echo Slept 2.1 seconds
+echo
+echo
+
+
+echo "03. Create an Entity E1 with A==1 (qP missing is created) - no notification"
+echo "==========================================================================="
+payload='{
+  "id": "urn:ngsi-ld:T:E1",
+  "type": "T",
+  "A": 1
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "04. Create an Entity E2 with B==1 - no notification"
+echo "==================================================="
+payload='{
+  "id": "urn:ngsi-ld:T:E2",
+  "type": "T",
+  "B": 1
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "05. Create an Entity E3 with A==0 - notification"
+echo "================================================"
+payload='{
+  "id": "urn:ngsi-ld:T:E3",
+  "type": "T",
+  "A": 0
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "06. Dump accumulator and see the notification for E3 only"
+echo "========================================================="
+accumulatorDump
+accumulatorReset
+echo
+echo
+
+
+--REGEXPECT--
+01. Create a subscription S1 with q=A==0|B==0 - q-tree created by postSubscriptions
+===================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:subs:S1
+Date: REGEX(.*)
+
+
+
+02. Wait 2.1 seconds, to give the broker time to refresh its sub cache
+======================================================================
+Slept 2.1 seconds
+
+
+03. Create an Entity E1 with A==1 (qP missing is created) - no notification
+===========================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:T:E1
+Date: REGEX(.*)
+
+
+
+04. Create an Entity E2 with B==1 - no notification
+===================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:T:E2
+Date: REGEX(.*)
+
+
+
+05. Create an Entity E3 with A==0 - notification
+================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:T:E3
+Date: REGEX(.*)
+
+
+
+06. Dump accumulator and see the notification for E3 only
+=========================================================
+POST REGEX(.*)
+Content-Length: 223
+User-Agent: orionld
+Accept: application/json
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Ngsild-Attribute-Format: Simplified
+
+{
+    "data": [
+        {
+            "A": 0,
+            "id": "urn:ngsi-ld:T:E3",
+            "type": "T"
+        }
+    ],
+    "id": "urn:ngsi-ld:Notification:REGEX(.*)",
+    "notifiedAt": "202REGEX(.*)",
+    "subscriptionId": "urn:ngsi-ld:subs:S1",
+    "type": "Notification"
+}
+=======================================
+
+
+--TEARDOWN--
+brokerStop CB
+accumulatorStop
+dbDrop CB


### PR DESCRIPTION
## Proposed changes
sub-cache-refresh runs in the main thread - can't use kalloc library.
So, instead of creating the QNode tree in the sub-cache-refresh routines, it is built on demand, by the updating request thread.
## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/FIWARE/context.Orion-LD/blob/master/CONTRIBUTING.md) doc
-   [x] I have signed the [CLA](https://fiware.github.io/contribution-requirements/individual-cla.pdf)
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...
