### PR TITLE
CMakeLists.txt: make DISTRO overwritable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,9 +41,10 @@ execute_process(COMMAND            echo $USER
                 COMMAND            tr 'a-z' 'A-Z'
                 OUTPUT_VARIABLE    USER)
 
-
+if (NOT DISTRO)
 execute_process(COMMAND            sh ../scripts/build/osDistro.sh
                 OUTPUT_VARIABLE    DISTRO)
+endif (NOT DISTRO)
 
 # TRACES: To remove LM_T
 #           [ and 15 log macros more, of which only LM_T is used by the broker.


### PR DESCRIPTION
Make it possible to overwrite the DISTRO determined by the osDistro.sh script. With this patch it is possible to overwrite -DDISTRO=foo from the command line, which is is helpful for cross build systems like ptxdist.

Fixes #1253.