### PR TITLE
Mongoc/get subscriptions

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -20,3 +20,4 @@
 * Issue #280   Reimplementation of GET /attributes/{attrName}, using the new mongo driver (mongoc) - only used if -experimental is set
 * Issue #280   Added a URL parameter for GET /subscriptions/{subId}: ?options=fromDb  to get the subscription from DB and not subscription cache
 * Issue #280   Implemented retrieval of a subscription from the database instead of from the subscription cache:  GET /subscriptions/{subId}?options=fromDb
+* Issue #280   Implemented query of subscriptions from the database instead of from the subscription cache:  GET /subscriptionss?options=fromDb

--- a/src/lib/orionld/dbModel/dbModelFromApiSubscription.cpp
+++ b/src/lib/orionld/dbModel/dbModelFromApiSubscription.cpp
@@ -274,7 +274,6 @@ bool dbModelFromApiSubscription(KjNode* apiSubscriptionP, bool patch)
     KjNode* coordinatesP = kjLookup(geoqP, "coordinates");
     KjNode* geometryP    = kjLookup(geoqP, "geometry");
     KjNode* georelP      = kjLookup(geoqP, "georel");
-    KjNode* geopropertyP = kjLookup(geoqP, "geoproperty");
 
     //
     // As "geoQ" in NGSI-LD Subscription contains many fields (4 out of 6) of what is "expression" in the DB Model
@@ -298,7 +297,12 @@ bool dbModelFromApiSubscription(KjNode* apiSubscriptionP, bool patch)
         return false;
     }
 
+    //
     // If 'geoproperty' is not there, add it:
+    // Database Model decision. Perhaps a bad one ...
+    // I could set it to "location", as that's the default value ...
+    //
+    KjNode* geopropertyP = kjLookup(geoqP, "geoproperty");
     if ((geopropertyP == NULL) && (patch == false))
     {
       geopropertyP = kjString(orionldState.kjsonP, "geoproperty", "");

--- a/src/lib/orionld/dbModel/dbModelToApiGeoQ.cpp
+++ b/src/lib/orionld/dbModel/dbModelToApiGeoQ.cpp
@@ -34,6 +34,7 @@ extern "C"
 #include "orionld/common/orionldState.h"                         // orionldState
 #include "orionld/common/orionldError.h"                         // orionldError
 #include "orionld/common/eqForDot.h"                             // eqForDot
+#include "orionld/kjTree/kjTreeLog.h"                            // kjTreeLog
 #include "orionld/context/orionldContextItemAliasLookup.h"       // orionldContextItemAliasLookup
 #include "orionld/dbModel/dbModelToApiGeometry.h"                // dbModelToApiGeometry
 #include "orionld/dbModel/dbModelToApiGeorel.h"                  // dbModelToApiGeorel
@@ -52,6 +53,8 @@ bool dbModelToApiGeoQ(KjNode* geoqP, KjNode** coordinatesPP, bool* emptyP)
   KjNode* georelP       = kjLookup(geoqP, "georel");
   KjNode* coordsP       = kjLookup(geoqP, "coords");
   KjNode* geopropertyP  = kjLookup(geoqP, "geoproperty");
+
+  kjTreeLog(geoqP, "GP: geoqP tree");
 
   if (geometryP == NULL)
   {
@@ -115,8 +118,14 @@ bool dbModelToApiGeoQ(KjNode* geoqP, KjNode** coordinatesPP, bool* emptyP)
 
   if (geopropertyP != NULL)
   {
-    eqForDot(geopropertyP->value.s);
-    geopropertyP->value.s = orionldContextItemAliasLookup(orionldState.contextP, geopropertyP->value.s, NULL, NULL);
+    // "geoproperty" is present in the DB also when not in use (its RHS is "")
+    if (geopropertyP->value.s[0] == 0)
+      kjChildRemove(geoqP, geopropertyP);
+    else
+    {
+      eqForDot(geopropertyP->value.s);
+      geopropertyP->value.s = orionldContextItemAliasLookup(orionldState.contextP, geopropertyP->value.s, NULL, NULL);
+    }
   }
 
   *coordinatesPP = coordsP;

--- a/src/lib/orionld/kjTree/kjTreeFromCachedSubscription.cpp
+++ b/src/lib/orionld/kjTree/kjTreeFromCachedSubscription.cpp
@@ -492,7 +492,7 @@ KjNode* kjTreeFromCachedSubscription(CachedSubscription* cSubP, bool sysAttrs, b
   //
   if (contextInBody == true)
   {
-    nodeP = kjString(orionldState.kjsonP, "@context", cSubP->ldContext.c_str());
+    nodeP = kjString(orionldState.kjsonP, "@context", orionldState.contextP->url);
     NULL_CHECK(nodeP);
     kjChildAdd(sP, nodeP);
   }

--- a/src/lib/orionld/mongoc/CMakeLists.txt
+++ b/src/lib/orionld/mongoc/CMakeLists.txt
@@ -60,6 +60,7 @@ SET (SOURCES
     mongocEntitiesGet.cpp
     mongocEntityTypesFromRegistrationsGet.cpp
     mongocEntityTypeGet.cpp
+    mongocSubscriptionsGet.cpp
 )
 
 # Include directories

--- a/src/lib/orionld/mongoc/mongocSubscriptionsGet.cpp
+++ b/src/lib/orionld/mongoc/mongocSubscriptionsGet.cpp
@@ -1,0 +1,171 @@
+/*
+*
+* Copyright 2022 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+#include <mongoc/mongoc.h>                                       // MongoDB C Client Driver
+
+extern "C"
+{
+#include "kjson/KjNode.h"                                        // KjNode
+#include "kjson/kjBuilder.h"                                     // kjArray, kjChildAdd, ...
+}
+
+#include "logMsg/logMsg.h"                                       // LM_*
+
+#include "orionld/common/orionldState.h"                         // orionldState
+#include "orionld/common/orionldError.h"                         // orionldError
+#include "orionld/dbModel/dbModelToApiSubscription.h"            // dbModelToApiSubscription
+#include "orionld/q/QNode.h"                                     // QNode
+#include "orionld/context/orionldContextFromUrl.h"               // orionldContextFromUrl
+#include "orionld/mongoc/mongocConnectionGet.h"                  // mongocConnectionGet
+#include "orionld/mongoc/mongocKjTreeFromBson.h"                 // mongocKjTreeFromBson
+#include "orionld/mongoc/mongocSubscriptionsGet.h"               // Own interface
+
+
+
+/* ****************************************************************************
+*
+* mongocSubscriptionsGet -
+*/
+KjNode* mongocSubscriptionsGet(int64_t* countP, bool contextInBody)
+{
+  bson_t               mongoFilter;
+  const bson_t*        mongoDocP;
+  mongoc_cursor_t*     mongoCursorP;
+  bson_error_t         mongoError;
+  mongoc_read_prefs_t* readPrefs = mongoc_read_prefs_new(MONGOC_READ_NEAREST);
+  char*                title;
+  char*                details;
+  KjNode*              subArrayP = kjArray(orionldState.kjsonP, NULL);  // This is the response payload body
+
+  //
+  // Sort, Limit, Offset
+  //
+  bson_t options;
+  bson_t sortDoc;
+  int    limit       = orionldState.uriParams.limit;
+  int    offset      = orionldState.uriParams.offset;
+
+  bson_init(&options);
+  bson_init(&sortDoc);
+
+  bson_append_int32(&sortDoc, "createdAt", 9, 1);
+  bson_append_document(&options, "sort", 4, &sortDoc);
+  bson_destroy(&sortDoc);
+
+  bson_append_int32(&options, "limit", 5, limit);
+  if (offset != 0)
+    bson_append_int32(&options, "skip", 4, offset);
+
+  //
+  // Empty filter for the query - we want ALL subscriptions
+  //
+  bson_init(&mongoFilter);
+
+  mongocConnectionGet();
+
+  if (orionldState.mongoc.subscriptionsP == NULL)
+    orionldState.mongoc.subscriptionsP = mongoc_client_get_collection(orionldState.mongoc.client, orionldState.tenantP->mongoDbName, "csubs");
+
+
+  // count?
+  if (orionldState.uriParams.count == true)
+  {
+    bson_error_t error;
+
+    *countP = mongoc_collection_count_documents(orionldState.mongoc.subscriptionsP, &mongoFilter, NULL, readPrefs, NULL, &error);
+    if (*countP == -1)
+    {
+      *countP = 0;
+      LM_E(("Database Error (error counting entities: %d.%d: %s)", error.domain, error.code, error.message));
+    }
+
+    if (limit == 0)  // Only count requested
+    {
+      bson_destroy(&mongoFilter);
+
+      if (*countP == -1)
+      {
+        orionldError(OrionldInternalError, "Database Error", error.message, 500);
+        return NULL;
+      }
+
+      return subArrayP;
+    }
+  }
+
+
+  //
+  // Run the query
+  //
+  mongoCursorP = mongoc_collection_find_with_opts(orionldState.mongoc.subscriptionsP, &mongoFilter, &options, readPrefs);
+  if (mongoCursorP == NULL)
+  {
+    orionldError(OrionldInternalError, "Database Error", "mongoc_collection_find_with_opts ERROR", 500);
+    return NULL;
+  }
+
+  while (mongoc_cursor_next(mongoCursorP, &mongoDocP))
+  {
+    KjNode* dbSubP = mongocKjTreeFromBson(mongoDocP, &title, &details);
+
+    if (dbSubP == NULL)
+    {
+      orionldError(OrionldInternalError, "Database Error", "unable to convert DB-Model subscription to API Format", 500);
+      continue;
+    }
+
+    QNode*  qTree        = NULL;
+    KjNode* contextNodeP = NULL;
+    KjNode* coordinatesP = NULL;
+    KjNode* apiSubP      = dbModelToApiSubscription(dbSubP, orionldState.tenantP->tenant, false, &qTree, &coordinatesP, &contextNodeP);
+
+    if (apiSubP == NULL)
+    {
+      orionldError(OrionldInternalError, "Database Error", "unable to convert subscription to API format)", 500);
+      continue;
+    }
+
+    if (contextInBody == true)
+    {
+      KjNode* nodeP = kjString(orionldState.kjsonP, "@context", orionldState.contextP->url);
+      if (nodeP == NULL)
+        LM_E(("Internal error (out of memory creating an '@context' field for a subscription)"));
+      else
+        kjChildAdd(apiSubP, nodeP);
+    }
+
+    kjChildAdd(subArrayP, apiSubP);
+  }
+
+  if (mongoc_cursor_error(mongoCursorP, &mongoError))
+  {
+    orionldError(OrionldInternalError, "Database Error", mongoError.message, 500);
+    return NULL;
+  }
+
+  mongoc_cursor_destroy(mongoCursorP);
+  bson_destroy(&mongoFilter);
+
+  return subArrayP;
+}

--- a/src/lib/orionld/mongoc/mongocSubscriptionsGet.h
+++ b/src/lib/orionld/mongoc/mongocSubscriptionsGet.h
@@ -1,0 +1,42 @@
+#ifndef SRC_LIB_ORIONLD_MONGOC_MONGOCSUBSCRIPTIONSGET_H_
+#define SRC_LIB_ORIONLD_MONGOC_MONGOCSUBSCRIPTIONSGET_H_
+
+/*
+*
+* Copyright 2022 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+
+extern "C"
+{
+#include "kjson/KjNode.h"                                        // KjNode
+}
+
+
+
+// -----------------------------------------------------------------------------
+//
+// mongocSubscriptionsGet -
+//
+extern KjNode* mongocSubscriptionsGet(int64_t* countP, bool contextInBody);
+
+#endif  // SRC_LIB_ORIONLD_MONGOC_MONGOCSUBSCRIPTIONSGET_H_

--- a/src/lib/orionld/mongoc/mongocSubscriptionsGet.h
+++ b/src/lib/orionld/mongoc/mongocSubscriptionsGet.h
@@ -37,6 +37,6 @@ extern "C"
 //
 // mongocSubscriptionsGet -
 //
-extern KjNode* mongocSubscriptionsGet(int64_t* countP, bool contextInBody);
+extern KjNode* mongocSubscriptionsGet(int64_t* countP);
 
 #endif  // SRC_LIB_ORIONLD_MONGOC_MONGOCSUBSCRIPTIONSGET_H_

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_subscription-list.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_subscription-list.test
@@ -40,6 +40,15 @@ brokerStart CB 0 IPv4 -experimental -multiservice
 # 06. GET subscriptions count with limit 0 - see HTTP header (NGSILD-Results-Count) and empty subscription array
 # 07. GET subscriptions count with limit 1 - see HTTP header (NGSILD-Results-Count) and ONE (sub0001) subscription in the array
 # 08. GET subscriptions from tenant t1, with offset 36 - see 4 subs
+# 09. GET subscriptions from tenant t1, with offset 36 AND with Accept: application/ld+json - see 4 subs
+#
+# 10. GET subscriptions from DB - see the first 20
+# 11. GET subscriptions from DB - with limit 5 - see the first 5
+# 12. GET subscriptions from DB - with limit 5 and offset 25, see subs 25-29
+# 13. GET subscriptions from DB - count with limit 0 - see HTTP header (NGSILD-Results-Count) and empty subscription array
+# 14. GET subscriptions from DB - count with limit 1 - see HTTP header (NGSILD-Results-Count) and ONE (sub0001) subscription in the array
+# 15. GET subscriptions from DB - from tenant t1, with offset 36 - see 4 subs
+# 16. GET subscriptions from DB - from tenant t1, with offset 36 AND with Accept: application/ld+json - see 4 subs
 #
 
 
@@ -210,6 +219,62 @@ echo
 echo "08. GET subscriptions from tenant t1, with offset 36 - see 4 subs"
 echo "================================================================="
 orionCurl --url '/ngsi-ld/v1/subscriptions?offset=36&count=true' -H "NGSILD-Tenant: t1" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+echo
+echo
+
+
+echo "09. GET subscriptions from tenant t1, with offset 36 AND with Accept: application/ld+json - see 4 subs"
+echo "======================================================================================================"
+orionCurl --url '/ngsi-ld/v1/subscriptions?offset=36&count=true' -H "NGSILD-Tenant: t1" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' -H "Accept: application/ld+json"
+echo
+echo
+
+
+echo "10. GET subscriptions from DB - see the first 20"
+echo "================================================"
+orionCurl --url /ngsi-ld/v1/subscriptions?options=fromDb -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+echo
+echo
+
+
+echo "11. GET subscriptions from DB - with limit 5 - see the first 5"
+echo "=============================================================="
+orionCurl --url '/ngsi-ld/v1/subscriptions?limit=5&options=fromDb' -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+echo
+echo
+
+
+echo "12. GET subscriptions from DB - with limit 5 and offset 25, see subs 25-29"
+echo "=========================================================================="
+orionCurl --url '/ngsi-ld/v1/subscriptions?limit=5&offset=25&options=fromDb' -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+echo
+echo
+
+
+echo "13. GET subscriptions from DB - count with limit 0 - see HTTP header (NGSILD-Results-Count) and empty subscription array"
+echo "========================================================================================================================"
+orionCurl --url '/ngsi-ld/v1/subscriptions?limit=0&count=true&options=fromDb'
+echo
+echo
+
+
+echo "14. GET subscriptions from DB - count with limit 1 - see HTTP header (NGSILD-Results-Count) and ONE (sub0001) subscription in the array"
+echo "======================================================================================================================================="
+orionCurl --url '/ngsi-ld/v1/subscriptions?limit=1&count=true&options=sysAttrs,fromDb'
+echo
+echo
+
+
+echo "15. GET subscriptions from DB - from tenant t1, with offset 36 - see 4 subs"
+echo "==========================================================================="
+orionCurl --url '/ngsi-ld/v1/subscriptions?offset=36&count=true&options=fromDb' -H "NGSILD-Tenant: t1" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+echo
+echo
+
+
+echo "16. GET subscriptions from DB - from tenant t1, with offset 36 AND with Accept: application/ld+json - see 4 subs"
+echo "================================================================================================================"
+orionCurl --url '/ngsi-ld/v1/subscriptions?offset=36&count=true&options=fromDb' -H "NGSILD-Tenant: t1" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' -H "Accept: application/ld+json"
 echo
 echo
 
@@ -2526,6 +2591,2263 @@ NGSILD-Results-Count: 40
             "status": "ok"
         },
         "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0040",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    }
+]
+
+
+09. GET subscriptions from tenant t1, with offset 36 AND with Accept: application/ld+json - see 4 subs
+======================================================================================================
+HTTP/1.1 200 OK
+Content-Length: 3005
+Content-Type: application/ld+json
+Date: REGEX(.*)
+NGSILD-Results-Count: 40
+
+[
+    {
+        "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld",
+        "description": "Description of Test subscription 0037",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0037",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0037",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld",
+        "description": "Description of Test subscription 0038",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0038",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0038",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld",
+        "description": "Description of Test subscription 0039",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0039",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0039",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld",
+        "description": "Description of Test subscription 0040",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0040",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0040",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    }
+]
+
+
+10. GET subscriptions from DB - see the first 20
+================================================
+HTTP/1.1 200 OK
+Content-Length: 13381
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+[
+    {
+        "description": "Description of Test subscription 0001",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0001",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0001",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0002",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0002",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0002",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0003",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0003",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0003",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0004",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0004",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0004",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0005",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0005",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0005",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0006",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0006",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0006",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0007",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0007",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0007",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0008",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0008",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0008",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0009",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0009",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0009",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0010",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0010",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0010",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0011",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0011",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0011",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0012",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0012",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0012",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0013",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0013",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0013",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0014",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0014",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0014",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0015",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0015",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0015",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0016",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0016",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0016",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0017",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0017",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0017",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0018",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0018",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0018",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0019",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0019",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0019",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0020",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0020",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0020",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    }
+]
+
+
+11. GET subscriptions from DB - with limit 5 - see the first 5
+==============================================================
+HTTP/1.1 200 OK
+Content-Length: 3346
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+[
+    {
+        "description": "Description of Test subscription 0001",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0001",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0001",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0002",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0002",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0002",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0003",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0003",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0003",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0004",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0004",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0004",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0005",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0005",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0005",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    }
+]
+
+
+12. GET subscriptions from DB - with limit 5 and offset 25, see subs 25-29
+==========================================================================
+HTTP/1.1 200 OK
+Content-Length: 3346
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+[
+    {
+        "description": "Description of Test subscription 0026",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0026",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0026",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0027",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0027",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0027",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0028",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0028",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0028",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0029",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0029",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0029",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0030",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0030",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0030",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    }
+]
+
+
+13. GET subscriptions from DB - count with limit 0 - see HTTP header (NGSILD-Results-Count) and empty subscription array
+========================================================================================================================
+HTTP/1.1 200 OK
+Content-Length: 2
+Content-Type: application/json
+Date: REGEX(.*)
+NGSILD-Results-Count: 50
+
+[]
+
+
+14. GET subscriptions from DB - count with limit 1 - see HTTP header (NGSILD-Results-Count) and ONE (sub0001) subscription in the array
+=======================================================================================================================================
+HTTP/1.1 200 OK
+Content-Length: 863
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+NGSILD-Results-Count: 50
+
+[
+    {
+        "createdAt": "202REGEX(.*)",
+        "description": "Description of Test subscription 0001",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "http://example.org/T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "http://example.org/T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0001",
+        "isActive": false,
+        "modifiedAt": "202REGEX(.*)",
+        "notification": {
+            "attributes": [
+                "http://example.org/P1",
+                "http://example.org/P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "http://example.org/P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0001",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "http://example.org/P2"
+        ]
+    }
+]
+
+
+15. GET subscriptions from DB - from tenant t1, with offset 36 - see 4 subs
+===========================================================================
+HTTP/1.1 200 OK
+Content-Length: 2677
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+NGSILD-Results-Count: 40
+
+[
+    {
+        "description": "Description of Test subscription 0037",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0037",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0037",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0038",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0038",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0038",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0039",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0039",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0039",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "description": "Description of Test subscription 0040",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0040",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0040",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    }
+]
+
+
+16. GET subscriptions from DB - from tenant t1, with offset 36 AND with Accept: application/ld+json - see 4 subs
+================================================================================================================
+HTTP/1.1 200 OK
+Content-Length: 3017
+Content-Type: application/ld+json
+Date: REGEX(.*)
+NGSILD-Results-Count: 40
+
+[
+    {
+        "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld",
+        "description": "Description of Test subscription 0037",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0037",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0037",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld",
+        "description": "Description of Test subscription 0038",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0038",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0038",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld",
+        "description": "Description of Test subscription 0039",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0039",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
+        "q": "P2>10",
+        "status": "paused",
+        "subscriptionName": "Test subscription 0039",
+        "throttling": 5,
+        "type": "Subscription",
+        "watchedAttributes": [
+            "P2"
+        ]
+    },
+    {
+        "@context": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld",
+        "description": "Description of Test subscription 0040",
+        "entities": [
+            {
+                "id": "urn:ngsi-ld:E01",
+                "type": "T1"
+            },
+            {
+                "id": "http://a.b.c/E02",
+                "type": "T2"
+            },
+            {
+                "idPattern": ".*E03.*",
+                "type": "T3"
+            }
+        ],
+        "expiresAt": "2028-12-31T10:00:00.000Z",
+        "geoQ": {
+            "coordinates": [
+                1,
+                2
+            ],
+            "geometry": "Point",
+            "georel": "near;maxDistance==10"
+        },
+        "id": "urn:ngsi-ld:Subscription:sub0040",
+        "isActive": false,
+        "notification": {
+            "attributes": [
+                "P1",
+                "P2",
+                "A3"
+            ],
+            "endpoint": {
+                "accept": "application/ld+json",
+                "uri": "http://valid.url/url"
+            },
+            "format": "keyValues",
+            "status": "ok"
+        },
+        "origin": "database",
         "q": "P2>10",
         "status": "paused",
         "subscriptionName": "Test subscription 0040",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subCache-with-mongoc-on-startup-with-ngsiv2-subscriptions.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subCache-with-mongoc-on-startup-with-ngsiv2-subscriptions.test
@@ -213,7 +213,7 @@ bye
 05. GET ALL subscriptions - from cache
 ======================================
 HTTP/1.1 200 OK
-Content-Length: 359
+Content-Length: 349
 Content-Type: application/json
 Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
@@ -223,7 +223,6 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http:/
         "description": "S1",
         "entities": [
             {
-                "id": ".*",
                 "type": "T"
             }
         ],


### PR DESCRIPTION
Implemented query of subscriptions from the database (mongoc) instead of from the subscription cache:
`GET /subscriptionss?options=fromDb`