### PR TITLE
Mongoc/subscription counters

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,4 @@
-* Issue #280    Implemented support for HTTPS notifications for the new implementation (experimental)
+* Issue #280  Implemented support for HTTPS notifications for the new implementation (experimental)
+* Issue #280  Persisting counters and timestamps of subscriptions from the subscription cache in the database
+* Issue #280  New CLI option: -cSubCounters - number of subscription counter updates before flushing from sub-cache to DB (0: never, 1: always)
+* Issue #280  Bug fix: getting lastNotification, lastSuccess, lastFailure from DB in when refreshing the subscription cache

--- a/src/app/orionld/orionld.cpp
+++ b/src/app/orionld/orionld.cpp
@@ -231,6 +231,7 @@ bool            noswap;
 bool            experimental = false;
 bool            mongocOnly   = false;
 bool            debugCurl    = false;
+int             cSubCounters;
 
 
 
@@ -313,6 +314,7 @@ bool            debugCurl    = false;
 #define DBCERTFILE_DESC        "path to TLS certificate file"
 #define DBURI_DESC             "complete URI for database connection"
 #define DEBUG_CURL_DESC        "turn on debugging of libcurl - to the broker's logfile"
+#define CSUBCOUNTERS_DESC      "number of subscription counter updates before flush from sub-cache to DB (0: never, 1: always)"
 
 
 
@@ -394,6 +396,7 @@ PaArgument paArgs[] =
   { "-noNotifyFalseUpdate",   &noNotifyFalseUpdate,     "NO_NOTIFY_FALSE_UPDATE",    PaBool,    PaOpt,  false,           false,  true,             NO_NOTIFY_FALSE_UPDATE_DESC  },
   { "-experimental",          &experimental,            "EXPERIMENTAL",              PaBool,    PaOpt,  false,           false,  true,             EXPERIMENTAL_DESC        },
   { "-mongocOnly",            &mongocOnly,              "MONGOCONLY",                PaBool,    PaOpt,  false,           false,  true,             MONGOCONLY_DESC          },
+  { "-cSubCounters",          &cSubCounters,            "CSUB_COUNTERS",             PaInt,     PaOpt,  20,              0,      PaNL,             CSUBCOUNTERS_DESC        },
   { "-debugCurl",             &debugCurl,               "DEBUG_CURL",                PaBool,    PaHid,  false,           false,  true,             DEBUG_CURL_DESC          },
 
   PA_END_OF_ARGS

--- a/src/lib/cache/CachedSubscription.h
+++ b/src/lib/cache/CachedSubscription.h
@@ -119,6 +119,7 @@ struct CachedSubscription
   double                      lastSuccess;           // timestamp of last successful notification
   int                         consecutiveErrors;     // Not in DB
   char                        lastErrorReason[128];  // Not in DB
+  int                         dirty;
 
   double                      createdAt;
   double                      modifiedAt;

--- a/src/lib/cache/subCache.cpp
+++ b/src/lib/cache/subCache.cpp
@@ -904,6 +904,7 @@ void subCacheItemInsert
   cSubP->lastFailure           = 0;  // Or, does this come from DB ?
   cSubP->consecutiveErrors     = 0;
   cSubP->lastErrorReason[0]    = 0;
+  cSubP->dirty                 = 0;
 
   //
   // The three 'q's
@@ -1347,7 +1348,7 @@ void subCacheSync(void)
     if (cssP != NULL)
     {
       if (experimental == true)
-        mongocSubCountersUpdate(cSubP, cssP->count, cssP->lastNotificationTime, cssP->lastFailure, cssP->lastSuccess, cssP->ngsild);
+        mongocSubCountersUpdate(cSubP, cssP->count, cssP->lastNotificationTime, cssP->lastFailure, cssP->lastSuccess, false, cssP->ngsild);
       else
       {
         std::string tenant = (cSubP->tenant == NULL)? "" : cSubP->tenant;  // Use char* !!!

--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -560,6 +560,7 @@ extern char              userAgentHeader[64];      // From notificationSend.cpp
 extern size_t            userAgentHeaderLen;       // From notificationSend.cpp
 extern bool              debugCurl;                // From orionld.cpp
 extern bool              noCache;                  // From orionld.cpp
+extern int               cSubCounters;             // Number of subscription counter updates before flush from sub-cache to DB
 
 
 

--- a/src/lib/orionld/common/subCacheApiSubscriptionInsert.cpp
+++ b/src/lib/orionld/common/subCacheApiSubscriptionInsert.cpp
@@ -83,6 +83,15 @@ CachedSubscription* subCacheApiSubscriptionInsert(KjNode* apiSubscriptionP, QNod
   KjNode* createdAtP         = kjLookup(apiSubscriptionP, "createdAt");
   KjNode* modifiedAtP        = kjLookup(apiSubscriptionP, "modifiedAt");
   KjNode* dbCountP           = kjLookup(apiSubscriptionP, "count");
+  KjNode* lastNotificationP  = kjLookup(apiSubscriptionP, "lastNotification");
+  KjNode* lastSuccessP       = kjLookup(apiSubscriptionP, "lastSuccess");
+  KjNode* lastFailureP       = kjLookup(apiSubscriptionP, "lastFailure");
+
+  // Fixing false alarms for q and mq
+  if ((qP != NULL) && (qP->value.s != NULL) && (qP->value.s[0] == 0))
+    qP = NULL;
+  if ((mqP != NULL) && (mqP->value.s != NULL) && (mqP->value.s[0] == 0))
+    mqP = NULL;
 
   if (subscriptionIdP == NULL)
     subscriptionIdP = kjLookup(apiSubscriptionP, "id");
@@ -100,6 +109,15 @@ CachedSubscription* subCacheApiSubscriptionInsert(KjNode* apiSubscriptionP, QNod
     cSubP->dbCount = dbCountP->value.i;
   else
     cSubP->dbCount = 0;
+
+  if (lastNotificationP != NULL)
+    cSubP->lastNotificationTime = lastNotificationP->value.f;
+
+  if (lastSuccessP != NULL)
+    cSubP->lastSuccess = lastSuccessP->value.f;
+
+  if (lastFailureP != NULL)
+    cSubP->lastFailure = lastFailureP->value.f;
 
   if (descriptionP != NULL)
     cSubP->description = strdup(descriptionP->value.s);
@@ -324,18 +342,14 @@ CachedSubscription* subCacheApiSubscriptionInsert(KjNode* apiSubscriptionP, QNod
   {
     std::string errorString;
     if (cSubP->expression.stringFilter.parse(qP->value.s, &errorString) == false)
-    {
-      LM_E(("Subscription '%s': invalid 'q': %s", qP->value.s, cSubP->subscriptionId));
-    }
+      LM_E(("Subscription '%s': invalid 'q': '%s'", cSubP->subscriptionId, qP->value.s));
   }
 
   if (mqP != NULL)
   {
     std::string errorString;
     if (cSubP->expression.mdStringFilter.parse(mqP->value.s, &errorString) == false)
-    {
-      LM_E(("Subscription '%s': invalid 'mq': %s", mqP->value.s, cSubP->subscriptionId));
-    }
+      LM_E(("Subscription '%s': invalid 'mq': '%s'", cSubP->subscriptionId, mqP->value.s));
   }
 
   if (createdAtP != NULL)

--- a/src/lib/orionld/mongoc/mongocSubCountersUpdate.h
+++ b/src/lib/orionld/mongoc/mongocSubCountersUpdate.h
@@ -40,6 +40,7 @@ extern void mongocSubCountersUpdate
   double               lastNotificationTime,
   double               lastFailure,
   double               lastSuccess,
+  bool                 forcedToPause,
   bool                 ngsild
 );
 

--- a/src/lib/orionld/notifications/notificationFailure.cpp
+++ b/src/lib/orionld/notifications/notificationFailure.cpp
@@ -30,6 +30,7 @@
 
 #include "orionld/common/orionldState.h"                            // promNotifications, promNotificationsFailed
 #include "orionld/prometheus/promCounterIncrease.h"                 // promCounterIncrease
+#include "orionld/mongoc/mongocSubCountersUpdate.h"                 // mongocSubCountersUpdate
 #include "orionld/notifications/notificationFailure.h"              // Own interface
 
 
@@ -40,23 +41,42 @@
 //
 void notificationFailure(CachedSubscription* subP, const char* errorReason, double timestamp)
 {
+  bool forcedToPause = false;
+
   subP->lastNotificationTime  = timestamp;
   subP->lastFailure           = timestamp;
   subP->consecutiveErrors    += 1;
   subP->count                += 1;
+  subP->dirty                += 1;
 
   strncpy(subP->lastErrorReason, errorReason, sizeof(subP->lastErrorReason) - 1);
 
   // Force the subscription into "paused" due to too many consecutive errors
   if (subP->consecutiveErrors >= 3)
   {
+    LM(("SUBC: Force the subscription into PAUSE due to 3 consecutive errors"));
     subP->isActive = false;
     subP->status   = "paused";
-    // FIXME: Write to DB !!!
+    forcedToPause  = true;
   }
-
-  // Write to DB ... ?
 
   promCounterIncrease(promNotifications);
   promCounterIncrease(promNotificationsFailed);
+
+  LM(("SUBC: dirty: %d, cSubCounters: %d", subP->dirty, cSubCounters));
+
+  //
+  // Flush to DB?
+  // - If forcedToPause
+  // - If subP->dirty (number of counter updates since last flush) >= cSubCounters
+  //   - AND cSubCounters != 0
+  //
+  if (((cSubCounters != 0) && (subP->dirty >= cSubCounters)) || (forcedToPause == true))
+  {
+    LM(("SUBC: Calling mongocSubCountersUpdate"));
+    mongocSubCountersUpdate(subP, subP->count, subP->lastNotificationTime, subP->lastFailure, subP->lastSuccess, forcedToPause, true);
+    subP->dirty    = 0;
+    subP->dbCount += subP->count;
+    subP->count    = 0;
+  }
 }

--- a/test/functionalTest/cases/0000_cli/bool_option_with_value.test
+++ b/test/functionalTest/cases/0000_cli/bool_option_with_value.test
@@ -107,5 +107,6 @@ Usage: orionld  [option '-U' (extended usage)]
                 [option '-noNotifyFalseUpdate' (turn off notifications on non-updates)]
                 [option '-experimental' (enable experimental implementation - use at own risk - see release notes of Orion-LD v1.1.0)]
                 [option '-mongocOnly' (enable experimental implementation + turn off mongo legacy driver)]
+                [option '-cSubCounters' <number of subscription counter updates before flush from sub-cache to DB (0: never, 1: always)>]
 
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_cli/command_line_options.test
+++ b/test/functionalTest/cases/0000_cli/command_line_options.test
@@ -96,5 +96,6 @@ Usage: orionld  [option '-U' (extended usage)]
                 [option '-noNotifyFalseUpdate' (turn off notifications on non-updates)]
                 [option '-experimental' (enable experimental implementation - use at own risk - see release notes of Orion-LD v1.1.0)]
                 [option '-mongocOnly' (enable experimental implementation + turn off mongo legacy driver)]
+                [option '-cSubCounters' <number of subscription counter updates before flush from sub-cache to DB (0: never, 1: always)>]
 
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_subscription_counters-for-http-notifications.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_subscription_counters-for-http-notifications.test
@@ -1,0 +1,576 @@
+# Copyright 2022 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Subscription Counters and timestamps for HTTP notifications
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+brokerStart CB 0 IPv4 -experimental -cSubCounters 5
+accumulatorStart --pretty-print 127.0.0.1 ${LISTENER_PORT}
+
+--SHELL--
+
+#
+# 01. Create subscription S1, on entity type T
+# 02. Create a matching entity E1
+# 03. GET S1, see lastSuccess, lastNotification, and timesSent==1
+# 04. See S1 in mongo - see timesSent==0, as no dump has been done yet
+# 05. Create a matching entity E2
+# 06. Create a matching entity E3
+# 07. Create a matching entity E4
+# 08. GET S1, see lastSuccess, lastNotification, and timesSent==4
+# 09. Kill accumulator
+# 10. Create a matching entity E5 - notification will fail
+# 11. GET S1, see lastSuccess, lastFailure, lastNotification, and timesSent==5
+# 12. See S1 in mongo - see count==5, as the dump has been done
+# 13. Restart broker
+# 14. GET S1, see lastSuccess, lastFailure, lastNotification, and timesSent==5
+# 15. Create a matching entity E6 - notification will fail
+# 16. Start the accumulator again
+# 17. Create a matching entity E7
+# 18. GET S1, see lastSuccess, lastFailure, lastNotification, and timesSent==7
+#
+
+
+echo "01. Create subscription S1, on entity type T"
+echo "============================================"
+payload='{
+  "id": "urn:ngsi-ld:subscriptions:S1",
+  "type": "Subscription",
+  "entities": [
+    {
+      "type": "T"
+    }
+  ],
+  "notification": {
+    "endpoint": {
+      "uri": "http://127.0.0.1:'${LISTENER_PORT}'/notify"
+    }
+  }
+}'
+orionCurl --url /ngsi-ld/v1/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo "02. Create a matching entity E1"
+echo "==============================="
+payload='{
+  "id": "urn:ngsi-ld:T:E1",
+  "type": "T",
+  "P": 1
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "03. GET S1, see lastSuccess, lastNotification, and timesSent==1"
+echo "==============================================================="
+orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:subscriptions:S1
+echo
+echo
+
+
+echo "04. See S1 in mongo - see timesSent==0, as no dump has been done yet"
+echo "===================================================================="
+mongoCmd2 ftest "db.csubs.findOne()"
+echo
+echo
+
+
+echo "05. Create a matching entity E2"
+echo "==============================="
+payload='{
+  "id": "urn:ngsi-ld:T:E2",
+  "type": "T",
+  "P": 1
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "06. Create a matching entity E3"
+echo "==============================="
+payload='{
+  "id": "urn:ngsi-ld:T:E3",
+  "type": "T",
+  "P": 1
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "07. Create a matching entity E4"
+echo "==============================="
+payload='{
+  "id": "urn:ngsi-ld:T:E4",
+  "type": "T",
+  "P": 1
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "08. GET S1, see lastSuccess, lastNotification, and timesSent==4"
+echo "==============================================================="
+orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:subscriptions:S1
+echo
+echo
+
+
+echo "09. Kill accumulator"
+echo "===================="
+accumulatorStop
+echo
+echo
+
+
+echo "10. Create a matching entity E5 - notification will fail"
+echo "========================================================"
+payload='{
+  "id": "urn:ngsi-ld:T:E5",
+  "type": "T",
+  "P": 1
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "11. GET S1, see lastSuccess, lastFailure, lastNotification, and timesSent==5"
+echo "============================================================================"
+orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:subscriptions:S1
+echo
+echo
+
+
+echo "12. See S1 in mongo - see count==5, as the dump has been done"
+echo "============================================================="
+mongoCmd2 ftest "db.csubs.findOne()"
+echo
+echo
+
+
+echo "13. Restart broker"
+echo "=================="
+brokerStop
+sleep .5
+brokerStart CB 0 IPv4 -experimental -cSubCounters 5
+echo
+echo
+
+
+echo "14. GET S1, see lastSuccess, lastFailure, lastNotification, and timesSent==5"
+echo "============================================================================"
+orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:subscriptions:S1
+echo
+echo
+
+
+echo "15. Create a matching entity E6 - notification will fail"
+echo "========================================================"
+payload='{
+  "id": "urn:ngsi-ld:T:E6",
+  "type": "T",
+  "P": 1
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "16. Start the accumulator again"
+echo "==============================="
+accumulatorStart --pretty-print 127.0.0.1 ${LISTENER_PORT}
+echo
+echo
+
+
+echo "17. Create a matching entity E7"
+echo "==============================="
+payload='{
+  "id": "urn:ngsi-ld:T:E7",
+  "type": "T",
+  "P": 1
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "18. GET S1, see lastSuccess, lastFailure, lastNotification, and timesSent==7"
+echo "============================================================================"
+orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:subscriptions:S1
+echo
+echo
+
+
+--REGEXPECT--
+01. Create subscription S1, on entity type T
+============================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:subscriptions:S1
+
+
+
+02. Create a matching entity E1
+===============================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:T:E1
+
+
+
+03. GET S1, see lastSuccess, lastNotification, and timesSent==1
+===============================================================
+HTTP/1.1 200 OK
+Content-Length: 368
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+{
+    "entities": [
+        {
+            "type": "T"
+        }
+    ],
+    "id": "urn:ngsi-ld:subscriptions:S1",
+    "isActive": true,
+    "notification": {
+        "endpoint": {
+            "accept": "application/json",
+            "uri": "http://127.0.0.1:9997/notify"
+        },
+        "format": "normalized",
+        "lastNotification": "202REGEX(.*)",
+        "lastSuccess": "202REGEX(.*)",
+        "status": "ok",
+        "timesSent": 1
+    },
+    "origin": "cache",
+    "status": "active",
+    "type": "Subscription"
+}
+
+
+04. See S1 in mongo - see timesSent==0, as no dump has been done yet
+====================================================================
+MongoDB shell version REGEX(.*)
+connecting to: mongodb:REGEX(.*)
+MongoDB server version: REGEX(.*)
+{
+	"_id" : "urn:ngsi-ld:subscriptions:S1",
+	"entities" : [
+		{
+			"type" : "https://uri.etsi.org/ngsi-ld/default-context/T",
+			"id" : ".*",
+			"isPattern" : "true",
+			"isTypePattern" : false
+		}
+	],
+	"createdAt" : REGEX(\d+\.\d+),
+	"modifiedAt" : REGEX(\d+\.\d+),
+	"throttling" : 0,
+	"expression" : {
+		"geometry" : "",
+		"coords" : "",
+		"georel" : "",
+		"geoproperty" : "",
+		"q" : "",
+		"mq" : ""
+	},
+	"reference" : "http://127.0.0.1:9997/notify",
+	"mimeType" : "application/json",
+	"attrs" : [ ],
+	"format" : "normalized",
+	"conditions" : [ ],
+	"status" : "active",
+	"custom" : false,
+	"servicePath" : "/#",
+	"blacklist" : false,
+	"ldContext" : "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
+}
+bye
+
+
+05. Create a matching entity E2
+===============================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:T:E2
+
+
+
+06. Create a matching entity E3
+===============================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:T:E3
+
+
+
+07. Create a matching entity E4
+===============================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:T:E4
+
+
+
+08. GET S1, see lastSuccess, lastNotification, and timesSent==4
+===============================================================
+HTTP/1.1 200 OK
+Content-Length: 368
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+{
+    "entities": [
+        {
+            "type": "T"
+        }
+    ],
+    "id": "urn:ngsi-ld:subscriptions:S1",
+    "isActive": true,
+    "notification": {
+        "endpoint": {
+            "accept": "application/json",
+            "uri": "http://127.0.0.1:9997/notify"
+        },
+        "format": "normalized",
+        "lastNotification": "202REGEX(.*)",
+        "lastSuccess": "202REGEX(.*)",
+        "status": "ok",
+        "timesSent": 4
+    },
+    "origin": "cache",
+    "status": "active",
+    "type": "Subscription"
+}
+
+
+09. Kill accumulator
+====================
+
+
+10. Create a matching entity E5 - notification will fail
+========================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:T:E5
+
+
+
+11. GET S1, see lastSuccess, lastFailure, lastNotification, and timesSent==5
+============================================================================
+HTTP/1.1 200 OK
+Content-Length: 498
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+{
+    "entities": [
+        {
+            "type": "T"
+        }
+    ],
+    "id": "urn:ngsi-ld:subscriptions:S1",
+    "isActive": true,
+    "notification": {
+        "consecutiveErrors": 1,
+        "endpoint": {
+            "accept": "application/json",
+            "uri": "http://127.0.0.1:9997/notify"
+        },
+        "format": "normalized",
+        "lastErrorReason": "Unable to connect to notification endpoint",
+        "lastFailure": "202REGEX(.*)",
+        "lastNotification": "202REGEX(.*)",
+        "lastSuccess": "202REGEX(.*)",
+        "status": "failed",
+        "timesSent": 5
+    },
+    "origin": "cache",
+    "status": "active",
+    "type": "Subscription"
+}
+
+
+12. See S1 in mongo - see count==5, as the dump has been done
+=============================================================
+MongoDB shell version REGEX(.*)
+connecting to: mongodb:REGEX(.*)
+MongoDB server version: REGEX(.*)
+{
+	"_id" : "urn:ngsi-ld:subscriptions:S1",
+	"entities" : [
+		{
+			"type" : "https://uri.etsi.org/ngsi-ld/default-context/T",
+			"id" : ".*",
+			"isPattern" : "true",
+			"isTypePattern" : false
+		}
+	],
+	"createdAt" : REGEX(\d+\.\d+),
+	"modifiedAt" : REGEX(\d+\.\d+),
+	"throttling" : 0,
+	"expression" : {
+		"geometry" : "",
+		"coords" : "",
+		"georel" : "",
+		"geoproperty" : "",
+		"q" : "",
+		"mq" : ""
+	},
+	"reference" : "http://127.0.0.1:9997/notify",
+	"mimeType" : "application/json",
+	"attrs" : [ ],
+	"format" : "normalized",
+	"conditions" : [ ],
+	"status" : "active",
+	"custom" : false,
+	"servicePath" : "/#",
+	"blacklist" : false,
+	"ldContext" : "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+	"count" : NumberLong(5),
+	"lastFailure" : REGEX(.*),
+	"lastNotification" : REGEX(.*),
+	"lastSuccess" : REGEX(.*)
+}
+bye
+
+
+13. Restart broker
+==================
+
+
+14. GET S1, see lastSuccess, lastFailure, lastNotification, and timesSent==5
+============================================================================
+HTTP/1.1 200 OK
+Content-Length: 409
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+{
+    "entities": [
+        {
+            "type": "T"
+        }
+    ],
+    "id": "urn:ngsi-ld:subscriptions:S1",
+    "isActive": true,
+    "notification": {
+        "endpoint": {
+            "accept": "application/json",
+            "uri": "http://127.0.0.1:9997/notify"
+        },
+        "format": "normalized",
+        "lastFailure": "202REGEX(.*)",
+        "lastNotification": "202REGEX(.*)",
+        "lastSuccess": "202REGEX(.*)",
+        "status": "ok",
+        "timesSent": 5
+    },
+    "origin": "cache",
+    "status": "active",
+    "type": "Subscription"
+}
+
+
+15. Create a matching entity E6 - notification will fail
+========================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:T:E6
+
+
+
+16. Start the accumulator again
+===============================
+accumulator running as PID REGEX(\d+)
+
+
+17. Create a matching entity E7
+===============================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:T:E7
+
+
+
+18. GET S1, see lastSuccess, lastFailure, lastNotification, and timesSent==7
+============================================================================
+HTTP/1.1 200 OK
+Content-Length: 472
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+{
+    "entities": [
+        {
+            "type": "T"
+        }
+    ],
+    "id": "urn:ngsi-ld:subscriptions:S1",
+    "isActive": true,
+    "notification": {
+        "endpoint": {
+            "accept": "application/json",
+            "uri": "http://127.0.0.1:9997/notify"
+        },
+        "format": "normalized",
+        "lastErrorReason": "Unable to connect to notification endpoint",
+        "lastFailure": "202REGEX(.*)",
+        "lastNotification": "202REGEX(.*)",
+        "lastSuccess": "202REGEX(.*)",
+        "status": "ok",
+        "timesSent": 7
+    },
+    "origin": "cache",
+    "status": "active",
+    "type": "Subscription"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_subscription_counters-for-https-notifications.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_subscription_counters-for-https-notifications.test
@@ -1,0 +1,577 @@
+# Copyright 2022 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Subscription Counters and timestamps for HTTPS notifications
+
+--SHELL-INIT--
+${SCRIPT_HOME}/httpsPrepare.sh --keyFileName /tmp/harnessTest.key --certFileName /tmp/harnessTest.pem
+export BROKER=orionld
+dbInit CB
+brokerStart CB 0 IPv4 -experimental -cSubCounters 5
+accumulatorStart --pretty-print --https --key /tmp/harnessTest.key --cert /tmp/harnessTest.pem
+
+--SHELL--
+
+#
+# 01. Create subscription S1, on entity type T
+# 02. Create a matching entity E1
+# 03. GET S1, see lastSuccess, lastNotification, and timesSent==1
+# 04. See S1 in mongo - see timesSent==0, as no dump has been done yet
+# 05. Create a matching entity E2
+# 06. Create a matching entity E3
+# 07. Create a matching entity E4
+# 08. GET S1, see lastSuccess, lastNotification, and timesSent==4
+# 09. Kill accumulator
+# 10. Create a matching entity E5 - notification will fail
+# 11. GET S1, see lastSuccess, lastFailure, lastNotification, and timesSent==5
+# 12. See S1 in mongo - see count==5, as the dump has been done
+# 13. Restart broker
+# 14. GET S1, see lastSuccess, lastFailure, lastNotification, and timesSent==5
+# 15. Create a matching entity E6 - notification will fail
+# 16. Start the accumulator again
+# 17. Create a matching entity E7
+# 18. GET S1, see lastSuccess, lastFailure, lastNotification, and timesSent==7
+#
+
+
+echo "01. Create subscription S1, on entity type T"
+echo "============================================"
+payload='{
+  "id": "urn:ngsi-ld:subscriptions:S1",
+  "type": "Subscription",
+  "entities": [
+    {
+      "type": "T"
+    }
+  ],
+  "notification": {
+    "endpoint": {
+      "uri": "https://127.0.0.1:'${LISTENER_PORT}'/notify"
+    }
+  }
+}'
+orionCurl --url /ngsi-ld/v1/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo "02. Create a matching entity E1"
+echo "==============================="
+payload='{
+  "id": "urn:ngsi-ld:T:E1",
+  "type": "T",
+  "P": 1
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "03. GET S1, see lastSuccess, lastNotification, and timesSent==1"
+echo "==============================================================="
+orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:subscriptions:S1
+echo
+echo
+
+
+echo "04. See S1 in mongo - see timesSent==0, as no dump has been done yet"
+echo "===================================================================="
+mongoCmd2 ftest "db.csubs.findOne()"
+echo
+echo
+
+
+echo "05. Create a matching entity E2"
+echo "==============================="
+payload='{
+  "id": "urn:ngsi-ld:T:E2",
+  "type": "T",
+  "P": 1
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "06. Create a matching entity E3"
+echo "==============================="
+payload='{
+  "id": "urn:ngsi-ld:T:E3",
+  "type": "T",
+  "P": 1
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "07. Create a matching entity E4"
+echo "==============================="
+payload='{
+  "id": "urn:ngsi-ld:T:E4",
+  "type": "T",
+  "P": 1
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "08. GET S1, see lastSuccess, lastNotification, and timesSent==4"
+echo "==============================================================="
+orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:subscriptions:S1
+echo
+echo
+
+
+echo "09. Kill accumulator"
+echo "===================="
+accumulatorStop
+echo
+echo
+
+
+echo "10. Create a matching entity E5 - notification will fail"
+echo "========================================================"
+payload='{
+  "id": "urn:ngsi-ld:T:E5",
+  "type": "T",
+  "P": 1
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "11. GET S1, see lastSuccess, lastFailure, lastNotification, and timesSent==5"
+echo "============================================================================"
+orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:subscriptions:S1
+echo
+echo
+
+
+echo "12. See S1 in mongo - see count==5, as the dump has been done"
+echo "============================================================="
+mongoCmd2 ftest "db.csubs.findOne()"
+echo
+echo
+
+
+echo "13. Restart broker"
+echo "=================="
+brokerStop
+sleep .5
+brokerStart CB 0 IPv4 -experimental -cSubCounters 5
+echo
+echo
+
+
+echo "14. GET S1, see lastSuccess, lastFailure, lastNotification, and timesSent==5"
+echo "============================================================================"
+orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:subscriptions:S1
+echo
+echo
+
+
+echo "15. Create a matching entity E6 - notification will fail"
+echo "========================================================"
+payload='{
+  "id": "urn:ngsi-ld:T:E6",
+  "type": "T",
+  "P": 1
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "16. Start the accumulator again"
+echo "==============================="
+accumulatorStart --pretty-print --https --key /tmp/harnessTest.key --cert /tmp/harnessTest.pem
+echo
+echo
+
+
+echo "17. Create a matching entity E7"
+echo "==============================="
+payload='{
+  "id": "urn:ngsi-ld:T:E7",
+  "type": "T",
+  "P": 1
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "18. GET S1, see lastSuccess, lastFailure, lastNotification, and timesSent==7"
+echo "============================================================================"
+orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:subscriptions:S1
+echo
+echo
+
+
+--REGEXPECT--
+01. Create subscription S1, on entity type T
+============================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:subscriptions:S1
+
+
+
+02. Create a matching entity E1
+===============================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:T:E1
+
+
+
+03. GET S1, see lastSuccess, lastNotification, and timesSent==1
+===============================================================
+HTTP/1.1 200 OK
+Content-Length: 369
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+{
+    "entities": [
+        {
+            "type": "T"
+        }
+    ],
+    "id": "urn:ngsi-ld:subscriptions:S1",
+    "isActive": true,
+    "notification": {
+        "endpoint": {
+            "accept": "application/json",
+            "uri": "https://127.0.0.1:9997/notify"
+        },
+        "format": "normalized",
+        "lastNotification": "202REGEX(.*)",
+        "lastSuccess": "202REGEX(.*)",
+        "status": "ok",
+        "timesSent": 1
+    },
+    "origin": "cache",
+    "status": "active",
+    "type": "Subscription"
+}
+
+
+04. See S1 in mongo - see timesSent==0, as no dump has been done yet
+====================================================================
+MongoDB shell version REGEX(.*)
+connecting to: mongodb:REGEX(.*)
+MongoDB server version: REGEX(.*)
+{
+	"_id" : "urn:ngsi-ld:subscriptions:S1",
+	"entities" : [
+		{
+			"type" : "https://uri.etsi.org/ngsi-ld/default-context/T",
+			"id" : ".*",
+			"isPattern" : "true",
+			"isTypePattern" : false
+		}
+	],
+	"createdAt" : REGEX(\d+\.\d+),
+	"modifiedAt" : REGEX(\d+\.\d+),
+	"throttling" : 0,
+	"expression" : {
+		"geometry" : "",
+		"coords" : "",
+		"georel" : "",
+		"geoproperty" : "",
+		"q" : "",
+		"mq" : ""
+	},
+	"reference" : "https://127.0.0.1:9997/notify",
+	"mimeType" : "application/json",
+	"attrs" : [ ],
+	"format" : "normalized",
+	"conditions" : [ ],
+	"status" : "active",
+	"custom" : false,
+	"servicePath" : "/#",
+	"blacklist" : false,
+	"ldContext" : "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
+}
+bye
+
+
+05. Create a matching entity E2
+===============================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:T:E2
+
+
+
+06. Create a matching entity E3
+===============================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:T:E3
+
+
+
+07. Create a matching entity E4
+===============================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:T:E4
+
+
+
+08. GET S1, see lastSuccess, lastNotification, and timesSent==4
+===============================================================
+HTTP/1.1 200 OK
+Content-Length: 369
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+{
+    "entities": [
+        {
+            "type": "T"
+        }
+    ],
+    "id": "urn:ngsi-ld:subscriptions:S1",
+    "isActive": true,
+    "notification": {
+        "endpoint": {
+            "accept": "application/json",
+            "uri": "https://127.0.0.1:9997/notify"
+        },
+        "format": "normalized",
+        "lastNotification": "202REGEX(.*)",
+        "lastSuccess": "202REGEX(.*)",
+        "status": "ok",
+        "timesSent": 4
+    },
+    "origin": "cache",
+    "status": "active",
+    "type": "Subscription"
+}
+
+
+09. Kill accumulator
+====================
+
+
+10. Create a matching entity E5 - notification will fail
+========================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:T:E5
+
+
+
+11. GET S1, see lastSuccess, lastFailure, lastNotification, and timesSent==5
+============================================================================
+HTTP/1.1 200 OK
+Content-Length: 497
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+{
+    "entities": [
+        {
+            "type": "T"
+        }
+    ],
+    "id": "urn:ngsi-ld:subscriptions:S1",
+    "isActive": true,
+    "notification": {
+        "consecutiveErrors": 1,
+        "endpoint": {
+            "accept": "application/json",
+            "uri": "https://127.0.0.1:9997/notify"
+        },
+        "format": "normalized",
+        "lastErrorReason": "CURL Error 7: Couldn't connect to server",
+        "lastFailure": "202REGEX(.*)",
+        "lastNotification": "202REGEX(.*)",
+        "lastSuccess": "202REGEX(.*)",
+        "status": "failed",
+        "timesSent": 5
+    },
+    "origin": "cache",
+    "status": "active",
+    "type": "Subscription"
+}
+
+
+12. See S1 in mongo - see count==5, as the dump has been done
+=============================================================
+MongoDB shell version REGEX(.*)
+connecting to: mongodb:REGEX(.*)
+MongoDB server version: REGEX(.*)
+{
+	"_id" : "urn:ngsi-ld:subscriptions:S1",
+	"entities" : [
+		{
+			"type" : "https://uri.etsi.org/ngsi-ld/default-context/T",
+			"id" : ".*",
+			"isPattern" : "true",
+			"isTypePattern" : false
+		}
+	],
+	"createdAt" : REGEX(\d+\.\d+),
+	"modifiedAt" : REGEX(\d+\.\d+),
+	"throttling" : 0,
+	"expression" : {
+		"geometry" : "",
+		"coords" : "",
+		"georel" : "",
+		"geoproperty" : "",
+		"q" : "",
+		"mq" : ""
+	},
+	"reference" : "https://127.0.0.1:9997/notify",
+	"mimeType" : "application/json",
+	"attrs" : [ ],
+	"format" : "normalized",
+	"conditions" : [ ],
+	"status" : "active",
+	"custom" : false,
+	"servicePath" : "/#",
+	"blacklist" : false,
+	"ldContext" : "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+	"count" : NumberLong(5),
+	"lastFailure" : REGEX(.*),
+	"lastNotification" : REGEX(.*),
+	"lastSuccess" : REGEX(.*)
+}
+bye
+
+
+13. Restart broker
+==================
+
+
+14. GET S1, see lastSuccess, lastFailure, lastNotification, and timesSent==5
+============================================================================
+HTTP/1.1 200 OK
+Content-Length: 410
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+{
+    "entities": [
+        {
+            "type": "T"
+        }
+    ],
+    "id": "urn:ngsi-ld:subscriptions:S1",
+    "isActive": true,
+    "notification": {
+        "endpoint": {
+            "accept": "application/json",
+            "uri": "https://127.0.0.1:9997/notify"
+        },
+        "format": "normalized",
+        "lastFailure": "202REGEX(.*)",
+        "lastNotification": "202REGEX(.*)",
+        "lastSuccess": "202REGEX(.*)",
+        "status": "ok",
+        "timesSent": 5
+    },
+    "origin": "cache",
+    "status": "active",
+    "type": "Subscription"
+}
+
+
+15. Create a matching entity E6 - notification will fail
+========================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:T:E6
+
+
+
+16. Start the accumulator again
+===============================
+accumulator running as PID REGEX(\d+)
+
+
+17. Create a matching entity E7
+===============================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:T:E7
+
+
+
+18. GET S1, see lastSuccess, lastFailure, lastNotification, and timesSent==7
+============================================================================
+HTTP/1.1 200 OK
+Content-Length: 471
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+{
+    "entities": [
+        {
+            "type": "T"
+        }
+    ],
+    "id": "urn:ngsi-ld:subscriptions:S1",
+    "isActive": true,
+    "notification": {
+        "endpoint": {
+            "accept": "application/json",
+            "uri": "https://127.0.0.1:9997/notify"
+        },
+        "format": "normalized",
+        "lastErrorReason": "CURL Error 7: Couldn't connect to server",
+        "lastFailure": "202REGEX(.*)",
+        "lastNotification": "202REGEX(.*)",
+        "lastSuccess": "202REGEX(.*)",
+        "status": "ok",
+        "timesSent": 7
+    },
+    "origin": "cache",
+    "status": "active",
+    "type": "Subscription"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/unittests/main_UnitTest.cpp
+++ b/test/unittests/main_UnitTest.cpp
@@ -105,6 +105,7 @@ char            dbPwd[64]               = { 0 };
 bool            experimental            = false;
 bool            mongocOnly              = false;
 bool            debugCurl               = false;
+int             cSubCounters            = 0;
 
 
 


### PR DESCRIPTION
* Persisting counters and timestamps of subscriptions from the subscription cache in the database
* New CLI option: -cSubCounters - number of subscription counter updates before flushing from sub-cache to DB (0: never, 1: always)
* Bug fix: getting lastNotification, lastSuccess, lastFailure from DB in when refreshing the subscription cache
