### PR TITLE
GET /subscriptions without legacy driver (from sub-cache)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -32,3 +32,4 @@
 * Issue #280   Common function for creation of the _id.id entities index now using the new mongo driver
 * Issue #280   Using the tenant list when populating the subscription cache instead of querying the database (less Mongo C++ Legacy driver usage)
 * Issue #280   GET /subscriptions/{subId} now uses the subscription cache and no database access is done (less Mongo C++ Legacy driver usage)
+* Issue #280   GET /subscriptions now uses the subscription cache and no database access is done (less Mongo C++ Legacy driver usage)

--- a/src/lib/orionld/payloadCheck/pCheckSubscription.cpp
+++ b/src/lib/orionld/payloadCheck/pCheckSubscription.cpp
@@ -26,6 +26,7 @@ extern "C"
 {
 #include "kbase/kMacros.h"                                       // K_FT
 #include "kjson/KjNode.h"                                        // KjNode
+#include "kjson/kjBuilder.h"                                     // kjChildRemove
 }
 
 #include "logMsg/logMsg.h"                                       // LM_*
@@ -139,8 +140,12 @@ bool pCheckSubscription
     }
   }
 
-  for (KjNode* subItemP = subP->value.firstChildP; subItemP != NULL; subItemP = subItemP->next)
+  KjNode* subItemP = subP->value.firstChildP;
+  KjNode* next;
+  while (subItemP != NULL)
   {
+    next = subItemP->next;
+
     if ((strcmp(subItemP->name, "subscriptionName") == 0) || (strcmp(subItemP->name, "name") == 0))
     {
       subItemP->name = (char*) "name";  // Must be called "name" in the database
@@ -243,14 +248,16 @@ bool pCheckSubscription
       orionldError(OrionldOperationNotSupported, "Not Implemented", SubscriptionScopePath, 501);
       return false;
     }
-    else if (strcmp(subItemP->name, "status")           == 0) {}  // Ignored
-    else if (strcmp(subItemP->name, "createdAt")        == 0) {}  // Ignored
-    else if (strcmp(subItemP->name, "modifiedAt")       == 0) {}  // Ignored
+    else if (strcmp(subItemP->name, "status")           == 0) { kjChildRemove(subP, subItemP); }  // Silently REMOVED
+    else if (strcmp(subItemP->name, "createdAt")        == 0) { kjChildRemove(subP, subItemP); }  // Silently REMOVED
+    else if (strcmp(subItemP->name, "modifiedAt")       == 0) { kjChildRemove(subP, subItemP); }  // Silently REMOVED
     else
     {
       orionldError(OrionldBadRequestData, "Unknown field for subscription", subItemP->name, 400);
       return false;
     }
+
+    subItemP = next;
   }
 
   // Make sure all mandatory fields are present

--- a/test/functionalTest/cases/0000_ngsild/ngsild_langprop-and-notifications.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_langprop-and-notifications.test
@@ -374,7 +374,7 @@ Date: REGEX(.*)
 04. GET ALL subscriptions see lang=en in S2
 ===========================================
 HTTP/1.1 200 OK
-Content-Length: 677
+Content-Length: 671
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -400,7 +400,7 @@ Date: REGEX(.*)
             "format": "normalized",
             "status": "ok"
         },
-        "origin": "database",
+        "origin": "cache",
         "status": "active",
         "type": "Subscription",
         "watchedAttributes": [
@@ -428,7 +428,7 @@ Date: REGEX(.*)
             "format": "normalized",
             "status": "ok"
         },
-        "origin": "database",
+        "origin": "cache",
         "status": "active",
         "type": "Subscription",
         "watchedAttributes": [

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new-subscription-list.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new-subscription-list.test
@@ -1,0 +1,2010 @@
+# Copyright 2019 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Subscription Creation and DB Contebt
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+brokerStart CB 0 IPv4 -experimental
+
+--SHELL--
+
+#
+# 01. Create 50 subscriptions, with ids urn:ngsi-ld:Subscription:1/2/3.../50
+# 02. GET subscriptions - see the first 20
+# 03. GET subscriptions with limit 5 - see the first 5
+# 04. GET subscriptions with limit 5 and offset 25, see subs 25-29
+#
+
+
+echo "01. Create 50 subscriptions, with ids urn:ngsi-ld:Subscription:sub1/2/3.../50"
+echo "============================================================================="
+typeset -i subNo;
+subNo=1
+
+while [ $subNo -le 50 ]
+do
+    subNoWithZeroes=$(printf "%04d" $subNo)
+    subId=urn:ngsi-ld:Subscription:sub$subNoWithZeroes
+    name="Test subscription "$subNoWithZeroes
+    description="Description of Test subscription "$subNoWithZeroes
+    payload='{
+      "id": "'$subId'",
+      "type": "Subscription",
+      "name": "'$name'",
+      "description": "'$description'",
+      "entities": [
+        {
+          "id": "urn:ngsi-ld:E01",
+          "type": "T1"
+        },
+        {
+          "id": "http://a.b.c/E02",
+          "type": "T2"
+        },
+        {
+          "idPattern": ".*E03.*",
+          "type": "T3"
+        }
+      ],
+      "watchedAttributes": [ "P2" ],
+      "q": "P2>10",
+      "geoQ": {
+        "geometry": "Point",
+        "coordinates": "[1,2]",
+        "georel": "near;maxDistance==10"
+      },
+      "isActive": false,
+      "notification": {
+        "attributes": [ "P1", "P2", "A3" ],
+        "format": "keyValues",
+        "endpoint": {
+          "uri": "http://valid.url/url",
+          "accept": "application/ld+json"
+        },
+        "status": "ignored",
+        "timesSent": "ignored",
+        "lastNotification": "ignored",
+        "lastFailure": "ignored",
+        "lastSuccess": "ignored"
+      },
+      "expiresAt": "2028-12-31T10:00:00",
+      "throttling": 5,
+      "status": "to be ignored - read-only",
+      "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld",
+      "createdAt": "ignored",
+      "modifiedAt": "ignored"
+    }'
+    orionCurl --url /ngsi-ld/v1/subscriptions --payload "$payload" -H "Content-Type: application/ld+json"
+    subNo=$subNo+1
+  done
+echo
+echo
+
+
+echo "02. GET subscriptions - see the first 20"
+echo "========================================"
+orionCurl --url /ngsi-ld/v1/subscriptions -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+echo
+echo
+
+
+echo "03. GET subscriptions with limit 5 - see the first 5"
+echo "===================================================="
+orionCurl --url /ngsi-ld/v1/subscriptions?limit=5 -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+echo
+echo
+
+
+echo "04. GET subscriptions with limit 5 and offset 25, see subs 25-29"
+echo "================================================================"
+orionCurl --url '/ngsi-ld/v1/subscriptions?limit=5&offset=25' -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+echo
+echo
+
+
+echo "05. GET subscriptions count with limit 0 - see HTTP header (NGSILD-Results-Count) and empty subscription array"
+echo "=============================================================================================================="
+orionCurl --url '/ngsi-ld/v1/subscriptions?limit=0&count=true'
+echo
+echo
+
+
+echo "06. GET subscriptions count with limit 1 - see HTTP header (NGSILD-Results-Count) and ONE (sub0001) subscription in the array"
+echo "============================================================================================================================="
+orionCurl --url '/ngsi-ld/v1/subscriptions?limit=1&count=true&options=sysAttrs'
+echo
+echo
+
+
+--REGEXPECT--
+01. Create 50 subscriptions, with ids urn:ngsi-ld:Subscription:sub1/2/3.../50
+=============================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0001
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0002
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0003
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0004
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0005
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0006
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0007
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0008
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0009
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0010
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0011
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0012
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0013
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0014
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0015
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0016
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0017
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0018
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0019
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0020
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0021
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0022
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0023
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0024
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0025
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0026
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0027
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0028
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0029
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0030
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0031
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0032
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0033
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0034
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0035
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0036
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0037
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0038
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0039
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0040
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0041
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0042
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0043
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0044
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0045
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0046
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0047
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0048
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0049
+Date: REGEX(.*)
+
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:sub0050
+Date: REGEX(.*)
+
+
+
+02. GET subscriptions - see the first 20
+========================================
+HTTP/1.1 200 OK
+Content-Length: 13321
+Content-Type: application/json
+Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+[
+    {
+        "description": "Description of Test subscription 0001",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0001",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0001",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0002",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0002",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0002",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0003",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0003",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0003",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0004",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0004",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0004",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0005",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0005",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0005",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0006",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0006",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0006",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0007",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0007",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0007",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0008",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0008",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0008",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0009",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0009",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0009",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0010",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0010",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0010",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0011",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0011",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0011",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0012",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0012",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0012",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0013",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0013",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0013",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0014",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0014",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0014",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0015",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0015",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0015",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0016",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0016",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0016",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0017",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0017",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0017",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0018",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0018",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0018",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0019",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0019",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0019",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0020",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0020",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0020",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    }
+]
+
+
+03. GET subscriptions with limit 5 - see the first 5
+====================================================
+HTTP/1.1 200 OK
+Content-Length: 3331
+Content-Type: application/json
+Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+[
+    {
+        "description": "Description of Test subscription 0001",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0001",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0001",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0002",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0002",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0002",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0003",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0003",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0003",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0004",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0004",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0004",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0005",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0005",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0005",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    }
+]
+
+
+04. GET subscriptions with limit 5 and offset 25, see subs 25-29
+================================================================
+HTTP/1.1 200 OK
+Content-Length: 3331
+Content-Type: application/json
+Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Date: REGEX(.*)
+
+[
+    {
+        "description": "Description of Test subscription 0026",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0026",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0026",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0027",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0027",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0027",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0028",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0028",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0028",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0029",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0029",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0029",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0030",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0030",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0030",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    }
+]
+
+
+05. GET subscriptions count with limit 0 - see HTTP header (NGSILD-Results-Count) and empty subscription array
+==============================================================================================================
+HTTP/1.1 200 OK
+Content-Length: 2
+Content-Type: application/json
+NGSILD-Results-Count: 50
+Date: REGEX(.*)
+
+[]
+
+
+06. GET subscriptions count with limit 1 - see HTTP header (NGSILD-Results-Count) and ONE (sub0001) subscription in the array
+=============================================================================================================================
+HTTP/1.1 200 OK
+Content-Length: 860
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+NGSILD-Results-Count: 50
+Date: REGEX(.*)
+
+[
+    {
+        "createdAt": "202REGEX(.*)",
+        "description": "Description of Test subscription 0001",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "http://example.org/T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "http://example.org/T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0001",
+        "isActive": false,
+        "modifiedAt": "202REGEX(.*)",
+        "notification": {
+            "attributes": [
+                "http://example.org/P1",
+                "http://example.org/P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "http://example.org/P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0001",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "http://example.org/P2"
+        ]
+    }
+]
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new-subscription_create.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new-subscription_create.test
@@ -115,7 +115,7 @@ echo
 
 echo "03. GET /ngsi-ld/v1/subscription/http://a.b.c/subs/sub01, see @context in HTTP header"
 echo "====================================================================================="
-orionCurl --url '/ngsi-ld/v1/subscriptions/http://a.b.c/subs/sub01?prettyPrint=yes&spaces=2' --noPayloadCheck -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+orionCurl --url '/ngsi-ld/v1/subscriptions/http://a.b.c/subs/sub01?prettyPrint=yes&spaces=2&options=sysAttrs' --noPayloadCheck -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -459,7 +459,7 @@ bye
 03. GET /ngsi-ld/v1/subscription/http://a.b.c/subs/sub01, see @context in HTTP header
 =====================================================================================
 HTTP/1.1 200 OK
-Content-Length: 1163
+Content-Length: 1250
 Content-Type: application/json
 Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Date: REGEX(.*)
@@ -525,6 +525,8 @@ Date: REGEX(.*)
   },
   "expiresAt": "2028-12-31T10:00:00.000Z",
   "throttling": 5,
+  "createdAt": "202REGEX(.*)",
+  "modifiedAt": "202REGEX(.*)",
   "origin": "cache"
 }
 


### PR DESCRIPTION
## Proposed changes
* Implemented GET /subscriptions to optionally take the list of subs from the sub-cache (start the broker with `-experimental`)
* Fixed a bug about sysAttrs in subscriptions (removed from the original request if present)

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/FIWARE/context.Orion-LD/blob/master/CONTRIBUTING.md) doc
-   [x] I have signed the [CLA](https://fiware.github.io/contribution-requirements/individual-cla.pdf)
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
