### PR TITLE
Fix json syntax on documentation

### DIFF
--- a/doc/manuals-ld/entities-and-attributes.md
+++ b/doc/manuals-ld/entities-and-attributes.md
@@ -36,7 +36,7 @@ The **value** is *mandatory* inside a property and it can be of any JSON type ex
 This is how a very simple Property _P1_ is expressed in JSON (P1 inside the entity _urn:entities:E1_):
 ```json
 {
-  "id: "urn:entities:E1",
+  "id": "urn:entities:E1",
   "type": "T",
   "P1": {
     "type": "Property",
@@ -61,7 +61,7 @@ $ curl localhost:1026//ngsi-ld/v1/entities -d "$payloadData"
 Here a somewhat more complex example - an attribute *P1 with a _compound value_ and one sub-attribute *P11* (a Property):
 ```json
 {
-  "id: "urn:entities:E1",
+  "id": "urn:entities:E1",
   "type": "T",
   "P1": {
     "type": "Property",
@@ -90,7 +90,7 @@ The second type of attributes, _relationships_, contain information on how an en
 An example entity with a *Relationship*: 
 ```json
 {
-  "id: "urn:entities:anura:E1",
+  "id": "urn:entities:anura:E1",
   "type": "T",
   "Cousin": {
     "type": "Relationship",


### PR DESCRIPTION
## Proposed changes

There is a typo error on some json on the documentation.

## Types of changes

-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/FIWARE/context.Orion-LD/blob/master/CONTRIBUTING.md) doc
-   [x] I have signed the [CLA](https://fiware.github.io/contribution-requirements/individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules
