### PR TITLE
orion-ld version in a functest REGEXPECT section is not a good idea

### DIFF
--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_notification_with-q-commalist-attr.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_notification_with-q-commalist-attr.test
@@ -522,7 +522,7 @@ Location: /ngsi-ld/v1/entities/urn:ngsi-ld:entities:T:E7
 ============================================
 POST http://127.0.0.1:9997/notify?subscriptionId=urn:ngsi-ld:subs:S4
 Content-Length: 301
-User-Agent: orionld/post-v1.0.1
+User-Agent: orionld/REGEX(.*)
 Accept: application/json
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_notification_with-q-range-attr.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_notification_with-q-range-attr.test
@@ -514,7 +514,7 @@ Location: /ngsi-ld/v1/entities/urn:ngsi-ld:entities:T:E7
 ============================================
 POST http://127.0.0.1:9997/notify?subscriptionId=urn:ngsi-ld:subs:S4
 Content-Length: 301
-User-Agent: orionld/post-v1.0.1
+User-Agent: orionld/REGEX(.*)
 Accept: application/json
 Content-Type: application/json
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"


### PR DESCRIPTION
orion-ld version in a functest REGEXPECT section is not a good idea - changed for a REGEX
