### PR TITLE
Temporal feature to test CosmosDB - completely disabling the mongo legacy driver via CLI

### DIFF
--- a/src/lib/orionld/mongoc/mongocInit.cpp
+++ b/src/lib/orionld/mongoc/mongocInit.cpp
@@ -84,4 +84,5 @@ void mongocInit(const char* dbHost, const char* dbName)
   // Semaphore for the 'contexts' collection on DB 'orionld' - hopefully not needed in the end ...
   //
   sem_init(&mongocContextsSem, 0, 1);  // 0: shared between threads of the same process. 1: free to be taken
+  LM_K(("mongoc initialized"));
 }


### PR DESCRIPTION

## Proposed changes
For now just a temporal thing for a test with Microsoft - connect Orion-LD to Azure Cosmos DB.
But, this might not be such a bad idea ...
To do it "the real way", I'd have to disable all those API endpoints that depend on the mongo legacy driver.
And the cache refresh functionality, as the legacy driver is in use there too.

Right now, you just have to be careful not to use any of the legacy driver dependent API endpoint as that would most probably hang the broker, perhaps even crash it.
Anyway, this "feature" is only activated via a hidden CLI option, so, not really a problem.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/FIWARE/context.Orion-LD/blob/master/CONTRIBUTING.md) doc
-   [x] I have signed the [CLA](https://fiware.github.io/contribution-requirements/individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...
