### PR TITLE
CMakeLists.txt: update minimal required cmake version from 2.6 to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@
 # Project name and basic prerequisities
 #
 PROJECT(orionld)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 
 #
 # DEBUG or RELEASE build ?

--- a/CMakeLists.txt.orion
+++ b/CMakeLists.txt.orion
@@ -22,7 +22,7 @@
 # Project name and basic prerequisities
 #
 PROJECT(contextBroker)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 
 #
 # DEBUG or RELEASE build ?

--- a/CMakeLists.txt.orionld
+++ b/CMakeLists.txt.orionld
@@ -22,7 +22,7 @@
 # Project name and basic prerequisities
 #
 PROJECT(orionld)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 
 #
 # DEBUG or RELEASE build ?

--- a/archive/proxyCoap/src/app/CMakeLists.txt
+++ b/archive/proxyCoap/src/app/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     proxyCoap.cpp

--- a/src/lib/alarmMgr/CMakeLists.txt
+++ b/src/lib/alarmMgr/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     AlarmManager.cpp

--- a/src/lib/apiTypesV2/CMakeLists.txt
+++ b/src/lib/apiTypesV2/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     Entity.cpp

--- a/src/lib/cache/CMakeLists.txt
+++ b/src/lib/cache/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     subCache.cpp

--- a/src/lib/common/CMakeLists.txt
+++ b/src/lib/common/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     globals.cpp

--- a/src/lib/convenience/CMakeLists.txt
+++ b/src/lib/convenience/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     AppendContextElementRequest.cpp

--- a/src/lib/jsonParse/CMakeLists.txt
+++ b/src/lib/jsonParse/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     jsonRequest.cpp

--- a/src/lib/jsonParseV2/CMakeLists.txt
+++ b/src/lib/jsonParseV2/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     jsonRequestTreat.cpp

--- a/src/lib/logMsg/CMakeLists.txt
+++ b/src/lib/logMsg/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (HEADERS
 	logMsg.h

--- a/src/lib/logSummary/CMakeLists.txt
+++ b/src/lib/logSummary/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     logSummary.cpp

--- a/src/lib/metricsMgr/CMakeLists.txt
+++ b/src/lib/metricsMgr/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     MetricsManager.cpp

--- a/src/lib/mongoBackend/CMakeLists.txt
+++ b/src/lib/mongoBackend/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     MongoGlobal.cpp

--- a/src/lib/ngsi/CMakeLists.txt
+++ b/src/lib/ngsi/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     AttributeDomainName.cpp

--- a/src/lib/ngsi10/CMakeLists.txt
+++ b/src/lib/ngsi10/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     NotifyContextRequest.cpp

--- a/src/lib/ngsi9/CMakeLists.txt
+++ b/src/lib/ngsi9/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     RegisterContextRequest.cpp

--- a/src/lib/ngsiNotify/CMakeLists.txt
+++ b/src/lib/ngsiNotify/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     Notifier.cpp

--- a/src/lib/orionTypes/CMakeLists.txt
+++ b/src/lib/orionTypes/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     areas.cpp

--- a/src/lib/orionld/common/CMakeLists.txt
+++ b/src/lib/orionld/common/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # orionld at fiware dot org
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     orionldRequestSend.cpp

--- a/src/lib/orionld/context/CMakeLists.txt
+++ b/src/lib/orionld/context/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # orionld at fiware dot org
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     orionldCoreContext.cpp

--- a/src/lib/orionld/contextCache/CMakeLists.txt
+++ b/src/lib/orionld/contextCache/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # orionld at fiware dot org
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     orionldContextCache.cpp

--- a/src/lib/orionld/db/CMakeLists.txt
+++ b/src/lib/orionld/db/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # orionld at fiware dot org
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     dbInit.cpp

--- a/src/lib/orionld/dbModel/CMakeLists.txt
+++ b/src/lib/orionld/dbModel/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # orionld at fiware dot org
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     dbModelFromApiEntity.cpp

--- a/src/lib/orionld/kjTree/CMakeLists.txt
+++ b/src/lib/orionld/kjTree/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # orionld at fiware dot org
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     kjTreeFromQueryContextResponse.cpp

--- a/src/lib/orionld/legacyDriver/CMakeLists.txt
+++ b/src/lib/orionld/legacyDriver/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # orionld at fiware dot org
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     legacyPostSubscriptions.cpp

--- a/src/lib/orionld/mongoBackend/CMakeLists.txt
+++ b/src/lib/orionld/mongoBackend/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # orionld at fiware dot org
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     mongoEntityExists.cpp

--- a/src/lib/orionld/mongoCppLegacy/CMakeLists.txt
+++ b/src/lib/orionld/mongoCppLegacy/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # orionld at fiware dot org
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     mongoCppLegacyInit.cpp

--- a/src/lib/orionld/mongoc/CMakeLists.txt
+++ b/src/lib/orionld/mongoc/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # orionld at fiware dot org
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     mongocAttributeDelete.cpp

--- a/src/lib/orionld/mqtt/CMakeLists.txt
+++ b/src/lib/orionld/mqtt/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # orionld at fiware dot org
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     mqttCheck.cpp

--- a/src/lib/orionld/notifications/CMakeLists.txt
+++ b/src/lib/orionld/notifications/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # orionld at fiware dot org
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     orionldAlterations.cpp

--- a/src/lib/orionld/payloadCheck/CMakeLists.txt
+++ b/src/lib/orionld/payloadCheck/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # orionld at fiware dot org
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
      fieldPaths.cpp

--- a/src/lib/orionld/prometheus/CMakeLists.txt
+++ b/src/lib/orionld/prometheus/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # orionld at fiware dot org
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     promInit.cpp

--- a/src/lib/orionld/q/CMakeLists.txt
+++ b/src/lib/orionld/q/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # orionld at fiware dot org
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     QNode.cpp

--- a/src/lib/orionld/rest/CMakeLists.txt
+++ b/src/lib/orionld/rest/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # orionld at fiware dot org
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     orionldMhdConnectionInit.cpp

--- a/src/lib/orionld/serviceRoutines/CMakeLists.txt
+++ b/src/lib/orionld/serviceRoutines/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # orionld at fiware dot org
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     orionldPostEntities.cpp

--- a/src/lib/orionld/socketService/CMakeLists.txt
+++ b/src/lib/orionld/socketService/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # orionld at fiware dot org
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     socketServiceInit.cpp

--- a/src/lib/orionld/troe/CMakeLists.txt
+++ b/src/lib/orionld/troe/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # orionld at fiware dot org
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     troe.cpp

--- a/src/lib/orionld/types/CMakeLists.txt
+++ b/src/lib/orionld/types/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # orionld at fiware dot org
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     OrionldProblemDetails.cpp

--- a/src/lib/parse/CMakeLists.txt
+++ b/src/lib/parse/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     CompoundValueNode.cpp

--- a/src/lib/rest/CMakeLists.txt
+++ b/src/lib/rest/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
     rest.cpp

--- a/src/lib/serviceRoutines/CMakeLists.txt
+++ b/src/lib/serviceRoutines/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
 versionTreat.cpp

--- a/src/lib/serviceRoutinesV2/CMakeLists.txt
+++ b/src/lib/serviceRoutinesV2/CMakeLists.txt
@@ -18,7 +18,7 @@
 # For those usages not covered by this license please contact with
 # iot_support at tid dot es
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 SET (SOURCES
 getEntities.cpp


### PR DESCRIPTION
Without this patch we get lots lof warnings like this one:

```
CMake Deprecation Warning at src/lib/metricsMgr/CMakeLists.txt:21 (CMAKE_MINIMUM_REQUIRED):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.

```
Ubuntu 16.04 has cmake 3.5, even Debian old-old-stable has 3.7, so 3.5 should be a sane default.