### PR TITLE
use case insensitive matching for http request header keys

### DIFF
--- a/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
@@ -400,11 +400,11 @@ bool pCheckTenantName(const char* dbName)
 //
 static MHD_Result orionldHttpHeaderReceive(void* cbDataP, MHD_ValueKind kind, const char* key, const char* value)
 {
-  if (strcmp(key, "Orionld-Legacy") == 0)
+  if (strcasecmp(key, "Orionld-Legacy") == 0)
     orionldState.in.legacy = (char*) value;
-  else if (strcmp(key, "Performance") == 0)
+  else if (strcasecmp(key, "Performance") == 0)
     orionldState.in.performance = true;
-  else if (strcmp(key, "NGSILD-Scope") == 0)
+  else if (strcasecmp(key, "NGSILD-Scope") == 0)
   {
     orionldState.scopes = strSplit((char*) value, ',', orionldState.scopeV, K_VEC_SIZE(orionldState.scopeV));
     if (orionldState.scopes == -1)
@@ -413,7 +413,7 @@ static MHD_Result orionldHttpHeaderReceive(void* cbDataP, MHD_ValueKind kind, co
       orionldError(OrionldBadRequestData, "Bad value for HTTP header /NGSILD-Scope/", value, 400);
     }
   }
-  else if (strcmp(key, "Accept") == 0)
+  else if (strcasecmp(key, "Accept") == 0)
   {
     orionldState.out.contentType = acceptHeaderParse((char*) value, false);
 


### PR DESCRIPTION
## Proposed changes

This PR fixes https://github.com/FIWARE/context.Orion-LD/issues/1226 by replacing strcmp with strcasecmp for the four request headers Orionld-Legacy, Performance, NGSILD-Scope and Accept.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/FIWARE/context.Orion-LD/blob/master/CONTRIBUTING.md) doc
-   [x] I have signed the [CLA](https://fiware.github.io/contribution-requirements/individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

I should have added a test for this, but I don't have the correct toolchain setup currently, and wanted to get the issue and PR posted as soon as possible in case there are others that get affected by this.

I have read the CLA Document and I hereby sign the CLA.
