### PR TITLE
Hopefully fixed the docker debug image

### DIFF
--- a/docker/Dockerfile-debug
+++ b/docker/Dockerfile-debug
@@ -2,12 +2,8 @@ FROM fiware/orion-ld-base
 
 ARG PATH_TO_SRC='opt/orion/'
 
-
 RUN cp -a /usr/local/lib/. /usr/lib/x86_64-linux-gnu/
 RUN rm -r /usr/local/lib/
-
-ADD ./docker/debug/gdbinit gdbinit
-RUN yum -y --nogpgcheck install gdb
 
 COPY . ${PATH_TO_SRC}
 
@@ -15,6 +11,10 @@ WORKDIR ${PATH_TO_SRC}
 
 RUN make debug install
 
-ENTRYPOINT ["gdb", "-x", "gdbinit", "--args", "orionld", "-fg", "-multiservice", "-ngsiv1Autocast"]
+RUN mkdir -p /var/{log,run}/orionld
+
+ENV LD_LIBRARY_PATH=/opt/paho.mqtt.c/build/output:/usr/local/lib64:/opt/prometheus-client-c/prom/build:/opt/prometheus-client-c/promhttp/build:/usr/lib/x86_64-linux-gnu/
+
+ENTRYPOINT ["orionld", "-fg", "-multiservice" ]
 
 EXPOSE 1026

--- a/docker/Dockerfile-debug
+++ b/docker/Dockerfile-debug
@@ -11,8 +11,6 @@ WORKDIR ${PATH_TO_SRC}
 
 RUN make debug install
 
-RUN mkdir -p /var/{log,run}/orionld
-
 ENV LD_LIBRARY_PATH=/opt/paho.mqtt.c/build/output:/usr/local/lib64:/opt/prometheus-client-c/prom/build:/opt/prometheus-client-c/promhttp/build:/usr/lib/x86_64-linux-gnu/
 
 ENTRYPOINT ["orionld", "-fg", "-multiservice" ]

--- a/docker/Dockerfile-ubi
+++ b/docker/Dockerfile-ubi
@@ -36,7 +36,6 @@ LABEL authors="Ken Zangelin - ken.zangelin@fiware.org, Stefan Wiedemann - stefan
 
 ENV LD_LIBRARY_PATH=/opt/paho.mqtt.c/build/output:/usr/local/lib64:/opt/prometheus-client-c/prom/build:/opt/prometheus-client-c/promhttp/build:/usr/lib/x86_64-linux-gnu
 RUN echo LD_LIBRARY_PATH: $LD_LIBRARY_PATH
-RUN mkdir -p /var/{log,run}/orionld
 
 RUN mkdir /licenses
 COPY ./LICENSE /licenses/LICENSE


### PR DESCRIPTION
The dockerfile for debug (Dockerfile-debug) for some reason tried to start the broker inside gdb.
That's not what we want, there's another dockerfile for that (Dockerfile-gdb).
After fixing that problem I stumbled upon a few more problems, about shared libraries not found.
Added an LD_LIBRARY_PATH to solve that.
