### PR TITLE
parseArgs: fix 32/64 bit compatiblity in formatstrings

### DIFF
--- a/src/lib/parseArgs/paLimitCheck.cpp
+++ b/src/lib/parseArgs/paLimitCheck.cpp
@@ -22,6 +22,8 @@
 *
 * Author: Ken Zangelin
 */
+#include <cinttypes>                  /* PRId64, PRIu64                      */
+
 #include <cstdlib>                    /* C++ free                            */
 
 #include "logMsg/logMsg.h"            /* lmVerbose, lmDebug, ...             */
@@ -172,8 +174,8 @@ static int limits(PaiArgument* paList, PaiArgument* aP)
                        aP->name, i64Val, aP->min, aP->max));
     if ((lower && (i64Val < aP->min)) || (upper && (i64Val > aP->max)))
     {
-      snprintf(valS, sizeof(valS), "%ld", i64Val);
-      snprintf(w, sizeof(w), "%ld <= %ld <= %ld (%s)",
+      snprintf(valS, sizeof(valS), "%" PRId64, i64Val);
+      snprintf(w, sizeof(w), "%" PRId64 " <= %" PRId64 " <= %" PRId64 " (%s)",
                aP->min,
                i64Val,
                aP->max,
@@ -186,8 +188,8 @@ static int limits(PaiArgument* paList, PaiArgument* aP)
                        aP->name, ui64Val, aP->min, aP->max));
     if ((lower && (uiVal < (uint64_t) aP->min)) || (upper && (uiVal > (uint64_t) aP->max)))
     {
-      snprintf(valS, sizeof(valS), "%lu", ui64Val);
-      snprintf(w, sizeof(w), "%lu <= %lu <= %lu (%s)",
+      snprintf(valS, sizeof(valS), "%" PRIu64, ui64Val);
+      snprintf(w, sizeof(w), "%" PRId64 " <= %" PRId64 " <= %" PRId64 " (%s)",
                aP->min,
                ui64Val,
                aP->max,

--- a/src/lib/parseArgs/paUsage.cpp
+++ b/src/lib/parseArgs/paUsage.cpp
@@ -22,6 +22,7 @@
 *
 * Author: developer
 */
+#include <cinttypes>                  /* PRId64, PRIu64                      */
 #include <stdlib.h>                   /* system                              */
 #include <unistd.h>                   /* getpid                              */
 #include <string>                     /* std::string                         */
@@ -166,10 +167,10 @@ static void getApVals
     break;
 
   case PaInt64:
-    snprintf(defVal,  defValLen,  "%ld", aP->def);
-    snprintf(minVal,  minValLen,  "%ld", aP->min);
-    snprintf(maxVal,  maxValLen,  "%ld", aP->max);
-    snprintf(realVal, realValLen, "%ld", *((int64_t*) aP->varP));
+    snprintf(defVal,  defValLen,  "%" PRId64, aP->def);
+    snprintf(minVal,  minValLen,  "%" PRId64, aP->min);
+    snprintf(maxVal,  maxValLen,  "%" PRId64, aP->max);
+    snprintf(realVal, realValLen, "%" PRId64, *((int64_t*) aP->varP));
     break;
 
   case PaIntU:
@@ -180,10 +181,10 @@ static void getApVals
     break;
 
   case PaIntU64:
-    snprintf(defVal,  defValLen,  "%lu", aP->def);
-    snprintf(minVal,  minValLen,  "%lu", aP->min);
-    snprintf(maxVal,  maxValLen,  "%lu", aP->max);
-    snprintf(realVal, realValLen, "%lu", *((uint64_t*) aP->varP));
+    snprintf(defVal,  defValLen,  "%" PRIu64, aP->def);
+    snprintf(minVal,  minValLen,  "%" PRIu64, aP->min);
+    snprintf(maxVal,  maxValLen,  "%" PRIu64, aP->max);
+    snprintf(realVal, realValLen, "%" PRIu64, *((uint64_t*) aP->varP));
     break;
 
   case PaShort:


### PR DESCRIPTION
Trying to print int64_t with `%ld` and uint64_t with `%lu` results in a compiler error:

```
error: format '%lu' expects argument of type 'long unsigned int', but argument N has type 'uint64_t' {aka 'long long unsigned int'}
```

when cross built for ARM 32 bit.

The correct way to print these types is with

```
  #include <cinttypes>
  ...
  printf("%" PRId64 "\n", var);
```

instead of `%ld` and

```
  printf("%" PRIu64 "\n", var);
```

instead of `%lu`.

Fixes #1255. 