### PR TITLE
Hardening/postgis astext format change

### DIFF
--- a/test/functionalTest/cases/0000_troe/troe_geo_multipoint.test
+++ b/test/functionalTest/cases/0000_troe/troe_geo_multipoint.test
@@ -128,7 +128,7 @@ Create,urn:ngsi-ld:entities:E1,https://uri.etsi.org/ngsi-ld/default-context/T
 03. See the attributes in the temporal database
 ===============================================
 opmode,id,valuetype,entityid,subproperties,unitcode,datasetid,st_astext,observedat
-Create,location,GeoMultiPoint,urn:ngsi-ld:entities:E1,f,,None,"MULTIPOINT Z (1 2 0,4 5 0)",
+Create,location,GeoMultiPoint,urn:ngsi-ld:entities:E1,f,,None,"MULTIPOINT Z REGEX((\(1 2 0,4 5 0\)|\(\(1 2 0\),\(4 5 0\)\)))",
 
 
 04. See the sub-attributes in the temporal database
@@ -169,13 +169,13 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http:/
 06. GET the attribute from TRoE
 ===============================
 id,valuetype,entityid,id,unitcode,st_astext,observedat
-location,GeoMultiPoint,urn:ngsi-ld:entities:E1,location,,"MULTIPOINT Z (1 2 0,4 5 0)",
+location,GeoMultiPoint,urn:ngsi-ld:entities:E1,location,,"MULTIPOINT Z REGEX((\(1 2 0,4 5 0\)|\(\(1 2 0\),\(4 5 0\)\)))",
 
 
 07. GET the attribute from TRoE using postgis
 =============================================
 valuetype,entityid,id,unitcode,st_astext,observedat
-GeoMultiPoint,urn:ngsi-ld:entities:E1,location,,"MULTIPOINT Z (1 2 0,4 5 0)",
+GeoMultiPoint,urn:ngsi-ld:entities:E1,location,,"MULTIPOINT Z REGEX((\(1 2 0,4 5 0\)|\(\(1 2 0\),\(4 5 0\)\)))",
 
 
 08. GET nothing from TRoE using postgis

--- a/test/functionalTest/cases/0000_troe/troe_geo_multipoint_3D.test
+++ b/test/functionalTest/cases/0000_troe/troe_geo_multipoint_3D.test
@@ -128,7 +128,7 @@ Create,urn:ngsi-ld:entities:E1,https://uri.etsi.org/ngsi-ld/default-context/T
 03. See the attributes in the temporal database
 ===============================================
 opmode,id,valuetype,entityid,subproperties,unitcode,datasetid,st_astext,observedat
-Create,location,GeoMultiPoint,urn:ngsi-ld:entities:E1,f,,None,"MULTIPOINT Z (1 2 3,4 5 6)",
+Create,location,GeoMultiPoint,urn:ngsi-ld:entities:E1,f,,None,"MULTIPOINT Z REGEX((\(1 2 3,4 5 6\)|\(\(1 2 3\),\(4 5 6\)\)))",
 
 
 04. See the sub-attributes in the temporal database
@@ -171,13 +171,13 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http:/
 06. GET the attribute from TRoE
 ===============================
 id,valuetype,entityid,id,unitcode,st_astext,observedat
-location,GeoMultiPoint,urn:ngsi-ld:entities:E1,location,,"MULTIPOINT Z (1 2 3,4 5 6)",
+location,GeoMultiPoint,urn:ngsi-ld:entities:E1,location,,"MULTIPOINT Z REGEX((\(1 2 3,4 5 6\)|\(\(1 2 3\),\(4 5 6\)\)))",
 
 
 07. GET the attribute from TRoE using postgis
 =============================================
 valuetype,entityid,id,unitcode,st_astext,observedat
-GeoMultiPoint,urn:ngsi-ld:entities:E1,location,,"MULTIPOINT Z (1 2 3,4 5 6)",
+GeoMultiPoint,urn:ngsi-ld:entities:E1,location,,"MULTIPOINT Z REGEX((\(1 2 3,4 5 6\)|\(\(1 2 3\),\(4 5 6\)\)))",
 
 
 08. GET nothing from TRoE using postgis

--- a/test/functionalTest/cases/0000_troe/troe_geo_sub_multipoint.test
+++ b/test/functionalTest/cases/0000_troe/troe_geo_sub_multipoint.test
@@ -133,7 +133,7 @@ Create,https://uri.etsi.org/ngsi-ld/default-context/A1,Number,urn:ngsi-ld:entiti
 04. See the sub-attributes in the temporal database
 ===================================================
 id,valuetype,entityid,unitcode,st_astext,observedat
-https://uri.etsi.org/ngsi-ld/default-context/mPoint,GeoMultiPoint,urn:ngsi-ld:entities:E1,,"MULTIPOINT Z (1 2 0,4 5 0)",2021-01-08 13:15:17.456
+https://uri.etsi.org/ngsi-ld/default-context/mPoint,GeoMultiPoint,urn:ngsi-ld:entities:E1,,"MULTIPOINT Z REGEX((\(1 2 0,4 5 0\)|\(\(1 2 0\),\(4 5 0\)\)))",2021-01-08 13:15:17.456
 
 
 05. GET the entity
@@ -175,7 +175,7 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http:/
 06. GET the sub-attributes from TRoE using postgis
 ==================================================
 id,valuetype,entityid,unitcode,st_astext,observedat
-https://uri.etsi.org/ngsi-ld/default-context/mPoint,GeoMultiPoint,urn:ngsi-ld:entities:E1,,"MULTIPOINT Z (1 2 0,4 5 0)",2021-01-08 13:15:17.456
+https://uri.etsi.org/ngsi-ld/default-context/mPoint,GeoMultiPoint,urn:ngsi-ld:entities:E1,,"MULTIPOINT Z REGEX((\(1 2 0,4 5 0\)|\(\(1 2 0\),\(4 5 0\)\)))",2021-01-08 13:15:17.456
 
 
 07. GET nothing from TRoE using postgis

--- a/test/functionalTest/cases/0000_troe/troe_geo_sub_multipoint_3D.test
+++ b/test/functionalTest/cases/0000_troe/troe_geo_sub_multipoint_3D.test
@@ -133,7 +133,7 @@ Create,https://uri.etsi.org/ngsi-ld/default-context/A1,Number,urn:ngsi-ld:entiti
 04. See the sub-attributes in the temporal database
 ===================================================
 id,valuetype,entityid,unitcode,st_astext,observedat
-https://uri.etsi.org/ngsi-ld/default-context/mPoint,GeoMultiPoint,urn:ngsi-ld:entities:E1,,"MULTIPOINT Z (1 2 3,4 5 6)",2021-01-08 13:15:17.456
+https://uri.etsi.org/ngsi-ld/default-context/mPoint,GeoMultiPoint,urn:ngsi-ld:entities:E1,,"MULTIPOINT Z REGEX((\(1 2 3,4 5 6\)|\(\(1 2 3\),\(4 5 6\)\)))",2021-01-08 13:15:17.456
 
 
 05. GET the entity
@@ -177,7 +177,7 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http:/
 06. GET the sub-attributes from TRoE using postgis
 ==================================================
 id,valuetype,entityid,unitcode,st_astext,observedat
-https://uri.etsi.org/ngsi-ld/default-context/mPoint,GeoMultiPoint,urn:ngsi-ld:entities:E1,,"MULTIPOINT Z (1 2 3,4 5 6)",2021-01-08 13:15:17.456
+https://uri.etsi.org/ngsi-ld/default-context/mPoint,GeoMultiPoint,urn:ngsi-ld:entities:E1,,"MULTIPOINT Z REGEX((\(1 2 3,4 5 6\)|\(\(1 2 3\),\(4 5 6\)\)))",2021-01-08 13:15:17.456
 
 
 07. GET nothing from TRoE using postgis


### PR DESCRIPTION
The output from postgis (geo multipoint astext) has changed in my local machine, and it now differs from the output in github actions.
Both formats are "correct", even though the format in github actions is considered a bug.
```
MULTIPOINT ((1 2), (3 4))
# vs
MULTIPOINT (1 2, 3 4)
```
The first format (each Point within parenthesis) is considered the correct format, and that's how it is now in my local machine.

See this issue in [github](https://github.com/r-spatial/sf/issues/1219) for more information.

To deal with these two different formats, as the functest suite deals with EXACT comparisons, I had to add a REGEX to accept both formats, in 4 troe functests.
