### PR TITLE
Eliminate some warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ ELSEIF (${DISTRO} MATCHES "Debian_9.*")
 ELSEIF (${DISTRO} MATCHES "RedHat_8.*")
   set (CMAKE_CXX_FLAGS "-Wall -Wno-unknown-pragmas -D_LARGEFILE64_SOURCE -DREDHAT_UBI=8.4 -D_GNU_SOURCE -Werror -Wno-deprecated-declarations -fno-var-tracking-assignments")
 ELSE()
-  set (CMAKE_CXX_FLAGS "-Wall -Wno-unknown-pragmas -D_LARGEFILE64_SOURCE -D_GNU_SOURCE -Werror -Wno-deprecated-declarations -fno-var-tracking-assignments")
+  set (CMAKE_CXX_FLAGS "-Wall -Wno-unknown-pragmas -D_LARGEFILE64_SOURCE -D_GNU_SOURCE -Werror -Wno-deprecated-declarations -Wno-psabi -fno-var-tracking-assignments")
 ENDIF ()
 
 #

--- a/src/lib/ngsi/Scope.cpp
+++ b/src/lib/ngsi/Scope.cpp
@@ -681,7 +681,7 @@ std::string Scope::check(void)
       {
         char noOfV[STRING_SIZE_FOR_INT];
 
-        snprintf(noOfV, sizeof(noOfV), "%lu", polygon.vertexList.size());
+        snprintf(noOfV, sizeof(noOfV), "%zu", polygon.vertexList.size());
         std::string details = std::string("too few vertices for a polygon (") + noOfV + " is less than three)";
         alarmMgr.badInput(clientIp, details);
 

--- a/src/lib/orionld/rest/OrionLdRestService.h
+++ b/src/lib/orionld/rest/OrionLdRestService.h
@@ -147,10 +147,10 @@ typedef struct OrionLdRestServiceSimplifiedVector
 #define ORIONLD_URIPARAM_NOTEXISTS            (1 << 29)
 #define ORIONLD_URIPARAM_RELATIONSHIPS        (1 << 30)
 #define ORIONLD_URIPARAM_GEOPROPERTIES        (1 << 31)
-#define ORIONLD_URIPARAM_LANGUAGEPROPERTIES   (1UL << 32)
-#define ORIONLD_URIPARAM_OBSERVEDAT           (1UL << 33)
-#define ORIONLD_URIPARAM_LANG                 (1UL << 34)
-#define ORIONLD_URIPARAM_LOCAL                (1UL << 35)
+#define ORIONLD_URIPARAM_LANGUAGEPROPERTIES   (UINT64_C(1) << 32)
+#define ORIONLD_URIPARAM_OBSERVEDAT           (UINT64_C(1) << 33)
+#define ORIONLD_URIPARAM_LANG                 (UINT64_C(1) << 34)
+#define ORIONLD_URIPARAM_LOCAL                (UINT64_C(1) << 35)
 
 
 

--- a/src/lib/rest/RestService.cpp
+++ b/src/lib/rest/RestService.cpp
@@ -237,7 +237,7 @@ std::string tenantCheck(const std::string& tenant)
     char numV2[STRING_SIZE_FOR_LONG];
 
     snprintf(numV1, sizeof(numV1), "%d",  SERVICE_NAME_MAX_LEN);
-    snprintf(numV2, sizeof(numV2), "%lu", strlen(name));
+    snprintf(numV2, sizeof(numV2), "%zu", strlen(name));
 
     std::string details = std::string("a tenant name can be max ") + numV1 + " characters long. Length: " + numV2;
     alarmMgr.badInput(clientIp, details);

--- a/src/lib/rest/httpHeaderAdd.cpp
+++ b/src/lib/rest/httpHeaderAdd.cpp
@@ -92,7 +92,7 @@ void httpHeaderLinkAdd(const char* _url)
   }
 
   urlLen = strlen(url);
-  if (urlLen > sizeof(link) + LINK_REL_AND_TYPE_SIZE + 5)
+  if (urlLen + LINK_REL_AND_TYPE_SIZE + 5 > sizeof(link))
   {
     linkP = (char*) malloc(urlLen + LINK_REL_AND_TYPE_SIZE + 5);
     if (linkP == NULL)

--- a/src/lib/rest/httpHeaderAdd.cpp
+++ b/src/lib/rest/httpHeaderAdd.cpp
@@ -92,6 +92,15 @@ void httpHeaderLinkAdd(const char* _url)
   }
 
   urlLen = strlen(url);
+
+  // make sure we don't sprintf() more than INT_MAX chars
+  // (which is what sprintf() can handle)
+  if (urlLen + LINK_REL_AND_TYPE_SIZE + 5 > INT_MAX)
+  {
+    LM_E(("Cannot add URL with > INT_MAX"));
+    return;
+  }
+
   if (urlLen + LINK_REL_AND_TYPE_SIZE + 5 > sizeof(link))
   {
     linkP = (char*) malloc(urlLen + LINK_REL_AND_TYPE_SIZE + 5);

--- a/src/lib/serviceRoutines/postSubscribeContext.cpp
+++ b/src/lib/serviceRoutines/postSubscribeContext.cpp
@@ -72,7 +72,7 @@ std::string postSubscribeContext
   if (ciP->servicePathV.size() > 1)
   {
     char  noOfV[STRING_SIZE_FOR_LONG + 3];
-    snprintf(noOfV, sizeof(noOfV) - 1, "%lu", ciP->servicePathV.size());
+    snprintf(noOfV, sizeof(noOfV) - 1, "%zu", ciP->servicePathV.size());
     orionldState.httpStatusCode   = SccOk;  // NGSIv1 is weird... it uses 200 OK at HTTP level for errors
     std::string details           = std::string("max *one* service-path allowed for subscriptions (") + noOfV + " given";
 


### PR DESCRIPTION
While trying to cross compile orion-ld I stumbled about a bunch of warnings.

Please review the patches carefully, as I'm not entirely sure I understood the issues correctly.