### PR TITLE
Mongoc/get subscription from sub cache

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -30,4 +30,5 @@
 * Issue #280   Common functions for Getting and Listing tenants now using the new mongo driver
 * Issue #280   Common functions for Geo indices now using the new mongo driver
 * Issue #280   Common function for creation of the _id.id entities index now using the new mongo driver
-* Issue #280   Using the tenant list when populating the subscription cache insterad of querying the database (less Mongo C++ Legacy driver usage)
+* Issue #280   Using the tenant list when populating the subscription cache instead of querying the database (less Mongo C++ Legacy driver usage)
+* Issue #280   GET /subscriptions/{subId} now uses the subscription cache and no database access is done (less Mongo C++ Legacy driver usage)

--- a/src/app/orionld/orionld.cpp
+++ b/src/app/orionld/orionld.cpp
@@ -824,6 +824,7 @@ static void libLogFunction
 }
 
 
+// char* SUB_CACHE_DISABLED = NULL;
 
 #define LOG_FILE_LINE_FORMAT "time=DATE | lvl=TYPE | corr=CORR_ID | trans=TRANS_ID | from=FROM_IP | srv=SERVICE | subsrv=SUB_SERVICE | comp=Orion | op=FILE[LINE]:FUNC | msg=TEXT"
 /* ****************************************************************************
@@ -832,6 +833,20 @@ static void libLogFunction
 */
 int main(int argC, char* argV[])
 {
+# if 0
+  //
+  // Just an experiment.
+  // It's an interesting way of "comparing strings"
+  // The problem is "const chasr*" vs "char*" - stupid C++ and its type checking!!!
+  //
+  char* sc = SUB_CACHE_DISABLED;
+  if (sc == SUB_CACHE_DISABLED)
+  {
+    printf("the sub cache is disabled\n");
+    exit(1);
+  }
+#endif
+
 #if LEAK_TEST
   char* allocated = strdup("123");
   if (allocated == NULL)

--- a/src/lib/apiTypesV2/HttpInfo.h
+++ b/src/lib/apiTypesV2/HttpInfo.h
@@ -56,7 +56,6 @@ struct HttpInfo
   MimeType                            mimeType;
   MqttInfo                            mqtt;
   std::vector<KeyValue*>              notifierInfo;
-  std::vector<KeyValue*>              receiverInfo;
 #endif
   HttpInfo();
   explicit HttpInfo(const std::string& _url);

--- a/src/lib/cache/subCache.cpp
+++ b/src/lib/cache/subCache.cpp
@@ -628,16 +628,6 @@ void subCacheItemDestroy(CachedSubscription* cSubP)
     cSubP->qP = NULL;
   }
 
-  for (int ix = 0; ix < (int) cSubP->httpInfo.receiverInfo.size(); ++ix)
-  {
-    if (cSubP->httpInfo.receiverInfo[ix] != NULL)
-    {
-      LM_TMP(("VE: Freeing Key-Value Pair at %p (receiverInfo)", cSubP->httpInfo.receiverInfo[ix]));
-      free(cSubP->httpInfo.receiverInfo[ix]);
-      cSubP->httpInfo.receiverInfo[ix] = NULL;
-    }
-  }
-
   for (int ix = 0; ix < (int) cSubP->httpInfo.notifierInfo.size(); ++ix)
   {
     if (cSubP->httpInfo.notifierInfo[ix] != NULL)

--- a/src/lib/cache/subCache.h
+++ b/src/lib/cache/subCache.h
@@ -135,6 +135,9 @@ struct CachedSubscription
   int                         consecutiveErrors;     // Not in DB
   char                        lastErrorReason[128];
 
+  double                      createdAt;
+  double                      modifiedAt;
+
   struct CachedSubscription*  next;
 };
 

--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -91,18 +91,19 @@ struct OrionLdRestService;
 //
 typedef struct OrionldUriParamOptions
 {
-  bool sysAttrs;
-  bool noOverwrite;
   bool update;
   bool replace;
+  bool noOverwrite;
   bool keyValues;
   bool concise;
+  bool sysAttrs;
   bool normalized;
+  bool fromDb;
+  bool append;         // Only NGSIv2
   bool values;         // Only NGSIv2
   bool uniqueValues;   // Only NGSIv2
   bool dateCreated;    // Only NGSIv2
   bool dateModified;   // Only NGSIv2
-  bool append;         // Only NGSIv2
   bool noAttrDetail;   // Only NGSIv2
   bool upsert;         // Only NGSIv2
 } OrionldUriParamOptions;

--- a/src/lib/orionld/common/subCacheApiSubscriptionInsert.cpp
+++ b/src/lib/orionld/common/subCacheApiSubscriptionInsert.cpp
@@ -60,7 +60,7 @@ CachedSubscription* subCacheApiSubscriptionInsert(KjNode* apiSubscriptionP, QNod
   cSubP->tenant              = (orionldState.in.tenant == NULL)? NULL : strdup(orionldState.in.tenant);
   cSubP->servicePath         = strdup("/#");
   cSubP->qP                  = qTree;
-  cSubP->contextP            = contextP;        // Right now, this is orionldState.contextP, i.e., the @context used when creating 
+  cSubP->contextP            = contextP;        // Right now, this is orionldState.contextP, i.e., the @context used when creating
   cSubP->ldContext           = contextP->url;   // the subscription. Soon, the subscription will contain a field for its context instead.
 
   KjNode* subscriptionIdP    = kjLookup(apiSubscriptionP, "_id");  // "id" was changed to "_id" by orionldPostSubscriptions to accomodate the DB insertion

--- a/src/lib/orionld/common/subCacheApiSubscriptionInsert.cpp
+++ b/src/lib/orionld/common/subCacheApiSubscriptionInsert.cpp
@@ -260,8 +260,7 @@ CachedSubscription* subCacheApiSubscriptionInsert(KjNode* apiSubscriptionP, QNod
           KjNode* keyP   = kjLookup(riP, "key");
           KjNode* valueP = kjLookup(riP, "value");
 
-          if ((keyP != NULL) && (valueP != NULL))
-            keyValueAdd(&cSubP->httpInfo.receiverInfo, keyP->value.s, valueP->value.s);
+          cSubP->httpInfo.headers[keyP->value.s] = valueP->value.s;
         }
       }
 
@@ -269,10 +268,13 @@ CachedSubscription* subCacheApiSubscriptionInsert(KjNode* apiSubscriptionP, QNod
       {
         for (KjNode* niP = notifierInfoP->value.firstChildP; niP != NULL; niP = niP->next)
         {
-          KjNode* keyP   = kjLookup(niP, "key");
-          KjNode* valueP = kjLookup(niP, "value");
+          KjNode*   keyP   = kjLookup(niP, "key");
+          KjNode*   valueP = kjLookup(niP, "value");
+          KeyValue* kvP    = keyValueLookup(cSubP->httpInfo.notifierInfo, keyP->value.s);
 
-          if ((keyP != NULL) && (valueP != NULL))
+          if (kvP != NULL)
+            strncpy(kvP->value, valueP->value.s, sizeof(kvP->value) - 1);
+          else
             keyValueAdd(&cSubP->httpInfo.notifierInfo, keyP->value.s, valueP->value.s);
         }
       }

--- a/src/lib/orionld/common/subCacheApiSubscriptionInsert.cpp
+++ b/src/lib/orionld/common/subCacheApiSubscriptionInsert.cpp
@@ -31,6 +31,7 @@ extern "C"
 #include "kjson/KjNode.h"                                        // kjBufferCreate
 #include "kjson/kjLookup.h"                                      // kjLookup
 #include "kjson/kjRender.h"                                      // kjFastRender
+#include "kjson/kjClone.h"                                       // kjClone
 }
 
 #include "logMsg/logMsg.h"                                       // LM_*
@@ -52,18 +53,18 @@ extern "C"
 // subCacheApiSubscriptionInsert -
 // subCacheDbSubscriptionInsert - later ...
 //
-CachedSubscription* subCacheApiSubscriptionInsert(KjNode* apiSubscriptionP, QNode* qTree, OrionldContext* contextP)
+CachedSubscription* subCacheApiSubscriptionInsert(KjNode* apiSubscriptionP, QNode* qTree, KjNode* geoCoordinatesP, OrionldContext* contextP)
 {
   CachedSubscription* cSubP = new CachedSubscription();
 
   cSubP->tenant              = (orionldState.in.tenant == NULL)? NULL : strdup(orionldState.in.tenant);
   cSubP->servicePath         = strdup("/#");
   cSubP->qP                  = qTree;
-  cSubP->contextP            = contextP;
-  cSubP->ldContext           = contextP->url;
+  cSubP->contextP            = contextP;        // Right now, this is orionldState.contextP, i.e., the @context used when creating 
+  cSubP->ldContext           = contextP->url;   // the subscription. Soon, the subscription will contain a field for its context instead.
 
   KjNode* subscriptionIdP    = kjLookup(apiSubscriptionP, "_id");  // "id" was changed to "_id" by orionldPostSubscriptions to accomodate the DB insertion
-  KjNode* subscriptionNameP  = kjLookup(apiSubscriptionP, "subscriptionName");
+  KjNode* subscriptionNameP  = kjLookup(apiSubscriptionP, "subscriptionName");  // "name" is accepted too ...
   KjNode* descriptionP       = kjLookup(apiSubscriptionP, "description");
   KjNode* entitiesP          = kjLookup(apiSubscriptionP, "entities");
   KjNode* watchedAttributesP = kjLookup(apiSubscriptionP, "watchedAttributes");
@@ -76,9 +77,14 @@ CachedSubscription* subCacheApiSubscriptionInsert(KjNode* apiSubscriptionP, QNod
   KjNode* expiresAtP         = kjLookup(apiSubscriptionP, "expiresAt");
   KjNode* throttlingP        = kjLookup(apiSubscriptionP, "throttling");
   KjNode* langP              = kjLookup(apiSubscriptionP, "lang");
+  KjNode* createdAtP         = kjLookup(apiSubscriptionP, "createdAt");
+  KjNode* modifiedAtP        = kjLookup(apiSubscriptionP, "modifiedAt");
 
   if (subscriptionIdP != NULL)
     cSubP->subscriptionId = strdup(subscriptionIdP->value.s);
+
+  if (subscriptionNameP == NULL)
+    subscriptionNameP = kjLookup(apiSubscriptionP, "name");
 
   if (subscriptionNameP != NULL)
     cSubP->name = subscriptionNameP->value.s;
@@ -87,12 +93,20 @@ CachedSubscription* subCacheApiSubscriptionInsert(KjNode* apiSubscriptionP, QNod
     cSubP->description = strdup(descriptionP->value.s);
 
   if (qP != NULL)
+  {
     cSubP->expression.q = qP->value.s;
+    LM_TMP(("KZ: q: '%s'", cSubP->expression.q.c_str()));
+  }
   if (mqP != NULL)
-    cSubP->expression.mq = qP->value.s;
+  {
+    cSubP->expression.mq = mqP->value.s;
+    LM_TMP(("KZ: mq: '%s'", cSubP->expression.mq.c_str()));
+  }
   if (ldqP != NULL)
-    cSubP->qText = strdup(qP->value.s);
-
+  {
+    cSubP->qText = strdup(ldqP->value.s);
+    LM_TMP(("KZ: ldQ: '%s'", cSubP->qText));
+  }
 
   if (isActiveP != NULL)
   {
@@ -138,7 +152,6 @@ CachedSubscription* subCacheApiSubscriptionInsert(KjNode* apiSubscriptionP, QNod
   if (geoqP != NULL)
   {
     KjNode* geometryP    = kjLookup(geoqP, "geometry");
-    KjNode* coordinatesP = kjLookup(geoqP, "coordinates");
     KjNode* georelP      = kjLookup(geoqP, "georel");
     KjNode* geopropertyP = kjLookup(geoqP, "geoproperty");
 
@@ -151,12 +164,14 @@ CachedSubscription* subCacheApiSubscriptionInsert(KjNode* apiSubscriptionP, QNod
     if (geopropertyP != NULL)
       cSubP->expression.geoproperty = geopropertyP->value.s;
 
-    if (coordinatesP != NULL)
+    if (geoCoordinatesP != NULL)
     {
-      if (coordinatesP->type == KjArray)
+      cSubP->geoCoordinatesP = kjClone(NULL, geoCoordinatesP);
+
+      if (geoCoordinatesP->type == KjArray)
       {
         char coords[1024];
-        kjFastRender(coordinatesP, coords);
+        kjFastRender(geoCoordinatesP, coords);
         cSubP->expression.coords = coords;  // Not sure this is 100% correct format, but is it used? DB is used for Geo ...
       }
     }
@@ -286,6 +301,12 @@ CachedSubscription* subCacheApiSubscriptionInsert(KjNode* apiSubscriptionP, QNod
       LM_E(("Subscription '%s': invalid 'mq': %s", mqP->value.s, cSubP->subscriptionId));
     }
   }
+
+  if (createdAtP != NULL)
+    cSubP->createdAt = createdAtP->value.f;
+
+  if (modifiedAtP != NULL)
+    cSubP->modifiedAt = modifiedAtP->value.f;
 
   subCacheItemInsert(cSubP);
 

--- a/src/lib/orionld/dbModel/dbModelFromApiSubscription.cpp
+++ b/src/lib/orionld/dbModel/dbModelFromApiSubscription.cpp
@@ -370,7 +370,7 @@ bool dbModelFromApiSubscription(KjNode* apiSubscriptionP, bool patch)
     }
     else if (strcmp(fragmentP->name, "q") == 0)
       qP = fragmentP;
-    else if (strcmp(fragmentP->name, "mq") == 0)  // Not NGSI-LD, but added in qFix() (orionldPostSubscriptions.cpp)
+    else if (strcmp(fragmentP->name, "mq") == 0)  // Not NGSI-LD, but added by orionldPostSubscriptions(), for NGSIv2
       mqP = fragmentP;
     else if (strcmp(fragmentP->name, "geoQ") == 0)
       geoqP = fragmentP;

--- a/src/lib/orionld/kjTree/CMakeLists.txt
+++ b/src/lib/orionld/kjTree/CMakeLists.txt
@@ -60,6 +60,7 @@ SET (SOURCES
     kjChildPrepend.cpp
     kjNodeDecouple.cpp
     kjNavigate.cpp
+    kjTreeFromCachedSubscription.cpp
 )
 
 # Include directories

--- a/src/lib/orionld/kjTree/kjTreeFromCachedSubscription.cpp
+++ b/src/lib/orionld/kjTree/kjTreeFromCachedSubscription.cpp
@@ -92,7 +92,7 @@ KjNode* dbModelToCoordinates(const char* coordinatesString)
 
 // -----------------------------------------------------------------------------
 //
-// kjTreeFromCachedSubscription - in NGSI-LD API format 
+// kjTreeFromCachedSubscription - in NGSI-LD API format
 //
 KjNode* kjTreeFromCachedSubscription(CachedSubscription* cSubP, bool sysAttrs, bool contextInBody)
 {
@@ -176,7 +176,7 @@ KjNode* kjTreeFromCachedSubscription(CachedSubscription* cSubP, bool sysAttrs, b
       char* shortType = orionldContextItemAliasLookup(orionldState.contextP, eiP->entityType.c_str(), NULL, NULL);
       nodeP = kjString(orionldState.kjsonP, "type", shortType);
       NULL_CHECK(nodeP);
-      
+
       kjChildAdd(eObjectP, nodeP);
 
       // Add the entitySelector object to the entities array
@@ -239,7 +239,7 @@ KjNode* kjTreeFromCachedSubscription(CachedSubscription* cSubP, bool sysAttrs, b
     }
 
     LM_TMP(("KZ: .value-fixed qText: '%s'", nodeP->value.s));
-    
+
     NULL_CHECK(nodeP);
     kjChildAdd(sP, nodeP);
   }
@@ -346,19 +346,21 @@ KjNode* kjTreeFromCachedSubscription(CachedSubscription* cSubP, bool sysAttrs, b
   kjChildAdd(endpointNodeP, nodeP);
 
   // notification::endpoint::receiverInfo
-  int ris = cSubP->httpInfo.receiverInfo.size();
+  int ris = cSubP->httpInfo.headers.size();
   if (ris > 0)
   {
     KjNode* ri = kjArray(orionldState.kjsonP, "receiverInfo");
     NULL_CHECK(ri);
 
-    for (int ix = 0; ix < ris; ix++)
+    for (std::map<std::string, std::string>::const_iterator it = cSubP->httpInfo.headers.begin(); it != cSubP->httpInfo.headers.end(); ++it)
     {
-      KjNode* kvP  = kjObject(orionldState.kjsonP, NULL);
+      const char* key   = it->first.c_str();
+      const char* value = it->second.c_str();
+      KjNode*     kvP   = kjObject(orionldState.kjsonP, NULL);
       NULL_CHECK(kvP);
-      KjNode* keyP = kjString(orionldState.kjsonP, "key",   cSubP->httpInfo.receiverInfo[ix]->key);
+      KjNode* keyP      = kjString(orionldState.kjsonP, "key",   key);
       NULL_CHECK(keyP);
-      KjNode* valueP = kjString(orionldState.kjsonP, "value", cSubP->httpInfo.receiverInfo[ix]->value);
+      KjNode* valueP    = kjString(orionldState.kjsonP, "value", value);
       NULL_CHECK(valueP);
 
       kjChildAdd(kvP, keyP);
@@ -469,7 +471,7 @@ KjNode* kjTreeFromCachedSubscription(CachedSubscription* cSubP, bool sysAttrs, b
   }
 
   kjChildAdd(sP, notificationNodeP);
-  
+
   //
   // expiresAt
   //

--- a/src/lib/orionld/kjTree/kjTreeFromCachedSubscription.cpp
+++ b/src/lib/orionld/kjTree/kjTreeFromCachedSubscription.cpp
@@ -1,0 +1,552 @@
+/*
+*
+* Copyright 2022 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+extern "C"
+{
+#include "kjson/KjNode.h"                                        // KjNode
+#include "kjson/kjParse.h"                                       // kjParse
+#include "kjson/kjBuilder.h"                                     // kjObject, kjString, ..., kjChildInsert
+#include "kjson/kjClone.h"                                       // kjClone
+}
+
+#include "logMsg/logMsg.h"                                       // LM_*
+
+#include "cache/subCache.h"                                      // CachedSubscription
+
+#include "orionld/common/orionldState.h"                         // orionldState
+#include "orionld/common/numberToDate.h"                         // numberToDate
+#include "orionld/context/orionldContextItemAliasLookup.h"       // orionldContextItemAliasLookup
+#include "orionld/q/qAliasCompact.h"                             // qAliasCompact
+#include "orionld/kjTree/kjTreeFromCachedSubscription.h"         // Own interface
+
+
+
+// -----------------------------------------------------------------------------
+//
+// NULL_CHECK -
+//
+#define NULL_CHECK(pointer) if (pointer == NULL) return outOfMemory()
+
+
+
+// -----------------------------------------------------------------------------
+//
+// outOfMemory -
+//
+static KjNode* outOfMemory(void)
+{
+  LM_E(("Internal Error (out of memory creating a KjNode-tree for a Subscription)"));
+  return NULL;
+}
+
+
+
+// -----------------------------------------------------------------------------
+//
+// dbModelToCoordinates -
+//
+KjNode* dbModelToCoordinates(const char* coordinatesString)
+{
+  int      coordinatesVectorLen = strlen(coordinatesString) * 4 + 10;
+  char*    coordinatesVector    = kaAlloc(&orionldState.kalloc, coordinatesVectorLen);
+  KjNode*  coordValueP;
+
+  //
+  // The "coords" are stored as a STRING in orion's database ...
+  // This here is a hack to make the string an array
+  // and then parse it using kjParse and get a KjNode tree
+  //
+  snprintf(coordinatesVector, coordinatesVectorLen, "[%s]", coordinatesString);
+  LM_TMP(("KZ: coordinatesVector: %s", coordinatesVector));
+  coordValueP = kjParse(orionldState.kjsonP, coordinatesVector);
+  if (coordValueP == NULL)
+    coordValueP = kjString(orionldState.kjsonP, "coordinates", "internal error parsing DB coordinates");
+  else
+    coordValueP->name = (char*) "coordinates";
+
+  return coordValueP;
+}
+
+
+
+// -----------------------------------------------------------------------------
+//
+// kjTreeFromCachedSubscription - in NGSI-LD API format 
+//
+KjNode* kjTreeFromCachedSubscription(CachedSubscription* cSubP, bool sysAttrs, bool contextInBody)
+{
+  KjNode* nodeP;
+  char    dateTime[64];
+
+  //
+  // Top level object - the Subscription
+  //
+  KjNode* sP = kjObject(orionldState.kjsonP, NULL);
+  NULL_CHECK(sP);
+
+  //
+  // id
+  //
+  nodeP = kjString(orionldState.kjsonP, "id", cSubP->subscriptionId);
+  NULL_CHECK(nodeP);
+  kjChildAdd(sP, nodeP);
+
+  //
+  // type
+  //
+  nodeP = kjString(orionldState.kjsonP, "type", "Subscription");
+  NULL_CHECK(nodeP);
+  kjChildAdd(sP, nodeP);
+
+  //
+  // subscriptionName
+  //
+  if (cSubP->name != "")
+  {
+    nodeP = kjString(orionldState.kjsonP, "subscriptionName", cSubP->name.c_str());
+    NULL_CHECK(nodeP);
+    kjChildAdd(sP, nodeP);
+  }
+  else
+    LM_TMP(("KZ: cSubP->name == \"\""));
+
+  //
+  // description
+  //
+  if (cSubP->description != NULL)
+  {
+    nodeP = kjString(orionldState.kjsonP, "description", cSubP->description);
+    NULL_CHECK(nodeP);
+    kjChildAdd(sP, nodeP);
+  }
+
+  //
+  // entities
+  //
+  int entities = cSubP->entityIdInfos.size();
+  if (entities > 0)
+  {
+    KjNode* entitiesP = kjArray(orionldState.kjsonP, "entities");
+    NULL_CHECK(entitiesP);
+
+    for (int eIx = 0; eIx < entities; eIx++)
+    {
+      EntityInfo* eiP      = cSubP->entityIdInfos[eIx];
+      KjNode*     eObjectP = kjObject(orionldState.kjsonP, NULL);
+      NULL_CHECK(eObjectP);
+
+      //
+      // id/idPattern
+      //
+      // SPECIAL CASE:
+      //  If it's a .* pattern, then it is omitted
+      //
+      const char*  entityId   = eiP->entityId.c_str();
+      bool         noIdNeeded = (eiP->isPattern == true) && (strcmp(entityId, ".*") == 0);
+
+      if ((noIdNeeded == false) && (*entityId != 0))
+      {
+        nodeP = (eiP->isPattern == false)? kjString(orionldState.kjsonP, "id", entityId) : kjString(orionldState.kjsonP, "idPattern", entityId);
+        NULL_CHECK(nodeP);
+        kjChildAdd(eObjectP, nodeP);
+      }
+
+      // type
+      char* shortType = orionldContextItemAliasLookup(orionldState.contextP, eiP->entityType.c_str(), NULL, NULL);
+      nodeP = kjString(orionldState.kjsonP, "type", shortType);
+      NULL_CHECK(nodeP);
+      
+      kjChildAdd(eObjectP, nodeP);
+
+      // Add the entitySelector object to the entities array
+      kjChildAdd(entitiesP, eObjectP);
+    }
+
+    kjChildAdd(sP, entitiesP);
+  }
+
+  //
+  // watchedAttributes
+  //
+  int watchedAttributes = (int) cSubP->notifyConditionV.size();
+  if (watchedAttributes > 0)
+  {
+    KjNode* watchedAttributesP = kjArray(orionldState.kjsonP, "watchedAttributes");
+    NULL_CHECK(watchedAttributesP);
+
+    for (int ix = 0; ix < watchedAttributes; ix++)
+    {
+      char* alias = orionldContextItemAliasLookup(orionldState.contextP, cSubP->notifyConditionV[ix].c_str(), NULL, NULL);
+
+      nodeP = kjString(orionldState.kjsonP, NULL, alias);
+      NULL_CHECK(nodeP);
+      kjChildAdd(watchedAttributesP, nodeP);
+    }
+
+    kjChildAdd(sP, watchedAttributesP);
+  }
+
+  //
+  // NGSI-LD q
+  //
+  if (cSubP->qText != NULL)
+  {
+    LM_TMP(("KZ: cSubP->qText: '%s' (should be EXACTLY as ldQ in the database)", cSubP->qText));
+    nodeP = kjString(orionldState.kjsonP, "q", cSubP->qText);
+    qAliasCompact(nodeP, true);  // qAliasCompact uses orionldState.contextP - all OK
+    LM_TMP(("KZ: Compacted qText: '%s'", nodeP->value.s));
+
+    //
+    // The ".value" is necessary for the database, but, we don't want to see it in a "GET /subscriptions/{subId}"
+    //
+    while (true)
+    {
+      char* dotValue = strstr(nodeP->value.s, ".value");
+
+      if (dotValue == NULL)
+        break;
+
+      // Left-Shift six steps
+      char* to = dotValue;
+
+      while (to[6] != 0)
+      {
+        to[0] = to[6];
+        ++to;
+      }
+      *to = 0;
+    }
+
+    LM_TMP(("KZ: .value-fixed qText: '%s'", nodeP->value.s));
+    
+    NULL_CHECK(nodeP);
+    kjChildAdd(sP, nodeP);
+  }
+
+  //
+  //  geoQ
+  //
+  if (cSubP->expression.geometry != "")
+  {
+    KjNode* geoqP = kjObject(orionldState.kjsonP, "geoQ");
+    NULL_CHECK(geoqP);
+
+    nodeP = kjString(orionldState.kjsonP, "geometry", cSubP->expression.geometry.c_str());
+    NULL_CHECK(nodeP);
+    kjChildAdd(geoqP, nodeP);
+
+    LM_TMP(("KZ: cSubP->expression.georel: '%s'", cSubP->expression.georel.c_str()));
+    nodeP = kjString(orionldState.kjsonP, "georel", cSubP->expression.georel.c_str());
+    NULL_CHECK(nodeP);
+    kjChildAdd(geoqP, nodeP);
+
+    LM_TMP(("KZ: cSubP->expression.coords: '%s'", cSubP->expression.coords.c_str()));
+    LM_TMP(("KZ: cSubP->geoCoordinatesP at %p", cSubP->geoCoordinatesP));
+    // nodeP = dbModelToCoordinates(cSubP->expression.coords.c_str());
+    LM_TMP(("KZ: cSubP->geoCoordinatesP is of tyoe '%s'", kjValueType(cSubP->geoCoordinatesP->type)));
+    nodeP = kjClone(orionldState.kjsonP, cSubP->geoCoordinatesP);
+    nodeP->name = (char*) "coordinates";
+    NULL_CHECK(nodeP);
+    kjChildAdd(geoqP, nodeP);
+
+    if (cSubP->expression.geoproperty != "")
+    {
+      nodeP = kjString(orionldState.kjsonP, "geoproperty", cSubP->expression.geoproperty.c_str());
+      NULL_CHECK(nodeP);
+      kjChildAdd(geoqP, nodeP);
+    }
+
+    kjChildAdd(sP, geoqP);
+  }
+
+  //
+  // status
+  //
+  if (cSubP->status == "active")
+    nodeP = kjString(orionldState.kjsonP, "status", "active");
+  else if (cSubP->status == "expired")
+    nodeP = kjString(orionldState.kjsonP, "status", "expired");
+  else
+    nodeP = kjString(orionldState.kjsonP, "status", "paused");
+  NULL_CHECK(nodeP);
+  kjChildAdd(sP, nodeP);
+
+  //
+  // isActive - possibly setting it
+  //
+  if ((cSubP->expirationTime > 0) && (cSubP->expirationTime < orionldState.requestTime))
+  {
+    cSubP->isActive = false;
+    cSubP->status   = "expired";
+  }
+  nodeP = kjBoolean(orionldState.kjsonP, "isActive", cSubP->isActive);
+  NULL_CHECK(nodeP);
+  kjChildAdd(sP, nodeP);
+
+  //
+  // notification
+  //
+  KjNode* notificationNodeP = kjObject(orionldState.kjsonP, "notification");
+  NULL_CHECK(notificationNodeP);
+
+  // notification::attributes
+  int attrs = cSubP->attributes.size();
+  if (attrs > 0)
+  {
+    KjNode* attributesNodeP = kjArray(orionldState.kjsonP, "attributes");
+
+    for (int ix = 0; ix < attrs; ix++)
+    {
+      char* alias = orionldContextItemAliasLookup(orionldState.contextP, cSubP->attributes[ix].c_str(), NULL, NULL);
+      nodeP = kjString(orionldState.kjsonP, NULL, alias);
+      NULL_CHECK(nodeP);
+      kjChildAdd(attributesNodeP, nodeP);
+    }
+    kjChildAdd(notificationNodeP, attributesNodeP);
+  }
+
+  // notification::format
+  nodeP = kjString(orionldState.kjsonP, "format", renderFormatToString(cSubP->renderFormat));
+  NULL_CHECK(nodeP);
+  kjChildAdd(notificationNodeP, nodeP);
+
+  // notification::endpoint
+  KjNode* endpointNodeP = kjObject(orionldState.kjsonP, "endpoint");
+  NULL_CHECK(endpointNodeP);
+
+  // notification::endpoint::uri
+  nodeP = kjString(orionldState.kjsonP, "uri", cSubP->httpInfo.url.c_str());
+  NULL_CHECK(nodeP);
+  kjChildAdd(endpointNodeP, nodeP);
+
+  // notification::endpoint::accept
+  nodeP	= kjString(orionldState.kjsonP, "accept", mimeTypeToLongString(cSubP->httpInfo.mimeType));
+  NULL_CHECK(nodeP);
+  kjChildAdd(endpointNodeP, nodeP);
+
+  // notification::endpoint::receiverInfo
+  int ris = cSubP->httpInfo.receiverInfo.size();
+  if (ris > 0)
+  {
+    KjNode* ri = kjArray(orionldState.kjsonP, "receiverInfo");
+    NULL_CHECK(ri);
+
+    for (int ix = 0; ix < ris; ix++)
+    {
+      KjNode* kvP  = kjObject(orionldState.kjsonP, NULL);
+      NULL_CHECK(kvP);
+      KjNode* keyP = kjString(orionldState.kjsonP, "key",   cSubP->httpInfo.receiverInfo[ix]->key);
+      NULL_CHECK(keyP);
+      KjNode* valueP = kjString(orionldState.kjsonP, "value", cSubP->httpInfo.receiverInfo[ix]->value);
+      NULL_CHECK(valueP);
+
+      kjChildAdd(kvP, keyP);
+      kjChildAdd(kvP, valueP);
+      kjChildAdd(ri, kvP);
+    }
+
+    kjChildAdd(endpointNodeP, ri);
+  }
+
+  // notification::endpoint::notifierInfo
+  int nis = cSubP->httpInfo.notifierInfo.size();
+  if (nis > 0)
+  {
+    KjNode* ni = kjArray(orionldState.kjsonP, "notifierInfo");
+    NULL_CHECK(ni);
+
+    for (int ix = 0; ix < nis; ix++)
+    {
+      KjNode* kvP  = kjObject(orionldState.kjsonP, NULL);
+      NULL_CHECK(kvP);
+      KjNode* keyP = kjString(orionldState.kjsonP, "key",   cSubP->httpInfo.notifierInfo[ix]->key);
+      NULL_CHECK(keyP);
+      KjNode* valueP = kjString(orionldState.kjsonP, "value", cSubP->httpInfo.notifierInfo[ix]->value);
+      NULL_CHECK(valueP);
+
+      kjChildAdd(kvP, keyP);
+      kjChildAdd(kvP, valueP);
+      kjChildAdd(ni, kvP);
+    }
+    kjChildAdd(endpointNodeP, ni);
+
+  }
+  kjChildAdd(notificationNodeP, endpointNodeP);
+
+  //
+  // notification::status
+  //
+  if (cSubP->consecutiveErrors == 0)
+    nodeP = kjString(orionldState.kjsonP, "status", "ok");
+  else
+    nodeP = kjString(orionldState.kjsonP, "status", "failed");
+  NULL_CHECK(nodeP);
+  kjChildAdd(notificationNodeP, nodeP);
+
+  //
+  // notification::timesSent
+  //
+  if (cSubP->count > 0)
+  {
+    nodeP = kjInteger(orionldState.kjsonP, "timesSent", cSubP->count);
+    NULL_CHECK(nodeP);
+    kjChildAdd(notificationNodeP, nodeP);
+  }
+
+  //
+  // notification::lastNotification
+  //
+  if (cSubP->lastNotificationTime > 0)
+  {
+    numberToDate(cSubP->lastNotificationTime, dateTime, sizeof(dateTime));
+    nodeP = kjString(orionldState.kjsonP, "lastNotification", dateTime);
+    NULL_CHECK(nodeP);
+    kjChildAdd(notificationNodeP, nodeP);
+  }
+
+  //
+  // notification::lastFailure
+  //
+  LM_TMP(("Getting lastFailure from sub cache"));
+  if (cSubP->lastFailure > 0)
+  {
+    numberToDate(cSubP->lastFailure, dateTime, sizeof(dateTime));
+    nodeP = kjString(orionldState.kjsonP, "lastFailure", dateTime);
+    NULL_CHECK(nodeP);
+    kjChildAdd(notificationNodeP, nodeP);
+  }
+
+  //
+  // notification::lastSuccess
+  //
+  if (cSubP->lastSuccess > 0)
+  {
+    numberToDate(cSubP->lastSuccess, dateTime, sizeof(dateTime));
+    nodeP = kjString(orionldState.kjsonP, "lastSuccess", dateTime);
+    NULL_CHECK(nodeP);
+    kjChildAdd(notificationNodeP, nodeP);
+  }
+
+  //
+  // notification::consecutiveErrors
+  //
+  if (cSubP->consecutiveErrors > 0)
+  {
+    nodeP = kjInteger(orionldState.kjsonP, "consecutiveErrors", cSubP->consecutiveErrors);
+    NULL_CHECK(nodeP);
+    kjChildAdd(notificationNodeP, nodeP);
+  }
+
+  //
+  // notification::lastErrorReason
+  //
+  if (cSubP->lastErrorReason[0] != 0)
+  {
+    nodeP = kjString(orionldState.kjsonP, "lastErrorReason", cSubP->lastErrorReason);
+    NULL_CHECK(nodeP);
+    kjChildAdd(notificationNodeP, nodeP);
+  }
+
+  kjChildAdd(sP, notificationNodeP);
+  
+  //
+  // expiresAt
+  //
+  if (cSubP->expirationTime > 0)
+  {
+    numberToDate(cSubP->expirationTime, dateTime, sizeof(dateTime));
+    nodeP = kjString(orionldState.kjsonP, "expiresAt", dateTime);
+    NULL_CHECK(nodeP);
+    kjChildAdd(sP, nodeP);
+  }
+
+  //
+  // throttling
+  //
+  if (cSubP->throttling > 0)
+  {
+    nodeP = kjFloat(orionldState.kjsonP, "throttling", cSubP->throttling);
+    NULL_CHECK(nodeP);
+    kjChildAdd(sP, nodeP);
+  }
+
+  // temporalQ - not implemented
+  // scopeQ - not implemented
+
+  //
+  // lang
+  //
+  if (cSubP->lang != "")
+  {
+    nodeP = kjString(orionldState.kjsonP, "lang", cSubP->lang.c_str());
+    NULL_CHECK(nodeP);
+    kjChildAdd(sP, nodeP);
+  }
+
+  //
+  // createdAt
+  //
+  LM_TMP(("KZ: cSubP->createdAt == %f", cSubP->createdAt));
+  if ((sysAttrs == true) && (cSubP->createdAt > 0))
+  {
+    numberToDate(cSubP->createdAt, dateTime, sizeof(dateTime));
+    nodeP = kjString(orionldState.kjsonP, "createdAt", dateTime);
+    NULL_CHECK(nodeP);
+    kjChildAdd(sP, nodeP);
+  }
+
+  //
+  // modifiedAt
+  //
+  LM_TMP(("KZ: cSubP->modifiedAt == %f", cSubP->modifiedAt));
+  if ((sysAttrs == true) && (cSubP->modifiedAt > 0))
+  {
+    numberToDate(cSubP->modifiedAt, dateTime, sizeof(dateTime));
+    nodeP = kjString(orionldState.kjsonP, "modifiedAt", dateTime);
+    NULL_CHECK(nodeP);
+    kjChildAdd(sP, nodeP);
+  }
+
+  //
+  // origin
+  //
+  if (experimental == true)
+  {
+    nodeP = kjString(orionldState.kjsonP, "origin", "cache");
+    NULL_CHECK(nodeP);
+    kjChildAdd(sP, nodeP);
+  }
+
+  //
+  // @context
+  //
+  if (contextInBody == true)
+  {
+    nodeP = kjString(orionldState.kjsonP, "@context", cSubP->ldContext.c_str());
+    NULL_CHECK(nodeP);
+    kjChildAdd(sP, nodeP);
+  }
+
+  return sP;
+}

--- a/src/lib/orionld/kjTree/kjTreeFromCachedSubscription.h
+++ b/src/lib/orionld/kjTree/kjTreeFromCachedSubscription.h
@@ -1,5 +1,5 @@
-#ifndef SRC_LIB_ORIONLD_COMMON_SUBCACHEAPISUBSCRIPTIONINSERT_H_
-#define SRC_LIB_ORIONLD_COMMON_SUBCACHEAPISUBSCRIPTIONINSERT_H_
+#ifndef SRC_LIB_ORIONLD_KJTREE_KJTREEFROMCACHEDSUBSCRIPTION_H_
+#define SRC_LIB_ORIONLD_KJTREE_KJTREEFROMCACHEDSUBSCRIPTION_H_
 
 /*
 *
@@ -27,19 +27,17 @@
 */
 extern "C"
 {
-#include "kjson/KjNode.h"                                      // KjNode
+#include "kjson/KjNode.h"                                        // KjNode
 }
 
-#include "cache/subCache.h"                                    // CachedSubscription
-#include "orionld/q/QNode.h"                                   // QNode
-#include "orionld/context/OrionldContext.h"                    // OrionldContext
+#include "cache/subCache.h"                                      // CachedSubscription
 
 
 
 // -----------------------------------------------------------------------------
 //
-// subCacheApiSubscriptionInsert -
+// kjTreeFromCachedSubscription - in NGSI-LD API format 
 //
-extern CachedSubscription* subCacheApiSubscriptionInsert(KjNode* apiSubscriptionP, QNode* qTree, KjNode* geoCoordinatesP, OrionldContext* contextP);
+extern KjNode* kjTreeFromCachedSubscription(CachedSubscription* cSubP, bool sysAttrs, bool contextInBody);
 
-#endif  // SRC_LIB_ORIONLD_COMMON_SUBCACHEAPISUBSCRIPTIONINSERT_H_
+#endif  // SRC_LIB_ORIONLD_KJTREE_KJTREEFROMCACHEDSUBSCRIPTION_H_

--- a/src/lib/orionld/kjTree/kjTreeFromCachedSubscription.h
+++ b/src/lib/orionld/kjTree/kjTreeFromCachedSubscription.h
@@ -36,7 +36,7 @@ extern "C"
 
 // -----------------------------------------------------------------------------
 //
-// kjTreeFromCachedSubscription - in NGSI-LD API format 
+// kjTreeFromCachedSubscription - in NGSI-LD API format
 //
 extern KjNode* kjTreeFromCachedSubscription(CachedSubscription* cSubP, bool sysAttrs, bool contextInBody);
 

--- a/src/lib/orionld/kjTree/kjTreeFromSubscription.cpp
+++ b/src/lib/orionld/kjTree/kjTreeFromSubscription.cpp
@@ -384,25 +384,6 @@ KjNode* kjTreeFromSubscription(ngsiv2::Subscription* subscriptionP, CachedSubscr
   }
 
 
-  // notification::endpoint::receiverInfo
-  if (subscriptionP->notification.httpInfo.receiverInfo.size() > 0)
-  {
-    KjNode* niArray = kjArray(orionldState.kjsonP, "receiverInfo");
-
-    for (unsigned int ix = 0; ix < subscriptionP->notification.httpInfo.receiverInfo.size(); ix++)
-    {
-      KjNode* kvObject = kjObject(orionldState.kjsonP, NULL);
-      KjNode* keyP     = kjString(orionldState.kjsonP, "key",   subscriptionP->notification.httpInfo.receiverInfo[ix]->key);
-      KjNode* valueP   = kjString(orionldState.kjsonP, "value", subscriptionP->notification.httpInfo.receiverInfo[ix]->value);
-
-      kjChildAdd(kvObject, keyP);
-      kjChildAdd(kvObject, valueP);
-      kjChildAdd(niArray,  kvObject);
-    }
-    kjChildAdd(endpointP, niArray);
-  }
-
-
   if (subscriptionP->notification.httpInfo.headers.size() > 0)
   {
     KjNode*           riArray   = kjArray(orionldState.kjsonP, "receiverInfo");

--- a/src/lib/orionld/kjTree/kjTreeFromSubscription.cpp
+++ b/src/lib/orionld/kjTree/kjTreeFromSubscription.cpp
@@ -54,6 +54,7 @@ extern "C"
 #include "orionld/kjTree/kjTreeFromSubscription.h"               // Own interface
 
 
+extern void dbModelValueStrip(KjNode* nodeP);  // FIXME: to its own modult under dbModel library
 
 // -----------------------------------------------------------------------------
 //
@@ -203,6 +204,7 @@ KjNode* kjTreeFromSubscription(ngsiv2::Subscription* subscriptionP, CachedSubscr
   if (q[0] != 0)
   {
     nodeP = kjString(orionldState.kjsonP, "q", q);
+    dbModelValueStrip(nodeP);
     qAliasCompact(nodeP, true);
     LM_TMP(("KZ: q after qAliasCompact: '%s'", nodeP->value.s));
     kjChildAdd(topP, nodeP);

--- a/src/lib/orionld/notifications/notificationSend.cpp
+++ b/src/lib/orionld/notifications/notificationSend.cpp
@@ -547,7 +547,6 @@ int notificationSend(OrionldAlterationMatch* mAltP, double timestamp)
   // Headers from Subscription::notification::endpoint::receiverInfo+headers (or custom notification in NGSIv2 ...)
   //
   headers += mAltP->subP->httpInfo.headers.size();
-  headers += mAltP->subP->httpInfo.receiverInfo.size();
 
 
   // Let's limit the number of headers to 50
@@ -675,21 +674,6 @@ int notificationSend(OrionldAlterationMatch* mAltP, double timestamp)
     ++headerIx;
     LM_TMP(("HttpInfo header '%s': '%s'", key, value));
   }
-
-  // receiverInfo
-  for (unsigned int ix = 0; ix < mAltP->subP->httpInfo.receiverInfo.size(); ix++)
-  {
-    const char* key    = mAltP->subP->httpInfo.receiverInfo[ix]->key;
-    const char* value  = mAltP->subP->httpInfo.receiverInfo[ix]->value;
-    int         len    = strlen(key) + strlen(value) + 10;
-    char*       buf    = kaAlloc(&orionldState.kalloc, len);
-
-    ioVec[headerIx].iov_len  = snprintf(buf, len, "%s: %s\r\n", key, value);
-    ioVec[headerIx].iov_base = buf;
-    ++headerIx;
-    LM_TMP(("HttpInfo receiverInfo '%s': '%s'", key, value));
-  }
-
 
   // Empty line delimiting HTTP Headers and Payload Body
   ioVec[headerIx].iov_base = (void*) "\r\n";

--- a/src/lib/orionld/payloadCheck/pCheckSubscription.cpp
+++ b/src/lib/orionld/payloadCheck/pCheckSubscription.cpp
@@ -24,6 +24,7 @@
 */
 extern "C"
 {
+#include "kbase/kMacros.h"                                       // K_FT
 #include "kjson/KjNode.h"                                        // KjNode
 }
 
@@ -101,6 +102,8 @@ bool pCheckSubscription
   KjNode**  qNodeP,
   QNode**   qTreeP,
   char**    qTextP,
+  bool*     qValidForV2P,
+  bool*     qIsMqP,
   KjNode**  uriPP,
   KjNode**  notifierInfoPP,
   KjNode**  geoCoordinatesPP
@@ -119,7 +122,6 @@ bool pCheckSubscription
   KjNode* qP                  = NULL;
   KjNode* geoqP               = NULL;
   KjNode* langP               = NULL;
-  QNode*  qTree               = NULL;
   double  expiresAt;
 
   if (idP != NULL)
@@ -179,15 +181,16 @@ bool pCheckSubscription
       PCHECK_DUPLICATE(qP, subItemP, 0, NULL, SubscriptionQPath, 400);
       PCHECK_STRING(qP, 0, NULL, SubscriptionQPath, 400);
 
-      LM_TMP(("QR: Calling qBuild(q='%s')", qP->value.s));
-      qTree = qBuild(qP->value.s);
-      LM_TMP(("QR: qTree at %p", qTree));
-
-      *qTextP = qP->value.s;
+      LM_TMP(("KZ: Calling qBuild(q='%s')", qP->value.s));
+      LM_TMP(("KZ: Need to expand the q so it looks like it does when it comes from the database before calling qBuild"));
+      *qTreeP = qBuild(qP->value.s, qTextP, qValidForV2P, qIsMqP, true);  // 5th parameter: qToDbModel == true
+      LM_TMP(("KZ: qTreeP:              %p", *qTreeP));
+      LM_TMP(("KZ: qTextP:              %s", *qTextP));
+      LM_TMP(("KZ: Valid for NGSIv2:    %s", K_FT(*qValidForV2P)));
+      LM_TMP(("KZ: Metadata for NGSIv2: %s", K_FT(*qIsMqP)));
       *qNodeP = qP;
-      *qTreeP = qTree;
 
-      if (qTree == NULL)
+      if (*qTreeP == NULL)
         return false;
     }
     else if (strcmp(subItemP->name, "geoQ") == 0)

--- a/src/lib/orionld/payloadCheck/pcheckQ.cpp
+++ b/src/lib/orionld/payloadCheck/pcheckQ.cpp
@@ -59,7 +59,7 @@ QNode* pcheckQ(char* qString)
     return NULL;
   }
 
-  if ((qTree = qParse(lexList, NULL, true, &title, &detail)) == NULL)
+  if ((qTree = qParse(lexList, NULL, true, true, &title, &detail)) == NULL)
   {
     orionldError(OrionldBadRequestData, title, detail, 400);
     return NULL;

--- a/src/lib/orionld/q/CMakeLists.txt
+++ b/src/lib/orionld/q/CMakeLists.txt
@@ -31,6 +31,7 @@ SET (SOURCES
     qRelease.cpp
     qBuild.cpp
     qRender.cpp
+    qLexListRender.cpp
 )
 
 # Include directories

--- a/src/lib/orionld/q/qBuild.h
+++ b/src/lib/orionld/q/qBuild.h
@@ -33,6 +33,28 @@
 //
 // qBuild - build QNode tree
 //
-extern QNode* qBuild(const char* q);
+// DESCRIPTION
+//   'q' filters are used for querying entities (GET /entities, POST /entityOperations/query) and
+//   for subscriptions/notifications.
+//
+//   For entity queries, the filter is parsed, used and thrown away - kalloc is used.
+//
+//   However, for subscriptions:
+//   - the filter needs to be expanded and saved in the database
+//   - the filter needs to ba allocated and stored in the subscription cache (for GET /subscriptions ops)
+//   - the resulting QNode tree needs to be allocated and stored in the subscription cache
+//
+//   At startup, when the subscription cache is populated from the database content, the same applies (for subscriptions).
+//   As well as for regular sub-cache refresh operations.
+//
+//   We assume for now that "GET /subscriptions" operations always use the sub-cache.
+//
+// PARAMETERS
+//   q          the string as it figures in uri param or payload body
+//   qRenderP   output parameter for the prepared filter (expansion, dotForEq, '.value')
+//   v2ValidP   output parameter indicating whether the q string id valid for NGSIv2
+//   isMdP      output parameter indicating whether the q para meter corresponds to 'mq' in NGSIv2
+//
+extern QNode* qBuild(const char* q, char** qRenderP, bool* v2ValidP, bool* isMdP, bool qToDbModel);
 
 #endif  // SRC_LIB_ORIONLD_Q_QBUILD_H_

--- a/src/lib/orionld/q/qLexListRender.cpp
+++ b/src/lib/orionld/q/qLexListRender.cpp
@@ -166,7 +166,7 @@ do {                                                                            
 //
 #define PUSH_INTEGER()                                                                              \
 do {                                                                                                \
-  char buf[32];                                                                                     \
+  char buf[20];                                                                                     \
   int  len = snprintf(buf, sizeof(buf) - 1, "%lld", qItemP->value.i);                               \
   if (outIx + len >= outSize)                                                                       \
   {                                                                                                 \

--- a/src/lib/orionld/q/qLexListRender.cpp
+++ b/src/lib/orionld/q/qLexListRender.cpp
@@ -1,0 +1,267 @@
+/*
+*
+* Copyright 2022 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+#include <stdio.h>                                             // snprintf
+#include <stdlib.h>                                            // malloc
+
+#include "logMsg/logMsg.h"                                     // LM_*
+
+#include "orionld/common/orionldState.h"                       // orionldState
+#include "orionld/common/orionldError.h"                       // orionldError
+#include "orionld/common/dotForEq.h"                           // dotForEq
+#include "orionld/context/orionldAttributeExpand.h"            // orionldAttributeExpand
+#include "orionld/q/QNode.h"                                   // QNode
+#include "orionld/q/qLexListRender.h"                          // Own interface
+
+
+
+// -----------------------------------------------------------------------------
+//
+// qVariableFix - from qParse.cpp - FIXME: new module q/qVariableFix.h/cpp
+//
+extern char* qVariableFix(char* varPath, bool forDb, bool* isMqP, char** detailsP);
+
+
+
+// -----------------------------------------------------------------------------
+//
+// PUSH_1 -
+//
+#define PUSH_1(c)          \
+do {                       \
+  outP[outIx] = c;         \
+  ++outIx;                 \
+} while (0)
+
+
+
+// -----------------------------------------------------------------------------
+//
+// PUSH_2 -
+//
+#define PUSH_2(c1, c2)     \
+do {                       \
+  outP[outIx]   = c1;      \
+  outP[outIx+1] = c2;      \
+  outIx += 2;              \
+} while (0)
+
+
+
+// -----------------------------------------------------------------------------
+//
+// PUSH_3 -
+//
+#define PUSH_3(c1, c2, c3) \
+do {                       \
+  outP[outIx]   = c1;      \
+  outP[outIx+1] = c2;      \
+  outP[outIx+2] = c3;      \
+  outIx += 3;              \
+} while (0)
+
+
+
+// -----------------------------------------------------------------------------
+//
+// PUSH_VARIABLE -
+//
+#define PUSH_VARIABLE()                                                                                 \
+do {                                                                                                    \
+  char* detail;                                                                                         \
+  char* varPath  = qVariableFix(qItemP->value.v, false, isMqP, &detail);                                \
+                                                                                                        \
+  if (varPath == NULL)                                                                                  \
+  {                                                                                                     \
+      orionldError(OrionldInternalError, "qVariableFix failed", detail, 500);                           \
+      return NULL;                                                                                      \
+  }                                                                                                     \
+                                                                                                        \
+  int len = strlen(varPath);                                                                            \
+  if (outIx + len >= outSize)                                                                           \
+  {                                                                                                     \
+    if ((outP = (char*) realloc(outP, outSize + 512)) == NULL)                                          \
+    {                                                                                                   \
+      orionldError(OrionldInternalError, "Out of memory", "allocating room for Q-List Variable", 500);  \
+      return NULL;                                                                                      \
+    }                                                                                                   \
+    outSize += 512;                                                                                     \
+  }                                                                                                     \
+  strncpy(&outP[outIx], varPath, len + 1);                                                              \
+  outIx += len;                                                                                         \
+} while (0)
+
+
+
+// -----------------------------------------------------------------------------
+//
+// PUSH_FLOAT -
+//
+#define PUSH_FLOAT()                                                                                \
+do                                                                                                  \
+{                                                                                                   \
+  char buf[32];                                                                                     \
+  int  len = snprintf(buf, sizeof(buf) - 1, "%f", qItemP->value.f);                                 \
+  if (outIx + len >= outSize)                                                                       \
+  {                                                                                                 \
+    if ((outP = (char*) realloc(outP, outSize + 512)) == NULL)                                      \
+    {                                                                                               \
+      orionldError(OrionldInternalError, "Out of memory", "allocating room for Q-List Text", 500);  \
+      return NULL;                                                                                  \
+    }                                                                                               \
+    outSize += 512;                                                                                 \
+  }                                                                                                 \
+  strncpy(&outP[outIx], buf, len + 1);                                                              \
+  outIx += len;                                                                                     \
+} while (0)
+
+
+
+// -----------------------------------------------------------------------------
+//
+// PUSH_STRING -
+//
+#define PUSH_STRING()                                                                                   \
+do {                                                                                                    \
+  int len = strlen(qItemP->value.s);                                                                    \
+  if (outIx + len >= outSize)                                                                           \
+  {                                                                                                     \
+    if ((outP = (char*) realloc(outP, outSize + 512)) == NULL)                                          \
+    {                                                                                                   \
+      orionldError(OrionldInternalError, "Out of memory", "allocating room for Q-List String", 500);    \
+      return NULL;                                                                                      \
+    }                                                                                                   \
+    outSize += 512;                                                                                     \
+  }                                                                                                     \
+  strncpy(&outP[outIx], qItemP->value.s, len + 1);                                                      \
+  outIx += len;                                                                                         \
+} while (0)
+
+
+
+// -----------------------------------------------------------------------------
+//
+// PUSH_INTEGER -
+//
+#define PUSH_INTEGER()                                                                              \
+do {                                                                                                \
+  char buf[32];                                                                                     \
+  int  len = snprintf(buf, sizeof(buf) - 1, "%lld", qItemP->value.i);                               \
+  if (outIx + len >= outSize)                                                                       \
+  {                                                                                                 \
+    if ((outP = (char*) realloc(outP, outSize + 512)) == NULL)                                      \
+    {                                                                                               \
+      orionldError(OrionldInternalError, "Out of memory", "allocating room for Q-List Text", 500);  \
+      return NULL;                                                                                  \
+    }                                                                                               \
+    outSize += 512;                                                                                 \
+  }                                                                                                 \
+  strncpy(&outP[outIx], buf, len+1);                                                                \
+  outIx += len;                                                                                     \
+} while (0)
+
+
+
+// -----------------------------------------------------------------------------
+//
+// PUSH_BOOLEAN -
+//
+#define PUSH_BOOLEAN(val)                                                                              \
+do {                                                                                                   \
+  int len = strlen(val);                                                                               \
+  if (outIx + len >= outSize)                                                                          \
+  {                                                                                                    \
+    if ((outP = (char*) realloc(outP, outSize + 512)) == NULL)                                         \
+    {                                                                                                  \
+      orionldError(OrionldInternalError, "Out of memory", "allocating room for Q-List Boolean", 500);  \
+      return NULL;                                                                                     \
+    }                                                                                                  \
+    outSize += 512;                                                                                    \
+  }                                                                                                    \
+  strncpy(&outP[outIx], val, len+1);                                                                   \
+  outIx += len;                                                                                        \
+} while (0)
+
+
+
+// -----------------------------------------------------------------------------
+//
+// PUSH_REGEX -
+//
+#define PUSH_REGEX()                             \
+do {                                             \
+  strncpy(&outP[outIx], "REGEX\0", 6);           \
+  outIx += 5;                                    \
+} while (0)
+
+
+
+// -----------------------------------------------------------------------------
+//
+// qLexListRender -
+//
+char* qLexListRender(QNode* qListP, bool* validInV2P, bool* isMqP)
+{
+  int   outSize = 512;
+  char* outP    = (char*) malloc(outSize);  // realloc if needed
+  int   outIx   = 0;
+
+  *validInV2P = true;   // Set to false later if need be (in the switch below)
+  *isMqP      = false;  // Set to true later if need be (in macro PUSH_VARIABLE)
+
+  int ix = 0;  // DEBUG
+  for (QNode* qItemP = qListP; qItemP != NULL; qItemP = qItemP->next)
+  {
+    switch (qItemP->type)
+    {
+    case QNodeVoid:                                            break;
+    case QNodeOpen:         PUSH_1('('); *validInV2P = false;  break;
+    case QNodeClose:        PUSH_1(')'); *validInV2P = false;  break;
+    case QNodeAnd:          PUSH_1(';');                       break;
+    case QNodeOr:           PUSH_1('|'); *validInV2P = false;  break;
+    case QNodeExists:                                          break;
+    case QNodeNotExists:    PUSH_1('!');                       break;
+    case QNodeGT:           PUSH_1('>');                       break;
+    case QNodeLT:           PUSH_1('<');                       break;
+    case QNodeEQ:           PUSH_2('=', '=');                  break;
+    case QNodeNE:           PUSH_2('=', '=');                  break;
+    case QNodeGE:           PUSH_2('>', '=');                  break;
+    case QNodeLE:           PUSH_2('<', '=');                  break;
+    case QNodeMatch:        PUSH_2('~', '=');                  break;
+    case QNodeNoMatch:      PUSH_3('!', '~', '=');             break;
+    case QNodeComma:        PUSH_1(',');                       break;
+    case QNodeRange:        PUSH_2('.', '.');                  break;
+    case QNodeVariable:     PUSH_VARIABLE();                   break;
+    case QNodeFloatValue:   PUSH_FLOAT();                      break;
+    case QNodeStringValue:  PUSH_STRING();                     break;
+    case QNodeIntegerValue: PUSH_INTEGER();                    break;
+    case QNodeTrueValue:    PUSH_BOOLEAN("true");              break;
+    case QNodeFalseValue:   PUSH_BOOLEAN("false");             break;
+    case QNodeRegexpValue:  PUSH_REGEX(); *validInV2P = false; break;
+    }
+    ++ix;
+  }
+
+  return outP;
+}

--- a/src/lib/orionld/q/qLexListRender.cpp
+++ b/src/lib/orionld/q/qLexListRender.cpp
@@ -46,174 +46,36 @@ extern char* qVariableFix(char* varPath, bool forDb, bool* isMqP, char** details
 
 // -----------------------------------------------------------------------------
 //
-// PUSH_1 -
+// intToString -
 //
-#define PUSH_1(c)          \
-do {                       \
-  outP[outIx] = c;         \
-  ++outIx;                 \
-} while (0)
+const char* intToString(QNode* qItemP, char* buf, int bufLen)
+{
+  snprintf(buf, bufLen - 1, "%lld", qItemP->value.i);
+  return buf;
+}
 
 
 
 // -----------------------------------------------------------------------------
 //
-// PUSH_2 -
+// floatToString -
 //
-#define PUSH_2(c1, c2)     \
-do {                       \
-  outP[outIx]   = c1;      \
-  outP[outIx+1] = c2;      \
-  outIx += 2;              \
-} while (0)
+const char* floatToString(QNode* qItemP, char* buf, int bufLen)
+{
+  snprintf(buf, bufLen - 1, "%f", qItemP->value.f);
+  return buf;
+}
 
 
 
 // -----------------------------------------------------------------------------
 //
-// PUSH_3 -
+// regexToString -
 //
-#define PUSH_3(c1, c2, c3) \
-do {                       \
-  outP[outIx]   = c1;      \
-  outP[outIx+1] = c2;      \
-  outP[outIx+2] = c3;      \
-  outIx += 3;              \
-} while (0)
-
-
-
-// -----------------------------------------------------------------------------
-//
-// PUSH_VARIABLE -
-//
-#define PUSH_VARIABLE()                                                                                 \
-do {                                                                                                    \
-  char* detail;                                                                                         \
-  char* varPath  = qVariableFix(qItemP->value.v, false, isMqP, &detail);                                \
-                                                                                                        \
-  if (varPath == NULL)                                                                                  \
-  {                                                                                                     \
-      orionldError(OrionldInternalError, "qVariableFix failed", detail, 500);                           \
-      return NULL;                                                                                      \
-  }                                                                                                     \
-                                                                                                        \
-  int len = strlen(varPath);                                                                            \
-  if (outIx + len >= outSize)                                                                           \
-  {                                                                                                     \
-    if ((outP = (char*) realloc(outP, outSize + 512)) == NULL)                                          \
-    {                                                                                                   \
-      orionldError(OrionldInternalError, "Out of memory", "allocating room for Q-List Variable", 500);  \
-      return NULL;                                                                                      \
-    }                                                                                                   \
-    outSize += 512;                                                                                     \
-  }                                                                                                     \
-  strncpy(&outP[outIx], varPath, len + 1);                                                              \
-  outIx += len;                                                                                         \
-} while (0)
-
-
-
-// -----------------------------------------------------------------------------
-//
-// PUSH_FLOAT -
-//
-#define PUSH_FLOAT()                                                                                \
-do                                                                                                  \
-{                                                                                                   \
-  char buf[32];                                                                                     \
-  int  len = snprintf(buf, sizeof(buf) - 1, "%f", qItemP->value.f);                                 \
-  if (outIx + len >= outSize)                                                                       \
-  {                                                                                                 \
-    if ((outP = (char*) realloc(outP, outSize + 512)) == NULL)                                      \
-    {                                                                                               \
-      orionldError(OrionldInternalError, "Out of memory", "allocating room for Q-List Text", 500);  \
-      return NULL;                                                                                  \
-    }                                                                                               \
-    outSize += 512;                                                                                 \
-  }                                                                                                 \
-  strncpy(&outP[outIx], buf, len + 1);                                                              \
-  outIx += len;                                                                                     \
-} while (0)
-
-
-
-// -----------------------------------------------------------------------------
-//
-// PUSH_STRING -
-//
-#define PUSH_STRING()                                                                                   \
-do {                                                                                                    \
-  int len = strlen(qItemP->value.s);                                                                    \
-  if (outIx + len >= outSize)                                                                           \
-  {                                                                                                     \
-    if ((outP = (char*) realloc(outP, outSize + 512)) == NULL)                                          \
-    {                                                                                                   \
-      orionldError(OrionldInternalError, "Out of memory", "allocating room for Q-List String", 500);    \
-      return NULL;                                                                                      \
-    }                                                                                                   \
-    outSize += 512;                                                                                     \
-  }                                                                                                     \
-  strncpy(&outP[outIx], qItemP->value.s, len + 1);                                                      \
-  outIx += len;                                                                                         \
-} while (0)
-
-
-
-// -----------------------------------------------------------------------------
-//
-// PUSH_INTEGER -
-//
-#define PUSH_INTEGER()                                                                              \
-do {                                                                                                \
-  char buf[20];                                                                                     \
-  int  len = snprintf(buf, sizeof(buf) - 1, "%lld", qItemP->value.i);                               \
-  if (outIx + len >= outSize)                                                                       \
-  {                                                                                                 \
-    if ((outP = (char*) realloc(outP, outSize + 512)) == NULL)                                      \
-    {                                                                                               \
-      orionldError(OrionldInternalError, "Out of memory", "allocating room for Q-List Text", 500);  \
-      return NULL;                                                                                  \
-    }                                                                                               \
-    outSize += 512;                                                                                 \
-  }                                                                                                 \
-  strncpy(&outP[outIx], buf, len+1);                                                                \
-  outIx += len;                                                                                     \
-} while (0)
-
-
-
-// -----------------------------------------------------------------------------
-//
-// PUSH_BOOLEAN -
-//
-#define PUSH_BOOLEAN(val)                                                                              \
-do {                                                                                                   \
-  int len = strlen(val);                                                                               \
-  if (outIx + len >= outSize)                                                                          \
-  {                                                                                                    \
-    if ((outP = (char*) realloc(outP, outSize + 512)) == NULL)                                         \
-    {                                                                                                  \
-      orionldError(OrionldInternalError, "Out of memory", "allocating room for Q-List Boolean", 500);  \
-      return NULL;                                                                                     \
-    }                                                                                                  \
-    outSize += 512;                                                                                    \
-  }                                                                                                    \
-  strncpy(&outP[outIx], val, len+1);                                                                   \
-  outIx += len;                                                                                        \
-} while (0)
-
-
-
-// -----------------------------------------------------------------------------
-//
-// PUSH_REGEX -
-//
-#define PUSH_REGEX()                             \
-do {                                             \
-  strncpy(&outP[outIx], "REGEX\0", 6);           \
-  outIx += 5;                                    \
-} while (0)
+const char* regexToString(QNode* qItemP, char* buf, int bufLen)
+{
+  return "REGEX";
+}
 
 
 
@@ -223,45 +85,78 @@ do {                                             \
 //
 char* qLexListRender(QNode* qListP, bool* validInV2P, bool* isMqP)
 {
-  int   outSize = 512;
-  char* outP    = (char*) malloc(outSize);  // realloc if needed
-  int   outIx   = 0;
+  int    outSize = 512;
+  char*  outP    = (char*) malloc(outSize);  // realloc if needed
+  int    outIx   = 0;
+  char*  detail;
 
   *validInV2P = true;   // Set to false later if need be (in the switch below)
-  *isMqP      = false;  // Set to true later if need be (in macro PUSH_VARIABLE)
+  *isMqP      = false;  // Set to true later if need be (qVariableFix)
 
-  int ix = 0;  // DEBUG
   for (QNode* qItemP = qListP; qItemP != NULL; qItemP = qItemP->next)
   {
+    char  buf[32];
+    char* bufP = buf;
+
     switch (qItemP->type)
     {
-    case QNodeVoid:                                            break;
-    case QNodeOpen:         PUSH_1('('); *validInV2P = false;  break;
-    case QNodeClose:        PUSH_1(')'); *validInV2P = false;  break;
-    case QNodeAnd:          PUSH_1(';');                       break;
-    case QNodeOr:           PUSH_1('|'); *validInV2P = false;  break;
-    case QNodeExists:                                          break;
-    case QNodeNotExists:    PUSH_1('!');                       break;
-    case QNodeGT:           PUSH_1('>');                       break;
-    case QNodeLT:           PUSH_1('<');                       break;
-    case QNodeEQ:           PUSH_2('=', '=');                  break;
-    case QNodeNE:           PUSH_2('=', '=');                  break;
-    case QNodeGE:           PUSH_2('>', '=');                  break;
-    case QNodeLE:           PUSH_2('<', '=');                  break;
-    case QNodeMatch:        PUSH_2('~', '=');                  break;
-    case QNodeNoMatch:      PUSH_3('!', '~', '=');             break;
-    case QNodeComma:        PUSH_1(',');                       break;
-    case QNodeRange:        PUSH_2('.', '.');                  break;
-    case QNodeVariable:     PUSH_VARIABLE();                   break;
-    case QNodeFloatValue:   PUSH_FLOAT();                      break;
-    case QNodeStringValue:  PUSH_STRING();                     break;
-    case QNodeIntegerValue: PUSH_INTEGER();                    break;
-    case QNodeTrueValue:    PUSH_BOOLEAN("true");              break;
-    case QNodeFalseValue:   PUSH_BOOLEAN("false");             break;
-    case QNodeRegexpValue:  PUSH_REGEX(); *validInV2P = false; break;
+    case QNodeVoid:         bufP = NULL;                                 break;
+    case QNodeOpen:         bufP = (char*) "("; *validInV2P = false;     break;
+    case QNodeClose:        bufP = (char*) ")"; *validInV2P = false;     break;
+    case QNodeAnd:          bufP = (char*) ";";                          break;
+    case QNodeOr:           bufP = (char*) "|"; *validInV2P = false;     break;
+    case QNodeExists:       bufP = NULL;                                 break;
+    case QNodeNotExists:    bufP = (char*) "!";                          break;
+    case QNodeGT:           bufP = (char*) ">";                          break;
+    case QNodeLT:           bufP = (char*) "<";                          break;
+    case QNodeEQ:           bufP = (char*) "==";                         break;
+    case QNodeNE:           bufP = (char*) "!=";                         break;
+    case QNodeGE:           bufP = (char*) ">=";                         break;
+    case QNodeLE:           bufP = (char*) "<=";                         break;
+    case QNodeMatch:        bufP = (char*) "~=";                         break;
+    case QNodeNoMatch:      bufP = (char*) "!~=";                        break;
+    case QNodeComma:        bufP = (char*) ",";                          break;
+    case QNodeRange:        bufP = (char*) "..";                         break;
+    case QNodeIntegerValue: intToString(qItemP, buf, sizeof(buf));       break;
+    case QNodeFloatValue:   floatToString(qItemP, buf, sizeof(buf));     break;
+    case QNodeStringValue:  bufP = qItemP->value.s;                      break;
+    case QNodeTrueValue:    bufP = (char*) "true";                       break;
+    case QNodeFalseValue:   bufP = (char*) "false";                      break;
+    case QNodeRegexpValue:
+      regexToString(qItemP, buf, sizeof(buf));
+      *validInV2P = false;
+      break;
+    case QNodeVariable:
+      bufP = qVariableFix(qItemP->value.v, false, isMqP, &detail);
+      if (bufP == NULL)
+      {
+        orionldError(OrionldInternalError, "qVariableFix failed", detail, 500);
+        return NULL;
+      }
+      break;
     }
-    ++ix;
+
+    if (bufP == NULL)
+      continue;
+
+    int len = strlen(bufP);
+    if (outIx + len >= outSize)
+    {
+      char* newBuf = (char*) realloc(outP, outSize + 512);
+
+      if (newBuf == NULL)
+      {
+        free(outP);
+        orionldError(OrionldInternalError, "Out of memory", "allocating room for Q-List", 500);
+        return NULL;
+      }
+      outP = newBuf;
+      outSize += 512;
+    }
+    strncpy(&outP[outIx], bufP, len);
+    outIx += len;
   }
 
+  outP[outIx] = 0;
   return outP;
 }

--- a/src/lib/orionld/q/qLexListRender.h
+++ b/src/lib/orionld/q/qLexListRender.h
@@ -1,5 +1,5 @@
-#ifndef SRC_LIB_ORIONLD_PAYLOADCHECK_PCHECKSUBSCRIPTION_H_
-#define SRC_LIB_ORIONLD_PAYLOADCHECK_PCHECKSUBSCRIPTION_H_
+#ifndef SRC_LIB_ORIONLD_Q_QLEXLISTRENDER_H_
+#define SRC_LIB_ORIONLD_Q_QLEXLISTRENDER_H_
 
 /*
 *
@@ -25,31 +25,14 @@
 *
 * Author: Ken Zangelin
 */
-extern "C"
-{
-#include "kjson/KjNode.h"                                     // KjNode
-}
+#include "orionld/q/QNode.h"                                   // QNode
 
 
 
 // -----------------------------------------------------------------------------
 //
-// pCheckSubscription -
+// qLexListRender -
 //
-extern bool pCheckSubscription
-(
-  KjNode*   subP,
-  KjNode*   idP,
-  KjNode*   typeP,
-  KjNode**  endpointP,
-  KjNode**  qNodeP,
-  QNode**   qTreeP,
-  char**    qTextP,
-  bool*     qValidForV2P,
-  bool*     qIsMqP,
-  KjNode**  uriPP,
-  KjNode**  notifierInfoPP,
-  KjNode**  geoCoordinatesPP
-);
+extern char* qLexListRender(QNode* qListP, bool* validInV2P, bool* isMqP);
 
-#endif  // SRC_LIB_ORIONLD_PAYLOADCHECK_PCHECKSUBSCRIPTION_H_
+#endif  // SRC_LIB_ORIONLD_Q_QLEXLISTRENDER_H_

--- a/src/lib/orionld/q/qParse.h
+++ b/src/lib/orionld/q/qParse.h
@@ -33,6 +33,6 @@
 //
 // qParse -
 //
-extern QNode* qParse(QNode* qLexList, QNode* endNodeP, bool forDb, char** titleP, char** detailsP);
+extern QNode* qParse(QNode* qLexList, QNode* endNodeP, bool forDb, bool qToDbModel, char** titleP, char** detailsP);
 
 #endif  // SRC_LIB_ORIONLD_Q_QPARSE_H_

--- a/src/lib/orionld/q/qRender.cpp
+++ b/src/lib/orionld/q/qRender.cpp
@@ -85,13 +85,13 @@ static bool qRenderOp(QNode* qP, const char* opString, ApiVersion apiVersion, ch
   return true;
 }
 
-
+// qRenderAND - any number of children
 
 // -----------------------------------------------------------------------------
 //
 // qRender -
 //
-bool qRender(QNode* qP, ApiVersion apiVersion, char* buf, int bufLen, bool* mqP, int* bufIxP)
+static bool qRender(QNode* qP, ApiVersion apiVersion, char* buf, int bufLen, bool* mqP, int* bufIxP)
 {
   LM_TMP(("QR: qP at %p (type: %s)", qP, (qP == NULL)? "NULL" : qNodeType(qP->type)));
   if ((qP->type == QNodeOr) && (apiVersion == V2))

--- a/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
@@ -192,6 +192,7 @@ static void optionsParse(const char* options)
       else if (strcmp(optionStart, "concise")       == 0)  orionldState.uriParamOptions.concise       = true;
       else if (strcmp(optionStart, "normalized")    == 0)  orionldState.uriParamOptions.normalized    = true;
       else if (strcmp(optionStart, "sysAttrs")      == 0)  orionldState.uriParamOptions.sysAttrs      = true;
+      else if (strcmp(optionStart, "fromDb")        == 0)  orionldState.uriParamOptions.fromDb        = true;
       else if (strcmp(optionStart, "append")        == 0)  orionldState.uriParamOptions.append        = true;  // NGSIv2 compatibility
       else if (strcmp(optionStart, "count")         == 0)  orionldState.uriParams.count               = true;  // NGSIv2 compatibility
       else if (strcmp(optionStart, "values")        == 0)  orionldState.uriParamOptions.values        = true;  // NGSIv2 compatibility

--- a/src/lib/orionld/serviceRoutines/orionldGetEntities.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntities.cpp
@@ -412,7 +412,7 @@ bool orionldGetEntities(void)
       return false;
     }
 
-    if ((qTree = qParse(lexList, NULL, true, &title, &detail)) == NULL)
+    if ((qTree = qParse(lexList, NULL, true, true, &title, &detail)) == NULL)
     {
       LM_W(("Bad Input (qParse: %s: %s)", title, detail));
       orionldError(OrionldBadRequestData, title, detail, 400);

--- a/src/lib/orionld/serviceRoutines/orionldPatchSubscription.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchSubscription.cpp
@@ -368,35 +368,35 @@ static bool subCacheItemUpdateNotificationEndpoint(CachedSubscription* cSubP, Kj
   if (receiverInfoP != NULL)
   {
     //
-    // for each key-value pair in "receiverInfo" -
-    // - look it up in cSubP->httpInfo.receiverInfo
-    // - replace the value if there, add if not there
+    // receiverInfo is stored in cSubP->httpInfo.headers
+    // - just set it (in the std::map)
     //
     for (KjNode* riP = receiverInfoP->value.firstChildP; riP != NULL; riP = riP->next)
     {
       KjNode*   keyP   = kjLookup(riP, "key");
       KjNode*   valueP = kjLookup(riP, "value");
-      KeyValue* kvP    = keyValueLookup(cSubP->httpInfo.receiverInfo, keyP->value.s);
 
-      if (kvP != NULL)
-        strncpy(kvP->value, valueP->value.s, sizeof(kvP->value) - 1);
-      else
-        keyValueAdd(&cSubP->httpInfo.receiverInfo, keyP->value.s, valueP->value.s);
+      cSubP->httpInfo.headers[keyP->value.s] = valueP->value.s;
     }
   }
 
   if (notifierInfoP != NULL)
   {
     //
-    // notifierInfo is stored in cSubP->httpInfo.headers
-    // - just set it (in the std::map)
+    // For each key-value pair in "notifierInfo":
+    //   - lookup the key in cSubP->httpInfo.notifierInfo
+    //   - replace the value if present, add it if not
     //
     for (KjNode* riP = notifierInfoP->value.firstChildP; riP != NULL; riP = riP->next)
     {
       KjNode*   keyP   = kjLookup(riP, "key");
       KjNode*   valueP = kjLookup(riP, "value");
+      KeyValue* kvP    = keyValueLookup(cSubP->httpInfo.notifierInfo, keyP->value.s);
 
-      cSubP->httpInfo.headers[keyP->value.s] = valueP->value.s;
+      if (kvP != NULL)
+        strncpy(kvP->value, valueP->value.s, sizeof(kvP->value) - 1);
+      else
+        keyValueAdd(&cSubP->httpInfo.notifierInfo, keyP->value.s, valueP->value.s);
     }
   }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_avoid_decimals_in_q.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_avoid_decimals_in_q.test
@@ -138,7 +138,7 @@ bye
 03. GET the subscription and see the Q String Filter P2>10
 ==========================================================
 HTTP/1.1 200 OK
-Content-Length: 549
+Content-Length: 561
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -146,7 +146,7 @@ Date: REGEX(.*)
 {
   "id": "http://a.b.c/subs/sub01",
   "type": "Subscription",
-  "name": "Test subscription 01",
+  "subscriptionName": "Test subscription 01",
   "description": "Description of Test subscription 01",
   "entities": [
     {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_geojson-format-subscription-get.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_geojson-format-subscription-get.test
@@ -136,7 +136,7 @@ bye
 03. GET the subscription
 ========================
 HTTP/1.1 200 OK
-Content-Length: 405
+Content-Length: 417
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -152,7 +152,6 @@ Date: REGEX(.*)
     "expiresAt": "2028-12-31T10:00:00.000Z",
     "id": "http://a.b.c/subs/sub01",
     "isActive": true,
-    "name": "Sub 01",
     "notification": {
         "endpoint": {
             "accept": "application/geo+json",
@@ -162,6 +161,7 @@ Date: REGEX(.*)
         "status": "ok"
     },
     "status": "active",
+    "subscriptionName": "Sub 01",
     "type": "Subscription"
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0118.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0118.test
@@ -219,7 +219,7 @@ bye
 02. GET subscriptions, no Accept MIME type, make sure application/json is returned
 ==================================================================================
 HTTP/1.1 200 OK
-Content-Length: 623
+Content-Length: 635
 Content-Type: application/json
 Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -252,7 +252,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub01",
         "isActive": false,
-        "name": "Sub 01",
         "notification": {
             "attributes": [
                 "P1",
@@ -268,6 +267,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Sub 01",
         "throttling": 5.001,
         "type": "Subscription",
         "watchedAttributes": [
@@ -280,7 +280,7 @@ Date: REGEX(.*)
 03. GET subscriptions, Accept MIME type explicitly set to application/json, make sure application/json is returned
 ==================================================================================================================
 HTTP/1.1 200 OK
-Content-Length: 623
+Content-Length: 635
 Content-Type: application/json
 Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -313,7 +313,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub01",
         "isActive": false,
-        "name": "Sub 01",
         "notification": {
             "attributes": [
                 "P1",
@@ -329,6 +328,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Sub 01",
         "throttling": 5.001,
         "type": "Subscription",
         "watchedAttributes": [
@@ -341,7 +341,7 @@ Date: REGEX(.*)
 04. GET subscriptions, Accept MIME type explicitly set to application/ld+json, make sure application/ld+json is returned
 ========================================================================================================================
 HTTP/1.1 200 OK
-Content-Length: 708
+Content-Length: 720
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -374,7 +374,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub01",
         "isActive": false,
-        "name": "Sub 01",
         "notification": {
             "attributes": [
                 "P1",
@@ -390,6 +389,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Sub 01",
         "throttling": 5.001,
         "type": "Subscription",
         "watchedAttributes": [
@@ -402,7 +402,7 @@ Date: REGEX(.*)
 05. GET particular subscription, no Accept MIME type, make sure application/json is returned
 ============================================================================================
 HTTP/1.1 200 OK
-Content-Length: 621
+Content-Length: 633
 Content-Type: application/json
 Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -434,7 +434,6 @@ Date: REGEX(.*)
     },
     "id": "urn:ngsi-ld:Subscription:sub01",
     "isActive": false,
-    "name": "Sub 01",
     "notification": {
         "attributes": [
             "P1",
@@ -450,6 +449,7 @@ Date: REGEX(.*)
     },
     "q": "P2>10",
     "status": "paused",
+    "subscriptionName": "Sub 01",
     "throttling": 5.001,
     "type": "Subscription",
     "watchedAttributes": [
@@ -461,7 +461,7 @@ Date: REGEX(.*)
 06. GET particular subscription, Accept MIME type explicitly set to application/json, make sure application/json is returned
 ============================================================================================================================
 HTTP/1.1 200 OK
-Content-Length: 621
+Content-Length: 633
 Content-Type: application/json
 Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -493,7 +493,6 @@ Date: REGEX(.*)
     },
     "id": "urn:ngsi-ld:Subscription:sub01",
     "isActive": false,
-    "name": "Sub 01",
     "notification": {
         "attributes": [
             "P1",
@@ -509,6 +508,7 @@ Date: REGEX(.*)
     },
     "q": "P2>10",
     "status": "paused",
+    "subscriptionName": "Sub 01",
     "throttling": 5.001,
     "type": "Subscription",
     "watchedAttributes": [
@@ -520,7 +520,7 @@ Date: REGEX(.*)
 07. GET particular subscription, Accept MIME type explicitly set to application/ld+json, make sure application/ld+json is returned
 ==================================================================================================================================
 HTTP/1.1 200 OK
-Content-Length: 706
+Content-Length: 718
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
@@ -552,7 +552,6 @@ Date: REGEX(.*)
     },
     "id": "urn:ngsi-ld:Subscription:sub01",
     "isActive": false,
-    "name": "Sub 01",
     "notification": {
         "attributes": [
             "P1",
@@ -568,6 +567,7 @@ Date: REGEX(.*)
     },
     "q": "P2>10",
     "status": "paused",
+    "subscriptionName": "Sub 01",
     "throttling": 5.001,
     "type": "Subscription",
     "watchedAttributes": [

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0329-get-subscription-with-complex-q-filter.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0329-get-subscription-with-complex-q-filter.test
@@ -143,7 +143,7 @@ bye
 03. GET /ngsi-ld/v1/subscription/urn:ngsi-ld:subscription:S1, make sure the Q-filter is OK
 ==========================================================================================
 HTTP/1.1 200 OK
-Content-Length: 626
+Content-Length: 638
 Content-Type: application/json
 Link: <https://fiware.github.io/tutorials.Step-by-Step/tutorials-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -157,7 +157,6 @@ Date: REGEX(.*)
     ],
     "id": "urn:ngsi-ld:subscription:S1",
     "isActive": true,
-    "name": "Test subscription 01",
     "notification": {
         "attributes": [
             "numberOfItems",
@@ -173,6 +172,7 @@ Date: REGEX(.*)
     },
     "q": "numberOfItems<10;locatedIn==%22urn:ngsi-ld:Store:001%22",
     "status": "active",
+    "subscriptionName": "Test subscription 01",
     "type": "Subscription",
     "watchedAttributes": [
         "numberOfItems"

--- a/test/functionalTest/cases/0000_ngsild/ngsild_langprop-and-notifications-new.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_langprop-and-notifications-new.test
@@ -197,7 +197,7 @@ bye
 04. GET subscription S2 - see lang=en
 =====================================
 HTTP/1.1 200 OK
-Content-Length: 323
+Content-Length: 340
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -223,6 +223,7 @@ Date: REGEX(.*)
         "format": "normalized",
         "status": "ok"
     },
+    "origin": "cache",
     "status": "active",
     "type": "Subscription",
     "watchedAttributes": [

--- a/test/functionalTest/cases/0000_ngsild/ngsild_langprop-and-notifications.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_langprop-and-notifications.test
@@ -336,7 +336,7 @@ bye
 04. GET subscription S2 - see lang=en
 =====================================
 HTTP/1.1 200 OK
-Content-Length: 323
+Content-Length: 340
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -362,6 +362,7 @@ Date: REGEX(.*)
         "format": "normalized",
         "status": "ok"
     },
+    "origin": "cache",
     "status": "active",
     "type": "Subscription",
     "watchedAttributes": [
@@ -373,7 +374,7 @@ Date: REGEX(.*)
 04. GET ALL subscriptions see lang=en in S2
 ===========================================
 HTTP/1.1 200 OK
-Content-Length: 637
+Content-Length: 677
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -399,6 +400,7 @@ Date: REGEX(.*)
             "format": "normalized",
             "status": "ok"
         },
+        "origin": "database",
         "status": "active",
         "type": "Subscription",
         "watchedAttributes": [
@@ -426,6 +428,7 @@ Date: REGEX(.*)
             "format": "normalized",
             "status": "ok"
         },
+        "origin": "database",
         "status": "active",
         "type": "Subscription",
         "watchedAttributes": [

--- a/test/functionalTest/cases/0000_ngsild/ngsild_list_subscriptions.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_list_subscriptions.test
@@ -382,7 +382,7 @@ Date: REGEX(.*)
 02. GET subscriptions - see the first 20
 ========================================
 HTTP/1.1 200 OK
-Content-Length: 12741
+Content-Length: 12981
 Content-Type: application/json
 Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -415,7 +415,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0001",
         "isActive": false,
-        "name": "Test subscription 0001",
         "notification": {
             "attributes": [
                 "P1",
@@ -431,6 +430,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0001",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -464,7 +464,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0002",
         "isActive": false,
-        "name": "Test subscription 0002",
         "notification": {
             "attributes": [
                 "P1",
@@ -480,6 +479,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0002",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -513,7 +513,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0003",
         "isActive": false,
-        "name": "Test subscription 0003",
         "notification": {
             "attributes": [
                 "P1",
@@ -529,6 +528,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0003",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -562,7 +562,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0004",
         "isActive": false,
-        "name": "Test subscription 0004",
         "notification": {
             "attributes": [
                 "P1",
@@ -578,6 +577,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0004",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -611,7 +611,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0005",
         "isActive": false,
-        "name": "Test subscription 0005",
         "notification": {
             "attributes": [
                 "P1",
@@ -627,6 +626,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0005",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -660,7 +660,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0006",
         "isActive": false,
-        "name": "Test subscription 0006",
         "notification": {
             "attributes": [
                 "P1",
@@ -676,6 +675,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0006",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -709,7 +709,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0007",
         "isActive": false,
-        "name": "Test subscription 0007",
         "notification": {
             "attributes": [
                 "P1",
@@ -725,6 +724,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0007",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -758,7 +758,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0008",
         "isActive": false,
-        "name": "Test subscription 0008",
         "notification": {
             "attributes": [
                 "P1",
@@ -774,6 +773,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0008",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -807,7 +807,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0009",
         "isActive": false,
-        "name": "Test subscription 0009",
         "notification": {
             "attributes": [
                 "P1",
@@ -823,6 +822,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0009",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -856,7 +856,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0010",
         "isActive": false,
-        "name": "Test subscription 0010",
         "notification": {
             "attributes": [
                 "P1",
@@ -872,6 +871,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0010",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -905,7 +905,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0011",
         "isActive": false,
-        "name": "Test subscription 0011",
         "notification": {
             "attributes": [
                 "P1",
@@ -921,6 +920,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0011",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -954,7 +954,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0012",
         "isActive": false,
-        "name": "Test subscription 0012",
         "notification": {
             "attributes": [
                 "P1",
@@ -970,6 +969,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0012",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -1003,7 +1003,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0013",
         "isActive": false,
-        "name": "Test subscription 0013",
         "notification": {
             "attributes": [
                 "P1",
@@ -1019,6 +1018,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0013",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -1052,7 +1052,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0014",
         "isActive": false,
-        "name": "Test subscription 0014",
         "notification": {
             "attributes": [
                 "P1",
@@ -1068,6 +1067,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0014",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -1101,7 +1101,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0015",
         "isActive": false,
-        "name": "Test subscription 0015",
         "notification": {
             "attributes": [
                 "P1",
@@ -1117,6 +1116,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0015",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -1150,7 +1150,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0016",
         "isActive": false,
-        "name": "Test subscription 0016",
         "notification": {
             "attributes": [
                 "P1",
@@ -1166,6 +1165,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0016",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -1199,7 +1199,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0017",
         "isActive": false,
-        "name": "Test subscription 0017",
         "notification": {
             "attributes": [
                 "P1",
@@ -1215,6 +1214,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0017",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -1248,7 +1248,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0018",
         "isActive": false,
-        "name": "Test subscription 0018",
         "notification": {
             "attributes": [
                 "P1",
@@ -1264,6 +1263,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0018",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -1297,7 +1297,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0019",
         "isActive": false,
-        "name": "Test subscription 0019",
         "notification": {
             "attributes": [
                 "P1",
@@ -1313,6 +1312,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0019",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -1346,7 +1346,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0020",
         "isActive": false,
-        "name": "Test subscription 0020",
         "notification": {
             "attributes": [
                 "P1",
@@ -1362,6 +1361,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0020",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -1374,7 +1374,7 @@ Date: REGEX(.*)
 03. GET subscriptions with limit 5 - see the first 5
 ====================================================
 HTTP/1.1 200 OK
-Content-Length: 3186
+Content-Length: 3246
 Content-Type: application/json
 Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -1407,7 +1407,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0001",
         "isActive": false,
-        "name": "Test subscription 0001",
         "notification": {
             "attributes": [
                 "P1",
@@ -1423,6 +1422,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0001",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -1456,7 +1456,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0002",
         "isActive": false,
-        "name": "Test subscription 0002",
         "notification": {
             "attributes": [
                 "P1",
@@ -1472,6 +1471,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0002",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -1505,7 +1505,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0003",
         "isActive": false,
-        "name": "Test subscription 0003",
         "notification": {
             "attributes": [
                 "P1",
@@ -1521,6 +1520,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0003",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -1554,7 +1554,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0004",
         "isActive": false,
-        "name": "Test subscription 0004",
         "notification": {
             "attributes": [
                 "P1",
@@ -1570,6 +1569,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0004",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -1603,7 +1603,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0005",
         "isActive": false,
-        "name": "Test subscription 0005",
         "notification": {
             "attributes": [
                 "P1",
@@ -1619,6 +1618,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0005",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -1631,7 +1631,7 @@ Date: REGEX(.*)
 04. GET subscriptions with limit 5 and offset 25, see subs 25-29
 ================================================================
 HTTP/1.1 200 OK
-Content-Length: 3186
+Content-Length: 3246
 Content-Type: application/json
 Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -1664,7 +1664,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0026",
         "isActive": false,
-        "name": "Test subscription 0026",
         "notification": {
             "attributes": [
                 "P1",
@@ -1680,6 +1679,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0026",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -1713,7 +1713,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0027",
         "isActive": false,
-        "name": "Test subscription 0027",
         "notification": {
             "attributes": [
                 "P1",
@@ -1729,6 +1728,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0027",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -1762,7 +1762,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0028",
         "isActive": false,
-        "name": "Test subscription 0028",
         "notification": {
             "attributes": [
                 "P1",
@@ -1778,6 +1777,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0028",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -1811,7 +1811,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0029",
         "isActive": false,
-        "name": "Test subscription 0029",
         "notification": {
             "attributes": [
                 "P1",
@@ -1827,6 +1826,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0029",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [
@@ -1860,7 +1860,6 @@ Date: REGEX(.*)
         },
         "id": "urn:ngsi-ld:Subscription:sub0030",
         "isActive": false,
-        "name": "Test subscription 0030",
         "notification": {
             "attributes": [
                 "P1",
@@ -1876,6 +1875,7 @@ Date: REGEX(.*)
         },
         "q": "P2>10",
         "status": "paused",
+        "subscriptionName": "Test subscription 0030",
         "throttling": 5,
         "type": "Subscription",
         "watchedAttributes": [

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new-subscription-get.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new-subscription-get.test
@@ -1,0 +1,306 @@
+# Copyright 2022 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Subscription Retrieval from cache and from DB
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+brokerStart CB 0 IPv4 -experimental
+
+--SHELL--
+
+#
+# 01. Create a subscription
+# 02. See the subscription in the database
+# 03. GET the subscription - from DB (options=fromDb)
+# 04. GET the subscription - from sub-cache (default since Summer '22)
+#
+
+
+echo "01. Create a subscription"
+echo "========================="
+payload='{
+  "id": "urn:ngsi-ld:subscriptions:S1",
+  "type": "Subscription",
+  "subscriptionName": "Test subscription 01",
+  "description": "Description of Test subscription 01",
+  "entities": [
+    {
+      "id": "urn:ngsi-ld:E01",
+      "type": "T1"
+    },
+    {
+      "id": "http://a.b.c/E02",
+      "type": "T2"
+    },
+    {
+      "idPattern": ".*E03.*",
+      "type": "T3"
+    }
+  ],
+  "watchedAttributes": [ "P2" ],
+  "q": "P2>10",
+  "geoQ": {
+    "geometry": "Point",
+    "coordinates": [1,2],
+    "georel": "near;maxDistance==100",
+    "geoproperty": "location"
+  },
+  "isActive": false,
+  "notification": {
+    "attributes": [ "P1", "P2", "A3" ],
+    "format": "keyValues",
+    "endpoint": {
+      "uri": "http://valid.url/url",
+      "accept": "application/ld+json"
+    }
+  },
+  "expiresAt": "2028-12-31T10:00:00",
+  "throttling": 5
+}'
+orionCurl --url /ngsi-ld/v1/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo "02. See the subscription in the database"
+echo "========================================"
+mongoCmd2 ftest "db.csubs.findOne()"
+echo
+echo
+
+
+echo "03. GET the subscription - from DB (options=fromDb)"
+echo "==================================================="
+orionCurl --url '/ngsi-ld/v1/subscriptions/urn:ngsi-ld:subscriptions:S1?options=fromDb&prettyPrint=yes&spaces=2' --noPayloadCheck
+echo
+echo
+
+
+echo "04. GET the subscription - from sub-cache (default since Summer '22)"
+echo "===================================================================="
+orionCurl --url '/ngsi-ld/v1/subscriptions/urn:ngsi-ld:subscriptions:S1?prettyPrint=yes&spaces=2' --noPayloadCheck
+echo
+echo
+
+
+--REGEXPECT--
+01. Create a subscription
+=========================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:subscriptions:S1
+Date: REGEX(.*)
+
+
+
+02. See the subscription in the database
+========================================
+MongoDB shell version REGEX(.*)
+connecting to: REGEX(.*)
+MongoDB server version: REGEX(.*)
+{
+	"_id" : "urn:ngsi-ld:subscriptions:S1",
+	"name" : "Test subscription 01",
+	"description" : "Description of Test subscription 01",
+	"entities" : [
+		{
+			"id" : "urn:ngsi-ld:E01",
+			"type" : "https://uri.etsi.org/ngsi-ld/default-context/T1",
+			"isPattern" : "false",
+			"isTypePattern" : false
+		},
+		{
+			"id" : "http://a.b.c/E02",
+			"type" : "https://uri.etsi.org/ngsi-ld/default-context/T2",
+			"isPattern" : "false",
+			"isTypePattern" : false
+		},
+		{
+			"id" : ".*E03.*",
+			"type" : "https://uri.etsi.org/ngsi-ld/default-context/T3",
+			"isPattern" : "true",
+			"isTypePattern" : false
+		}
+	],
+	"conditions" : [
+		"https://uri.etsi.org/ngsi-ld/default-context/P2"
+	],
+	"ldQ" : "https://uri.etsi.org/ngsi-ld/default-context/P2>10",
+	"expression" : {
+		"geometry" : "point",
+		"coords" : "1,2",
+		"georel" : "near;maxDistance:100",
+		"geoproperty" : "location",
+		"q" : "https://uri=etsi=org/ngsi-ld/default-context/P2.value>10",
+		"mq" : "P.P;!P.P"
+	},
+	"status" : "inactive",
+	"expiration" : 1861869600,
+	"throttling" : 5,
+	"createdAt" : REGEX(.*),
+	"modifiedAt" : REGEX(.*),
+	"attrs" : [
+		"https://uri.etsi.org/ngsi-ld/default-context/P1",
+		"https://uri.etsi.org/ngsi-ld/default-context/P2",
+		"https://uri.etsi.org/ngsi-ld/default-context/A3"
+	],
+	"format" : "keyValues",
+	"reference" : "http://valid.url/url",
+	"mimeType" : "application/ld+json",
+	"custom" : false,
+	"servicePath" : "/#",
+	"blacklist" : false,
+	"ldContext" : "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
+}
+bye
+
+
+03. GET the subscription - from DB (options=fromDb)
+===================================================
+HTTP/1.1 200 OK
+Content-Length: 953
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+{
+  "id": "urn:ngsi-ld:subscriptions:S1",
+  "type": "Subscription",
+  "subscriptionName": "Test subscription 01",
+  "description": "Description of Test subscription 01",
+  "entities": [
+    {
+      "id": "urn:ngsi-ld:E01",
+      "type": "T1"
+    },
+    {
+      "id": "http://a.b.c/E02",
+      "type": "T2"
+    },
+    {
+      "idPattern": ".*E03.*",
+      "type": "T3"
+    }
+  ],
+  "watchedAttributes": [
+    "P2"
+  ],
+  "q": "P2>10",
+  "geoQ": {
+    "geometry": "Point",
+    "coordinates": [
+      1,
+      2
+    ],
+    "georel": "near;maxDistance==100",
+    "geoproperty": "location"
+  },
+  "status": "paused",
+  "isActive": false,
+  "notification": {
+    "attributes": [
+      "P1",
+      "P2",
+      "A3"
+    ],
+    "format": "keyValues",
+    "endpoint": {
+      "uri": "http://valid.url/url",
+      "accept": "application/ld+json"
+    },
+    "status": "ok"
+  },
+  "expiresAt": "2028-12-31T10:00:00.000Z",
+  "throttling": 5,
+  "origin": "database"
+}
+
+
+
+04. GET the subscription - from sub-cache (default since Summer '22)
+====================================================================
+HTTP/1.1 200 OK
+Content-Length: 950
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+{
+  "id": "urn:ngsi-ld:subscriptions:S1",
+  "type": "Subscription",
+  "subscriptionName": "Test subscription 01",
+  "description": "Description of Test subscription 01",
+  "entities": [
+    {
+      "id": "urn:ngsi-ld:E01",
+      "type": "T1"
+    },
+    {
+      "id": "http://a.b.c/E02",
+      "type": "T2"
+    },
+    {
+      "idPattern": ".*E03.*",
+      "type": "T3"
+    }
+  ],
+  "watchedAttributes": [
+    "P2"
+  ],
+  "q": "P2>10",
+  "geoQ": {
+    "geometry": "Point",
+    "georel": "near;maxDistance==100",
+    "coordinates": [
+      1,
+      2
+    ],
+    "geoproperty": "location"
+  },
+  "status": "paused",
+  "isActive": false,
+  "notification": {
+    "attributes": [
+      "P1",
+      "P2",
+      "A3"
+    ],
+    "format": "keyValues",
+    "endpoint": {
+      "uri": "http://valid.url/url",
+      "accept": "application/ld+json"
+    },
+    "status": "ok"
+  },
+  "expiresAt": "2028-12-31T10:00:00.000Z",
+  "throttling": 5,
+  "origin": "cache"
+}
+
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new-subscription-get.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new-subscription-get.test
@@ -147,14 +147,14 @@ MongoDB server version: REGEX(.*)
 	"conditions" : [
 		"https://uri.etsi.org/ngsi-ld/default-context/P2"
 	],
-	"ldQ" : "https://uri.etsi.org/ngsi-ld/default-context/P2>10",
+	"ldQ" : "https://uri=etsi=org/ngsi-ld/default-context/P2.value>10",
 	"expression" : {
 		"geometry" : "point",
 		"coords" : "1,2",
 		"georel" : "near;maxDistance:100",
 		"geoproperty" : "location",
 		"q" : "https://uri=etsi=org/ngsi-ld/default-context/P2.value>10",
-		"mq" : "P.P;!P.P"
+		"mq" : ""
 	},
 	"status" : "inactive",
 	"expiration" : 1861869600,

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new-subscription-with-complex-q.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new-subscription-with-complex-q.test
@@ -1,0 +1,173 @@
+# Copyright 2022 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+New subscription with a complex q, for creation, update and sub-cache-refresh
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+brokerStart CB 0 IPv4 -experimental -subCacheIval 5
+accumulatorStart --pretty-print 127.0.0.1 ${LISTENER_PORT}
+
+--SHELL--
+
+#
+# 01. Create a subscription S1 with q=(temp<18|temp>25)&(humidity<20|humidity>80)
+# 02. See the subscription in mongo - see ldQ as expanded q with '.value' and '=' ???
+# 03. GET the subscription from cache - assure 'q' is OK
+# 04. GET the subscription from DB - assure 'q' is OK
+# 05. Create a matching Entity E1, to provoke a notification
+# 06. Create a non-matching Entity E2, to NOT provoke any notification
+# 07. Dump+Reset accumulator, see ONE notification (E1)
+#
+# 08. PATCH sub with q=(temp<19|temp>26)&(humidity<21|humidity>81)
+# 09. See the subscription in mongo - see ldQ as expanded q with '.value' and '='
+# 10. GET the subscription from cache - assure 'q' is OK
+# 11. GET the subscription from DB - assure 'q' is OK
+# 12. Create a matching Entity E3, to provoke a notification
+# 13. Create a non-matching Entity E4, to NOT provoke any notification
+# 14. Dump+Reset accumulator, see ONE notification (E3)
+#
+# 15. Sleep 5 secs, to give the broker time to refresh the subcache
+# 16. GET the subscription from cache - assure 'q' is OK
+# 17. GET the subscription from DB - assure 'q' is OK
+# 18. Create a matching Entity E5, to provoke a notification
+# 19. Create a non-matching Entity E6, to NOT provoke any notification
+# 20. Dump+Reset accumulator, see ONE notification (E5)
+#
+# 21. Restart the broker
+# 22. GET the subscription from cache - assure 'q' is OK
+# 23. GET the subscription from DB - assure 'q' is OK
+# 24. Create a matching Entity E7, to provoke a notification
+# 25. Create a non-matching Entity E8, to NOT provoke any notification
+# 26. Dump+Reset accumulator, see ONE notification (E7)
+#
+
+
+echo "01. Create a subscription S1 with q=(temp<18|temp>25)&(humidity<20|humidity>80)"
+echo "==============================================================================="
+payload='{
+  "id": "urn:ngsi-ld:subs:S1",
+  "type": "Subscription",
+  "entities": [
+    {
+      "type": "T"
+    }
+  ],
+  "q": "(temp<18|temp>25)&(humidity<20|humidity>80)",
+  "notification": {
+    "format": "simplified",
+    "endpoint": {
+      "uri": "http://127.0.0.1:'${LISTENER_PORT}'/notify"
+    }
+  }
+}'
+orionCurl --url /ngsi-ld/v1/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo "02. See the subscription in mongo - see ldQ as expanded q with '.value' and '='"
+echo "==============================================================================="
+mongoCmd2 ftest "db.csubs.findOne()"
+echo
+echo
+
+
+echo "03. GET the subscription from cache - assure 'q' is OK"
+echo "======================================================"
+#orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:subs:S1
+echo
+echo
+
+
+echo "04. GET the subscription from DB - assure 'q' is OK"
+echo "==================================================="
+#orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:subs:S1?options=fromDb
+echo
+echo
+
+
+--REGEXPECT--
+01. Create a subscription S1 with q=(temp<18|temp>25)&(humidity<20|humidity>80)
+===============================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:subs:S1
+Date: REGEX(.*)
+
+
+
+02. See the subscription in mongo - see ldQ as expanded q with '.value' and '='
+===============================================================================
+MongoDB shell version REGEX(.*)
+connecting to: REGEX(.*)
+MongoDB server version: REGEX(.*)
+{
+	"_id" : "urn:ngsi-ld:subs:S1",
+	"entities" : [
+		{
+			"type" : "https://uri.etsi.org/ngsi-ld/default-context/T",
+			"id" : ".*",
+			"isPattern" : "true",
+			"isTypePattern" : false
+		}
+	],
+	"ldQ" : "(https://uri=etsi=org/ngsi-ld/default-context/temp.value<18|https://uri=etsi=org/ngsi-ld/default-context/temp.value>25);(https://uri=etsi=org/ngsi-ld/default-context/humidity.value<20|https://uri=etsi=org/ngsi-ld/default-context/humidity.value>80)",
+	"createdAt" : REGEX(.*),
+	"modifiedAt" : REGEX(.*),
+	"throttling" : 0,
+	"expression" : {
+		"geometry" : "",
+		"coords" : "",
+		"georel" : "",
+		"geoproperty" : "",
+		"q" : "P;!P",
+		"mq" : "P.P;!P.P"
+	},
+	"format" : "simplified",
+	"reference" : "http://127.0.0.1:9997/notify",
+	"mimeType" : "application/json",
+	"attrs" : [ ],
+	"conditions" : [ ],
+	"status" : "active",
+	"custom" : false,
+	"servicePath" : "/#",
+	"blacklist" : false,
+	"ldContext" : "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
+}
+bye
+
+
+03. GET the subscription from cache - assure 'q' is OK
+======================================================
+
+
+04. GET the subscription from DB - assure 'q' is OK
+===================================================
+
+
+--TEARDOWN--
+brokerStop CB
+accumulatorStop
+dbDrop CB

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new-subscription-with-mqtt-notification.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new-subscription-with-mqtt-notification.test
@@ -236,7 +236,7 @@ bye
 03. GET the subscription
 ========================
 HTTP/1.1 200 OK
-Content-Length: 449
+Content-Length: 487
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -244,7 +244,7 @@ Date: REGEX(.*)
 {
     "entities": [
         {
-            "type": "AirQualityObserved"
+            "type": "https://uri.fiware.org/ns/data-models#AirQualityObserved"
         },
         {
             "type": "AirQualityObserved2"
@@ -332,7 +332,7 @@ Notifications: 1
 07. GET the subscription, without context => AirQualityObserved as longname
 ===========================================================================
 HTTP/1.1 200 OK
-Content-Length: 505
+Content-Length: 487
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -381,9 +381,9 @@ Date: REGEX(.*)
 07. GET the subscription, with context => AirQualityObserved as shortname
 =========================================================================
 HTTP/1.1 200 OK
-Content-Length: 466
+Content-Length: 449
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://fiware.github.io/data-models/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
 
 {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new-subscription-with-mqtt-notification.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new-subscription-with-mqtt-notification.test
@@ -38,7 +38,7 @@ mqttTestClientStart --mqttBrokerPort $MQTT_BROKER_PORT --mqttBrokerIp $MQTT_BROK
 # 04. Create an entity matching the subscription
 # 05. Dump and Reset the MQTT test client and see one notification
 # 06. Restart the broker
-# 07. GET the subscription
+# 07. GET the subscription, without context => AirQualityObserved as longname
 # 08. Create another entity matching the subscription
 # 09. Dump the MQTT test client and see one notification
 #
@@ -134,9 +134,16 @@ echo
 echo
 
 
-echo "07. GET the subscription"
-echo "========================"
+echo "07. GET the subscription, without context => AirQualityObserved as longname"
+echo "==========================================================================="
 orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:mqttNotification
+echo
+echo
+
+
+echo "07. GET the subscription, with context => AirQualityObserved as shortname"
+echo "========================================================================="
+orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:mqttNotification  -H 'Link: <https://fiware.github.io/data-models/context.jsonld>'
 echo
 echo
 
@@ -229,7 +236,7 @@ bye
 03. GET the subscription
 ========================
 HTTP/1.1 200 OK
-Content-Length: 432
+Content-Length: 449
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -269,6 +276,7 @@ Date: REGEX(.*)
         "format": "normalized",
         "status": "ok"
     },
+    "origin": "cache",
     "status": "active",
     "type": "Subscription"
 }
@@ -321,10 +329,59 @@ Notifications: 1
 ======================
 
 
-07. GET the subscription
-========================
+07. GET the subscription, without context => AirQualityObserved as longname
+===========================================================================
 HTTP/1.1 200 OK
-Content-Length: 432
+Content-Length: 505
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+{
+    "entities": [
+        {
+            "type": "https://uri.fiware.org/ns/data-models#AirQualityObserved"
+        },
+        {
+            "type": "AirQualityObserved2"
+        }
+    ],
+    "id": "urn:ngsi-ld:Subscription:mqttNotification",
+    "isActive": true,
+    "notification": {
+        "endpoint": {
+            "accept": "application/json",
+            "notifierInfo": [
+                {
+                    "key": "MQTT-QoS",
+                    "value": "2"
+                }
+            ],
+            "receiverInfo": [
+                {
+                    "key": "H1",
+                    "value": "123"
+                },
+                {
+                    "key": "H2",
+                    "value": "456"
+                }
+            ],
+            "uri": "mqtt://localhost:1883/entities"
+        },
+        "format": "normalized",
+        "status": "ok"
+    },
+    "origin": "cache",
+    "status": "active",
+    "type": "Subscription"
+}
+
+
+07. GET the subscription, with context => AirQualityObserved as shortname
+=========================================================================
+HTTP/1.1 200 OK
+Content-Length: 466
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -364,6 +421,7 @@ Date: REGEX(.*)
         "format": "normalized",
         "status": "ok"
     },
+    "origin": "cache",
     "status": "active",
     "type": "Subscription"
 }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new-subscription_create.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new-subscription_create.test
@@ -420,7 +420,7 @@ MongoDB server version: REGEX(.*)
 	"conditions" : [
 		"http://example.org/P2"
 	],
-	"ldQ" : "http://example.org/P2>10|http://example.org/P1==7",
+	"ldQ" : "http://example=org/P2.value>10|http://example=org/P1.value==7",
 	"expression" : {
 		"geometry" : "point",
 		"coords" : "1,2",
@@ -728,7 +728,7 @@ MongoDB server REGEX(.*)
 			"isTypePattern" : false
 		}
 	],
-	"ldQ" : "https://uri.etsi.org/ngsi-ld/default-context/P2>10",
+	"ldQ" : "https://uri=etsi=org/ngsi-ld/default-context/P2.value>10",
 	"createdAt" : REGEX(.*),
 	"modifiedAt" : REGEX(.*),
 	"throttling" : 0,
@@ -738,7 +738,7 @@ MongoDB server REGEX(.*)
 		"georel" : "",
 		"geoproperty" : "",
 		"q" : "https://uri=etsi=org/ngsi-ld/default-context/P2.value>10",
-		"mq" : "P.P;!P.P"
+		"mq" : ""
 	},
 	"format" : "normalized",
 	"reference" : "http://tutorial:3000/subscription/test0001",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new-subscription_create.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new-subscription_create.test
@@ -420,7 +420,7 @@ MongoDB server version: REGEX(.*)
 	"conditions" : [
 		"http://example.org/P2"
 	],
-	"ldQ" : "P2>10|P1==7",
+	"ldQ" : "http://example.org/P2>10|http://example.org/P1==7",
 	"expression" : {
 		"geometry" : "point",
 		"coords" : "1,2",
@@ -459,7 +459,7 @@ bye
 03. GET /ngsi-ld/v1/subscription/http://a.b.c/subs/sub01, see @context in HTTP header
 =====================================================================================
 HTTP/1.1 200 OK
-Content-Length: 1132
+Content-Length: 1163
 Content-Type: application/json
 Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -467,7 +467,7 @@ Date: REGEX(.*)
 {
   "id": "http://a.b.c/subs/sub01",
   "type": "Subscription",
-  "name": "Test subscription 01",
+  "subscriptionName": "Test subscription 01",
   "description": "Description of Test subscription 01",
   "entities": [
     {
@@ -489,14 +489,14 @@ Date: REGEX(.*)
   "q": "P2>10|P1==7",
   "geoQ": {
     "geometry": "Point",
+    "georel": "near;maxDistance==1000",
     "coordinates": [
       1,
       2
     ],
-    "georel": "near;maxDistance==1000",
     "geoproperty": "location"
   },
-  "status": "inactive",
+  "status": "paused",
   "isActive": false,
   "notification": {
     "attributes": [
@@ -508,88 +508,16 @@ Date: REGEX(.*)
     "endpoint": {
       "uri": "http://valid.url/url",
       "accept": "application/ld+json",
-      "notifierInfo": [
-        {
-          "key": "MQTT-QoS",
-          "value": "0"
-        }
-      ],
       "receiverInfo": [
         {
           "key": "H1",
           "value": "header 1"
         }
-      ]
-    },
-    "status": "ok"
-  },
-  "expiresAt": "2028-12-31T10:00:00.000Z",
-  "throttling": 5
-}
-
-
-
-04. GET /ngsi-ld/v1/subscription/http://a.b.c/subs/sub01, accepting jsonld - see @context in payload
-====================================================================================================
-HTTP/1.1 200 OK
-Content-Length: 1221
-Content-Type: application/ld+json
-Date: REGEX(.*)
-
-{
-  "id": "http://a.b.c/subs/sub01",
-  "type": "Subscription",
-  "name": "Test subscription 01",
-  "description": "Description of Test subscription 01",
-  "entities": [
-    {
-      "id": "urn:ngsi-ld:E01",
-      "type": "T1"
-    },
-    {
-      "id": "http://a.b.c/E02",
-      "type": "T2"
-    },
-    {
-      "idPattern": ".*E03.*",
-      "type": "T3"
-    }
-  ],
-  "watchedAttributes": [
-    "P2"
-  ],
-  "q": "P2>10|P1==7",
-  "geoQ": {
-    "geometry": "Point",
-    "coordinates": [
-      1,
-      2
-    ],
-    "georel": "near;maxDistance==1000",
-    "geoproperty": "location"
-  },
-  "status": "inactive",
-  "isActive": false,
-  "notification": {
-    "attributes": [
-      "P1",
-      "P2",
-      "A3"
-    ],
-    "format": "keyValues",
-    "endpoint": {
-      "uri": "http://valid.url/url",
-      "accept": "application/ld+json",
+      ],
       "notifierInfo": [
         {
           "key": "MQTT-QoS",
           "value": "0"
-        }
-      ],
-      "receiverInfo": [
-        {
-          "key": "H1",
-          "value": "header 1"
         }
       ]
     },
@@ -597,6 +525,80 @@ Date: REGEX(.*)
   },
   "expiresAt": "2028-12-31T10:00:00.000Z",
   "throttling": 5,
+  "origin": "cache"
+}
+
+
+
+04. GET /ngsi-ld/v1/subscription/http://a.b.c/subs/sub01, accepting jsonld - see @context in payload
+====================================================================================================
+HTTP/1.1 200 OK
+Content-Length: 1252
+Content-Type: application/ld+json
+Date: REGEX(.*)
+
+{
+  "id": "http://a.b.c/subs/sub01",
+  "type": "Subscription",
+  "subscriptionName": "Test subscription 01",
+  "description": "Description of Test subscription 01",
+  "entities": [
+    {
+      "id": "urn:ngsi-ld:E01",
+      "type": "T1"
+    },
+    {
+      "id": "http://a.b.c/E02",
+      "type": "T2"
+    },
+    {
+      "idPattern": ".*E03.*",
+      "type": "T3"
+    }
+  ],
+  "watchedAttributes": [
+    "P2"
+  ],
+  "q": "P2>10|P1==7",
+  "geoQ": {
+    "geometry": "Point",
+    "georel": "near;maxDistance==1000",
+    "coordinates": [
+      1,
+      2
+    ],
+    "geoproperty": "location"
+  },
+  "status": "paused",
+  "isActive": false,
+  "notification": {
+    "attributes": [
+      "P1",
+      "P2",
+      "A3"
+    ],
+    "format": "keyValues",
+    "endpoint": {
+      "uri": "http://valid.url/url",
+      "accept": "application/ld+json",
+      "receiverInfo": [
+        {
+          "key": "H1",
+          "value": "header 1"
+        }
+      ],
+      "notifierInfo": [
+        {
+          "key": "MQTT-QoS",
+          "value": "0"
+        }
+      ]
+    },
+    "status": "ok"
+  },
+  "expiresAt": "2028-12-31T10:00:00.000Z",
+  "throttling": 5,
+  "origin": "cache",
   "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
 }
 
@@ -665,7 +667,7 @@ Date: REGEX(.*)
 10. GET sub09 with sysAttrs and make sure no 'expires' nor 'throttling' is returned
 ===================================================================================
 HTTP/1.1 200 OK
-Content-Length: 456
+Content-Length: 485
 Content-Type: application/json
 Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -682,7 +684,6 @@ Date: REGEX(.*)
     "id": "http://a.b.c/subs/sub09",
     "isActive": true,
     "modifiedAt": REGEX(.*),
-    "name": "Test subscription 09",
     "notification": {
         "attributes": [
             "P1"
@@ -694,8 +695,10 @@ Date: REGEX(.*)
         "format": "keyValues",
         "status": "ok"
     },
+    "origin": "cache",
     "q": "P2>10",
     "status": "active",
+    "subscriptionName": "Test subscription 09",
     "type": "Subscription"
 }
 
@@ -725,7 +728,7 @@ MongoDB server REGEX(.*)
 			"isTypePattern" : false
 		}
 	],
-	"ldQ" : "P2>10",
+	"ldQ" : "https://uri.etsi.org/ngsi-ld/default-context/P2>10",
 	"createdAt" : REGEX(.*),
 	"modifiedAt" : REGEX(.*),
 	"throttling" : 0,

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_notification_with-q-and-subcache-refresh.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_notification_with-q-and-subcache-refresh.test
@@ -33,11 +33,14 @@ accumulatorStart --pretty-print 127.0.0.1 ${LISTENER_PORT}
 
 #
 # 01. Create a subscription S1 with q=A==0|B==0 - q-tree created by postSubscriptions
-# 02. Wait 2.1 seconds, to give the broker time to refresh its sub cache
-# 03. Create an Entity E1 with A==1 - no notification
-# 04. Create an Entity E2 with B==1 - no notification
-# 05. Create an Entity E3 with A==0 - notification
-# 06. Dump accumulator and see the notification for E3 only
+# 02. 01. See the subscription in the database
+# 03. GET the subscription - from the sub-cache
+# 04. Wait 2.1 seconds, to give the broker time to refresh its sub cache
+# 05. GET the subscription - from the sub-cache
+# 06. Create an Entity E1 with A==1 - no notification
+# 07. Create an Entity E2 with B==1 - no notification
+# 08. Create an Entity E3 with A==0 - notification
+# 09. Dump accumulator and see the notification for E3 only
 #
 
 echo "01. Create a subscription S1 with q=A==0|B==0 - q-tree created by postSubscriptions"
@@ -63,7 +66,21 @@ echo
 echo
 
 
-echo "02. Wait 2.1 seconds, to give the broker time to refresh its sub cache"
+echo "02. See the subscription in the database"
+echo "========================================"
+mongoCmd2 ftest "db.csubs.findOne()"
+echo
+echo
+
+
+echo "03. GET the subscription - from the sub-cache"
+echo "============================================="
+orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:subs:S1
+echo
+echo
+
+
+echo "04. Wait 2.1 seconds, to give the broker time to refresh its sub cache"
 echo "======================================================================"
 sleep 2.1s
 echo Slept 2.1 seconds
@@ -71,7 +88,14 @@ echo
 echo
 
 
-echo "03. Create an Entity E1 with A==1 (qP missing is created) - no notification"
+echo "05. GET the subscription - from the sub-cache"
+echo "============================================="
+orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:subs:S1
+echo
+echo
+
+
+echo "06. Create an Entity E1 with A==1 (qP missing is created) - no notification"
 echo "==========================================================================="
 payload='{
   "id": "urn:ngsi-ld:T:E1",
@@ -83,7 +107,7 @@ echo
 echo
 
 
-echo "04. Create an Entity E2 with B==1 - no notification"
+echo "07. Create an Entity E2 with B==1 - no notification"
 echo "==================================================="
 payload='{
   "id": "urn:ngsi-ld:T:E2",
@@ -95,7 +119,7 @@ echo
 echo
 
 
-echo "05. Create an Entity E3 with A==0 - notification"
+echo "08. Create an Entity E3 with A==0 - notification"
 echo "================================================"
 payload='{
   "id": "urn:ngsi-ld:T:E3",
@@ -107,7 +131,7 @@ echo
 echo
 
 
-echo "06. Dump accumulator and see the notification for E3 only"
+echo "09. Dump accumulator and see the notification for E3 only"
 echo "========================================================="
 accumulatorDump
 accumulatorReset
@@ -125,12 +149,115 @@ Date: REGEX(.*)
 
 
 
-02. Wait 2.1 seconds, to give the broker time to refresh its sub cache
+02. See the subscription in the database
+========================================
+MongoDB shell version REGEX(.*)
+connecting to: REGEX(.*)
+MongoDB server version: REGEX(.*)
+{
+	"_id" : "urn:ngsi-ld:subs:S1",
+	"entities" : [
+		{
+			"type" : "https://uri.etsi.org/ngsi-ld/default-context/T",
+			"id" : ".*",
+			"isPattern" : "true",
+			"isTypePattern" : false
+		}
+	],
+	"ldQ" : "https://uri=etsi=org/ngsi-ld/default-context/A.value==0|https://uri=etsi=org/ngsi-ld/default-context/B.value==0",
+	"createdAt" : REGEX(.*),
+	"modifiedAt" : REGEX(.*),
+	"throttling" : 0,
+	"expression" : {
+		"geometry" : "",
+		"coords" : "",
+		"georel" : "",
+		"geoproperty" : "",
+		"q" : "P;!P",
+		"mq" : "P.P;!P.P"
+	},
+	"format" : "simplified",
+	"reference" : "http://127.0.0.1:9997/notify",
+	"mimeType" : "application/json",
+	"attrs" : [ ],
+	"conditions" : [ ],
+	"status" : "active",
+	"custom" : false,
+	"servicePath" : "/#",
+	"blacklist" : false,
+	"ldContext" : "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
+}
+bye
+
+
+03. GET the subscription - from the sub-cache
+=============================================
+HTTP/1.1 200 OK
+Content-Length: 273
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+{
+    "entities": [
+        {
+            "type": "T"
+        }
+    ],
+    "id": "urn:ngsi-ld:subs:S1",
+    "isActive": true,
+    "notification": {
+        "endpoint": {
+            "accept": "application/json",
+            "uri": "http://127.0.0.1:9997/notify"
+        },
+        "format": "keyValues",
+        "status": "ok"
+    },
+    "origin": "cache",
+    "q": "A==0|B==0",
+    "status": "active",
+    "type": "Subscription"
+}
+
+
+04. Wait 2.1 seconds, to give the broker time to refresh its sub cache
 ======================================================================
 Slept 2.1 seconds
 
 
-03. Create an Entity E1 with A==1 (qP missing is created) - no notification
+05. GET the subscription - from the sub-cache
+=============================================
+HTTP/1.1 200 OK
+Content-Length: 273
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+{
+    "entities": [
+        {
+            "type": "T"
+        }
+    ],
+    "id": "urn:ngsi-ld:subs:S1",
+    "isActive": true,
+    "notification": {
+        "endpoint": {
+            "accept": "application/json",
+            "uri": "http://127.0.0.1:9997/notify"
+        },
+        "format": "keyValues",
+        "status": "ok"
+    },
+    "origin": "cache",
+    "q": "A==0|B==0",
+    "status": "active",
+    "type": "Subscription"
+}
+
+
+06. Create an Entity E1 with A==1 (qP missing is created) - no notification
 ===========================================================================
 HTTP/1.1 201 Created
 Content-Length: 0
@@ -139,7 +266,7 @@ Date: REGEX(.*)
 
 
 
-04. Create an Entity E2 with B==1 - no notification
+07. Create an Entity E2 with B==1 - no notification
 ===================================================
 HTTP/1.1 201 Created
 Content-Length: 0
@@ -148,7 +275,7 @@ Date: REGEX(.*)
 
 
 
-05. Create an Entity E3 with A==0 - notification
+08. Create an Entity E3 with A==0 - notification
 ================================================
 HTTP/1.1 201 Created
 Content-Length: 0
@@ -157,7 +284,7 @@ Date: REGEX(.*)
 
 
 
-06. Dump accumulator and see the notification for E3 only
+09. Dump accumulator and see the notification for E3 only
 =========================================================
 POST REGEX(.*)
 Content-Length: 223

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_notification_with-q-or.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_notification_with-q-or.test
@@ -90,7 +90,7 @@ echo
 
 
 echo "04. See subscription in mongo - make sure ldQ =='P1==5|P2==9', and that q+mq are P&!P"
-echo "========================================================================================"
+echo "====================================================================================="
 mongoCmd2 ftest "db.csubs.findOne()"
 echo
 echo
@@ -230,7 +230,7 @@ MongoDB server version: REGEX(.*)
 			"isTypePattern" : false
 		}
 	],
-	"ldQ" : "https://uri.etsi.org/ngsi-ld/default-context/P1==5|https://uri.etsi.org/ngsi-ld/default-context/P2==9",
+	"ldQ" : "https://uri=etsi=org/ngsi-ld/default-context/P1.value==5|https://uri=etsi=org/ngsi-ld/default-context/P2.value==9",
 	"createdAt" : REGEX(.*),
 	"modifiedAt" : REGEX(.*),
 	"throttling" : 0,

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_notification_with-q-or.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_notification_with-q-or.test
@@ -35,7 +35,7 @@ accumulatorStart --pretty-print 127.0.0.1 ${LISTENER_PORT}
 # 01. Create a subscription S1 on type=T and with q='P1==5|P2==9'
 # 02. Create an Entity E1/T, using POST /ngsi-ld/v1/entities, matching S5
 # 03. Dump accumulator to see one notification
-# 04. See subscription in mongo - make sure ldQ =='P2==true|P3==9', and that q+mq are P&!P
+# 04. See subscription in mongo - make sure ldQ =='P1==5|P2==9', and that q+mq are P&!P
 # 05. Create an Entity E2/T, using POST /v2/entities, matching S5
 # 06. Dump accumulator to see NO notification
 #
@@ -89,7 +89,7 @@ echo
 echo
 
 
-echo "04. See subscription in mongo - make sure ldQ =='P2==true|P3==9', and that q+mq are P&!P"
+echo "04. See subscription in mongo - make sure ldQ =='P1==5|P2==9', and that q+mq are P&!P"
 echo "========================================================================================"
 mongoCmd2 ftest "db.csubs.findOne()"
 echo
@@ -215,8 +215,8 @@ Ngsild-Attribute-Format: Simplified
 =======================================
 
 
-04. See subscription in mongo - make sure ldQ =='P2==true|P3==9', and that q+mq are P&!P
-========================================================================================
+04. See subscription in mongo - make sure ldQ =='P1==5|P2==9', and that q+mq are P&!P
+=====================================================================================
 MongoDB shell version REGEX(.*)
 connecting to: REGEX(.*)
 MongoDB server version: REGEX(.*)
@@ -230,7 +230,7 @@ MongoDB server version: REGEX(.*)
 			"isTypePattern" : false
 		}
 	],
-	"ldQ" : "P1==5|P2==9",
+	"ldQ" : "https://uri.etsi.org/ngsi-ld/default-context/P1==5|https://uri.etsi.org/ngsi-ld/default-context/P2==9",
 	"createdAt" : REGEX(.*),
 	"modifiedAt" : REGEX(.*),
 	"throttling" : 0,

--- a/test/functionalTest/cases/0000_ngsild/ngsild_patch_entity2-notification-counters.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_patch_entity2-notification-counters.test
@@ -223,7 +223,7 @@ HTTP/1.1 204 No Content
 07. GET S1 - see lastSuccess==now, lastFailure==never, errors==0, timesSent==10, status==active
 ===============================================================================================
 HTTP/1.1 200 OK
-Content-Length: 344
+Content-Length: 361
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -248,6 +248,7 @@ Date: REGEX(.*)
         "status": "ok",
         "timesSent": 10
     },
+    "origin": "cache",
     "status": "active",
     "type": "Subscription"
 }
@@ -256,7 +257,7 @@ Date: REGEX(.*)
 08. GET S2 - see lastSuccess==never, lastFailure==now, timesSent==4, status==paused
 ===================================================================================
 HTTP/1.1 200 OK
-Content-Length: 433
+Content-Length: 450
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -283,6 +284,7 @@ Date: REGEX(.*)
         "status": "failed",
         "timesSent": 3
     },
+    "origin": "cache",
     "status": "paused",
     "type": "Subscription"
 }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_create.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_create.test
@@ -478,7 +478,7 @@ bye
 03. GET /ngsi-ld/v1/subscription/http://a.b.c/subs/sub01, see @context in HTTP header
 =====================================================================================
 HTTP/1.1 200 OK
-Content-Length: 938
+Content-Length: 950
 Content-Type: application/json
 Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -486,7 +486,7 @@ Date: REGEX(.*)
 {
   "id": "http://a.b.c/subs/sub01",
   "type": "Subscription",
-  "name": "Test subscription 01",
+  "subscriptionName": "Test subscription 01",
   "description": "Description of Test subscription 01",
   "entities": [
     {
@@ -540,14 +540,14 @@ Date: REGEX(.*)
 04. GET /ngsi-ld/v1/subscription/http://a.b.c/subs/sub01, accepting jsonld - see @context in payload
 ====================================================================================================
 HTTP/1.1 200 OK
-Content-Length: 1027
+Content-Length: 1039
 Content-Type: application/ld+json
 Date: REGEX(.*)
 
 {
   "id": "http://a.b.c/subs/sub01",
   "type": "Subscription",
-  "name": "Test subscription 01",
+  "subscriptionName": "Test subscription 01",
   "description": "Description of Test subscription 01",
   "entities": [
     {
@@ -662,7 +662,7 @@ Date: REGEX(.*)
 10. GET sub09 with sysAttrs and make sure no 'expires' nor 'throttling' is returned
 ===================================================================================
 HTTP/1.1 200 OK
-Content-Length: 444
+Content-Length: 456
 Content-Type: application/json
 Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -679,7 +679,6 @@ Date: REGEX(.*)
     "id": "http://a.b.c/subs/sub09",
     "isActive": true,
     "modifiedAt": REGEX(.*),
-    "name": "Test subscription 09",
     "notification": {
         "attributes": [
             "P1"
@@ -692,6 +691,7 @@ Date: REGEX(.*)
         "status": "ok"
     },
     "status": "active",
+    "subscriptionName": "Test subscription 09",
     "type": "Subscription"
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_create_auto_sub_id.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_create_auto_sub_id.test
@@ -183,7 +183,7 @@ bye
 03. Grep mongo content for subscription id and do a GET /ngsi-ld/v1/subscription/$SUB_ID
 ========================================================================================
 HTTP/1.1 200 OK
-Content-Length: 976
+Content-Length: 988
 Content-Type: application/json
 Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -191,7 +191,7 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:Subscription:REGEX([0-9a-f\-]{36})",
   "type": "Subscription",
-  "name": "Test subscription 01",
+  "subscriptionName": "Test subscription 01",
   "description": "Description of Test subscription 01",
   "entities": [
     {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_delete.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_delete.test
@@ -144,7 +144,7 @@ Date: REGEX(.*)
 02. GET subscription 'http://a.b.c/subs/sub01' and see it
 =========================================================
 HTTP/1.1 200 OK
-Content-Length: 756
+Content-Length: 768
 Content-Type: application/json
 Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -152,7 +152,7 @@ Date: REGEX(.*)
 {
   "id": "http://a.b.c/subs/sub01",
   "type": "Subscription",
-  "name": "Test subscription 01",
+  "subscriptionName": "Test subscription 01",
   "description": "Description of Test subscription 01",
   "entities": [
     {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_delete_errors.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_delete_errors.test
@@ -136,7 +136,7 @@ Date: REGEX(.*)
 02. GET subscription 'http://a.b.c/subs/sub01' and see it
 =========================================================
 HTTP/1.1 200 OK
-Content-Length: 940
+Content-Length: 952
 Content-Type: application/json
 Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -144,7 +144,7 @@ Date: REGEX(.*)
 {
   "id": "http://a.b.c/subs/sub01",
   "type": "Subscription",
-  "name": "Test subscription 01",
+  "subscriptionName": "Test subscription 01",
   "description": "Description of Test subscription 01",
   "entities": [
     {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_patch.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_patch.test
@@ -197,7 +197,7 @@ bye
 03. GET the subscription - see its initial state
 ================================================
 HTTP/1.1 200 OK
-Content-Length: 615
+Content-Length: 627
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -205,7 +205,7 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:subscriptions:01",
   "type": "Subscription",
-  "name": "Test subscription S01",
+  "subscriptionName": "Test subscription S01",
   "entities": [
     {
       "id": "urn:ngsi-ld:E01",
@@ -248,7 +248,7 @@ Date: REGEX(.*)
 05. GET the subscription - see the modification
 ===============================================
 HTTP/1.1 200 OK
-Content-Length: 780
+Content-Length: 792
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -256,7 +256,7 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:subscriptions:01",
   "type": "Subscription",
-  "name": "Changed Name for Test subscription S01",
+  "subscriptionName": "Changed Name for Test subscription S01",
   "description": "New Description of Test subscription S01",
   "createdAt": "REGEX(.*)",
   "modifiedAt": "REGEX(.*)",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_patch_update_all_individual_fields.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_patch_update_all_individual_fields.test
@@ -602,7 +602,7 @@ bye
 03. GET subscription from the broker
 ====================================
 HTTP/1.1 200 OK
-Content-Length: 826
+Content-Length: 838
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -610,7 +610,7 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:subscriptions:S01",
   "type": "Subscription",
-  "name": "Test subscription S01",
+  "subscriptionName": "Test subscription S01",
   "description": "Description of Test subscription S01",
   "entities": [
     {
@@ -663,7 +663,7 @@ Date: REGEX(.*)
 05. GET subscription and see the new 'name'
 ===========================================
 HTTP/1.1 200 OK
-Content-Length: 813
+Content-Length: 825
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -671,7 +671,7 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:subscriptions:S01",
   "type": "Subscription",
-  "name": "New Name",
+  "subscriptionName": "New Name",
   "description": "Description of Test subscription S01",
   "entities": [
     {
@@ -724,7 +724,7 @@ Date: REGEX(.*)
 07. GET subscription and see the new 'description'
 ==================================================
 HTTP/1.1 200 OK
-Content-Length: 792
+Content-Length: 804
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -732,7 +732,7 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:subscriptions:S01",
   "type": "Subscription",
-  "name": "New Name",
+  "subscriptionName": "New Name",
   "description": "New Description",
   "entities": [
     {
@@ -842,7 +842,7 @@ bye
 10. GET subscription and see the new 'entities'
 ===============================================
 HTTP/1.1 200 OK
-Content-Length: 793
+Content-Length: 805
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -850,7 +850,7 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:subscriptions:S01",
   "type": "Subscription",
-  "name": "New Name",
+  "subscriptionName": "New Name",
   "description": "New Description",
   "entities": [
     {
@@ -962,7 +962,7 @@ bye
 13. GET subscription and see the new 'watchedAttributes'
 ========================================================
 HTTP/1.1 200 OK
-Content-Length: 793
+Content-Length: 805
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -970,7 +970,7 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:subscriptions:S01",
   "type": "Subscription",
-  "name": "New Name",
+  "subscriptionName": "New Name",
   "description": "New Description",
   "entities": [
     {
@@ -1096,7 +1096,7 @@ bye
 17. GET subscription and see the new 'q'
 ========================================
 HTTP/1.1 200 OK
-Content-Length: 802
+Content-Length: 814
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -1104,7 +1104,7 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:subscriptions:S01",
   "type": "Subscription",
-  "name": "New Name",
+  "subscriptionName": "New Name",
   "description": "New Description",
   "entities": [
     {
@@ -1215,7 +1215,7 @@ bye
 20. GET subscription and see the new 'geoQ'
 ===========================================
 HTTP/1.1 200 OK
-Content-Length: 800
+Content-Length: 812
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -1223,7 +1223,7 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:subscriptions:S01",
   "type": "Subscription",
-  "name": "New Name",
+  "subscriptionName": "New Name",
   "description": "New Description",
   "entities": [
     {
@@ -1278,7 +1278,7 @@ Date: REGEX(.*)
 22. GET subscription and see the new 'csf'
 ==========================================
 HTTP/1.1 200 OK
-Content-Length: 815
+Content-Length: 827
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -1286,7 +1286,7 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:subscriptions:S01",
   "type": "Subscription",
-  "name": "New Name",
+  "subscriptionName": "New Name",
   "description": "New Description",
   "entities": [
     {
@@ -1397,7 +1397,7 @@ bye
 25. GET subscription and see the new 'isActive'
 ===============================================
 HTTP/1.1 200 OK
-Content-Length: 816
+Content-Length: 828
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -1405,7 +1405,7 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:subscriptions:S01",
   "type": "Subscription",
-  "name": "New Name",
+  "subscriptionName": "New Name",
   "description": "New Description",
   "entities": [
     {
@@ -1516,7 +1516,7 @@ bye
 28. GET subscription and see the new 'notification'
 ===================================================
 HTTP/1.1 200 OK
-Content-Length: 815
+Content-Length: 827
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -1524,7 +1524,7 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:subscriptions:S01",
   "type": "Subscription",
-  "name": "New Name",
+  "subscriptionName": "New Name",
   "description": "New Description",
   "entities": [
     {
@@ -1579,7 +1579,7 @@ Date: REGEX(.*)
 30. GET subscription and see the new 'expiresAt'
 ================================================
 HTTP/1.1 200 OK
-Content-Length: 815
+Content-Length: 827
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -1587,7 +1587,7 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:subscriptions:S01",
   "type": "Subscription",
-  "name": "New Name",
+  "subscriptionName": "New Name",
   "description": "New Description",
   "entities": [
     {
@@ -1642,7 +1642,7 @@ Date: REGEX(.*)
 32. GET subscription and see the new 'throttling'
 =================================================
 HTTP/1.1 200 OK
-Content-Length: 816
+Content-Length: 828
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -1650,7 +1650,7 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:subscriptions:S01",
   "type": "Subscription",
-  "name": "New Name",
+  "subscriptionName": "New Name",
   "description": "New Description",
   "entities": [
     {
@@ -1761,7 +1761,7 @@ Date: REGEX(.*)
 35. GET subscription and see all the fields
 ===========================================
 HTTP/1.1 200 OK
-Content-Length: 853
+Content-Length: 865
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -1769,7 +1769,7 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:subscriptions:S01",
   "type": "Subscription",
-  "name": "Name 34",
+  "subscriptionName": "Name 34",
   "description": "Description 34",
   "entities": [
     {
@@ -1941,7 +1941,7 @@ bye
 39. GET subscription and see A=1 in receiverInfo
 ================================================
 HTTP/1.1 200 OK
-Content-Length: 951
+Content-Length: 963
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -1949,7 +1949,7 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:subscriptions:S01",
   "type": "Subscription",
-  "name": "Name 34",
+  "subscriptionName": "Name 34",
   "description": "Description 34",
   "entities": [
     {
@@ -2012,7 +2012,7 @@ Date: REGEX(.*)
 41. GET subscription and see A=2 in receiverInfo
 ================================================
 HTTP/1.1 200 OK
-Content-Length: 951
+Content-Length: 963
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -2020,7 +2020,7 @@ Date: REGEX(.*)
 {
   "id": "urn:ngsi-ld:subscriptions:S01",
   "type": "Subscription",
-  "name": "Name 34",
+  "subscriptionName": "Name 34",
   "description": "Description 34",
   "entities": [
     {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_timestamps.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_timestamps.test
@@ -294,7 +294,7 @@ bye
 03. GET the subscription via REST - make sure all timestamps have milliseconds, save timestamps
 ===============================================================================================
 HTTP/1.1 200 OK
-Content-Length: 469
+Content-Length: 481
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -311,7 +311,6 @@ Date: REGEX(.*)
     "id": "urn:ngsi-ld:subscriptions:s1",
     "isActive": true,
     "modifiedAt": "REGEX(.*\.\d\d\dZ)",
-    "name": "Test subscription 01",
     "notification": {
         "endpoint": {
             "accept": "application/json",
@@ -321,6 +320,7 @@ Date: REGEX(.*)
         "status": "ok"
     },
     "status": "active",
+    "subscriptionName": "Test subscription 01",
     "throttling": 1.459,
     "type": "Subscription"
 }
@@ -376,7 +376,7 @@ Date: REGEX(.*)
 07. GET the subscription via REST - see 'timesSent==1' and timestamps for lastSuccess, lastNotification
 =======================================================================================================
 HTTP/1.1 200 OK
-Content-Length: 570
+Content-Length: 582
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -393,7 +393,6 @@ Date: REGEX(.*)
     "id": "urn:ngsi-ld:subscriptions:s1",
     "isActive": true,
     "modifiedAt": "REGEX(.*\.\d\d\dZ)",
-    "name": "Test subscription 01",
     "notification": {
         "endpoint": {
             "accept": "application/json",
@@ -406,6 +405,7 @@ Date: REGEX(.*)
         "timesSent": 2
     },
     "status": "active",
+    "subscriptionName": "Test subscription 01",
     "throttling": 1.459,
     "type": "Subscription"
 }
@@ -424,7 +424,7 @@ Date: REGEX(.*)
 09. GET the subscription via REST - make sure 'modifiedAt' has changed and 'createdAt' has not
 ==============================================================================================
 HTTP/1.1 200 OK
-Content-Length: 583
+Content-Length: 595
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -441,7 +441,6 @@ Date: REGEX(.*)
     "id": "urn:ngsi-ld:subscriptions:s1",
     "isActive": true,
     "modifiedAt": "REGEX(.*\.\d\d\dZ)",
-    "name": "New Name for Test subscription 01",
     "notification": {
         "endpoint": {
             "accept": "application/json",
@@ -454,6 +453,7 @@ Date: REGEX(.*)
         "timesSent": 2
     },
     "status": "active",
+    "subscriptionName": "New Name for Test subscription 01",
     "throttling": 1.459,
     "type": "Subscription"
 }
@@ -477,7 +477,7 @@ Date: REGEX(.*)
 12. GET the subscription via REST - make sure lastFailure is present and has milliseconds
 =========================================================================================
 HTTP/1.1 200 OK
-Content-Length: 624
+Content-Length: 636
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -494,7 +494,6 @@ Date: REGEX(.*)
     "id": "urn:ngsi-ld:subscriptions:s1",
     "isActive": true,
     "modifiedAt": "REGEX(.*\.\d\d\dZ)",
-    "name": "New Name for Test subscription 01",
     "notification": {
         "endpoint": {
             "accept": "application/json",
@@ -508,6 +507,7 @@ Date: REGEX(.*)
         "timesSent": 3
     },
     "status": "active",
+    "subscriptionName": "New Name for Test subscription 01",
     "throttling": 1.459,
     "type": "Subscription"
 }


### PR DESCRIPTION
## Proposed changes
Had to fix a few messes:
* q in subscription - 3 different values as we need to spuuport NGSIv2 q/mq as well as NGSI-LD q, which is quite different
* coordinates in geoQ/expression, as it is also different NGSIv2/NGSI-LD

With that done, **subscriptions are now taken from the subscription cache for a `GET /subscriptions/{subId}`** and no database access is needed.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/FIWARE/context.Orion-LD/blob/master/CONTRIBUTING.md) doc
-   [x] I have signed the [CLA](https://fiware.github.io/contribution-requirements/individual-cla.pdf)
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
Will have to implement the mongoc implementation for taking the subscription from the database as well. No hurry ... 