### PR TITLE
CMakeLists.txt: use correct path to script in source dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ execute_process(COMMAND            echo $USER
                 OUTPUT_VARIABLE    USER)
 
 
-execute_process(COMMAND            sh ../scripts/build/osDistro.sh
+execute_process(COMMAND            sh ${CMAKE_SOURCE_DIR}/scripts/build/osDistro.sh
                 OUTPUT_VARIABLE    DISTRO)
 
 # TRACES: To remove LM_T


### PR DESCRIPTION
The CMakeLists.txt file currently assumes that the source dir is one level above the build dir, but this might not necessairily be the case. Instead of ../, use the official CMAKE_BUILD_DIR variable that references the directory where the CMakeLists.txt file is.

This avoids the following error when building, for example, with a cross build system like ptxdist, that knows about how to build any kind of CMake based project, and choses to put its build dir somewhere else:

  sh: 0: cannot open ../scripts/build/osDistro.sh: No such file

This fixes #1251.