### PR TITLE
Using tenant list when populating subscription cache

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -30,3 +30,4 @@
 * Issue #280   Common functions for Getting and Listing tenants now using the new mongo driver
 * Issue #280   Common functions for Geo indices now using the new mongo driver
 * Issue #280   Common function for creation of the _id.id entities index now using the new mongo driver
+* Issue #280   Using the tenant list when populating the subscription cache insterad of querying the database (less Mongo C++ Legacy driver usage)

--- a/test/functionalTest/cases/0000_ngsild/ngsild_patch_entity2-notification-many-alterations-on-same-sub.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_patch_entity2-notification-many-alterations-on-same-sub.test
@@ -132,7 +132,7 @@ Date: REGEX(.*)
 ================
 MongoDB shell version REGEX(.*)
 connecting to: REGEX(.*)
-MongoDB server version: REGEX(.*)4.4.13
+MongoDB server version: REGEX(.*)
 {
 	"_id" : {
 		"id" : "urn:E1",
@@ -185,7 +185,7 @@ Date: REGEX(.*)
 ================
 MongoDB shell version REGEX(.*)
 connecting to: REGEX(.*)
-MongoDB server version: REGEX(.*)4.4.13
+MongoDB server version: REGEX(.*)
 {
 	"_id" : {
 		"id" : "urn:E1",


### PR DESCRIPTION
## Proposed changes
Using the tenant list when populating the subscription cache instead of querying the database (less Mongo C++ Legacy driver usage)

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/FIWARE/context.Orion-LD/blob/master/CONTRIBUTING.md) doc
-   [x] I have signed the [CLA](https://fiware.github.io/contribution-requirements/individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
