### PR TITLE
hardening/3rd-party-prs

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -1,10 +1,7 @@
 name: Compliance Test
 
 on:
-  push:
   pull_request:
-    branches:
-      - develop
 
 jobs:
   compliance:

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -1,7 +1,6 @@
 name: Functional Test
 
 on:
-  push:
   pull_request:
 
 env:

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -2,6 +2,7 @@ name: Functional Test
 
 on:
   push:
+  pull_request:
 
 env:
   IMAGE_NAME: localhost:5000/orion-ld-test:latest

--- a/.github/workflows/mintaka-compatibility.yml
+++ b/.github/workflows/mintaka-compatibility.yml
@@ -1,7 +1,6 @@
 name: Test compatiblity to mintaka
 
 on:
-  push:
   pull_request:
 
 jobs:

--- a/.github/workflows/mintaka-compatibility.yml
+++ b/.github/workflows/mintaka-compatibility.yml
@@ -2,6 +2,7 @@ name: Test compatiblity to mintaka
 
 on:
   push:
+  pull_request:
 
 jobs:
   test-latest:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -2,6 +2,7 @@ name: Unit Test
 
 on:
   push:
+pull_request:  pull_request:
 
 env:
   IMAGE_NAME: localhost:5000/orion-ld-test:latest

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,8 +1,7 @@
 name: Unit Test
 
 on:
-  push:
-pull_request:  pull_request:
+  pull_request:
 
 env:
   IMAGE_NAME: localhost:5000/orion-ld-test:latest


### PR DESCRIPTION
Added the label "pull_request" in github actions for:
* func-tests
* unit-tests and
*  mintaka-compat-tests

Those three only had the label "push".

Hopefully, this fixes the problem with not running the tests for pull requests from forks.

And if not ... please help!!!
