### PR TITLE
hardening/local-contexts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: SonarCloud
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  build:
+    name: Build and analyze
+    runs-on: ubuntu-latest
+    env:
+      BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Install sonar-scanner and build-wrapper
+        uses: SonarSource/sonarcloud-github-c-cpp@v1
+      - name: Run build-wrapper
+        run: |
+          build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} make clean
+      - name: Run sonar-scanner
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          sonar-scanner --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"

--- a/scripts/check_files_compliance.py
+++ b/scripts/check_files_compliance.py
@@ -158,6 +158,10 @@ def ignore(root, file):
     if 'heavyTest' in root and (file.endswith('.json') or file.endswith('.xml')):
         return True
 
+    # JSONLD files in test/functionalTest/contexts are not processed
+    if 'contexts' in root and file.endswith('.jsonld'):
+        return True
+
     # Some files in docker/ directory are not processed
     if 'docker' in root and file in ['Dockerfile', 'Dockerfile-base', 'Dockerfile-ubi-base', 'Dockerfile-ubi', 'Dockerfile-test', 'Dockerfile-debug', 'Dockerfile-gdb', 'gdbinit', 'docker-compose.yml', 'subscription-manager.conf', 'ubi.repo']:
         return True

--- a/scripts/check_files_compliance.py
+++ b/scripts/check_files_compliance.py
@@ -158,7 +158,7 @@ def ignore(root, file):
     if 'heavyTest' in root and (file.endswith('.json') or file.endswith('.xml')):
         return True
 
-    # JSONLD files in test/functionalTest/contexts are not processed
+    # JSONLD files in test/functionalTest/contexts are not processed - they can't have the Copyright header
     if 'contexts' in root and file.endswith('.jsonld'):
         return True
 

--- a/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
@@ -36,7 +36,6 @@ extern "C"
 
 #include "orionld/common/orionldState.h"                         // orionldState
 #include "orionld/common/orionldError.h"                         // orionldError
-#include "orionld/common/curlToBrokerStrerror.h"                 // curlToBrokerStrerror
 #include "orionld/common/tenantList.h"                           // tenant0
 #include "orionld/context/orionldEntityExpand.h"                 // orionldEntityExpand
 #include "orionld/context/orionldEntityCompact.h"                // orionldEntityCompact
@@ -172,6 +171,7 @@ bool orionldGetEntity(void)
 
   KjNode* dbEntityP  = mongocEntityLookup(entityId, &orionldState.in.attrList, orionldState.uriParams.geometryProperty);
   KjNode* apiEntityP = NULL;
+
   if (dbEntityP == NULL)
   {
     if (forwards == 0)

--- a/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert-many-geoproperties.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert-many-geoproperties.test
@@ -68,7 +68,7 @@ payload='[
       "observedAt": "2020-04-06T20:40:02.260Z"
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ]
   },
@@ -100,7 +100,7 @@ payload='[
       "observedAt": "2020-04-06T20:40:02.260Z"
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ]
   }
@@ -112,7 +112,7 @@ echo
 
 echo "02. GET the entities"
 echo "===================="
-orionCurl --url '/ngsi-ld/v1/entities?type=GtfsStation&options=keyValues' -H 'Link: <https://schema.lab.fiware.org/ld/context>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+orionCurl --url '/ngsi-ld/v1/entities?type=GtfsStation&options=keyValues' -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -149,7 +149,7 @@ payload='[
       "observedAt": "2020-04-06T20:40:02.260Z"
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ]
   },
@@ -181,7 +181,7 @@ payload='[
       "observedAt": "2020-04-06T20:40:02.260Z"
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ]
   }
@@ -193,7 +193,7 @@ echo
 
 echo "04. GET the entities"
 echo "===================="
-orionCurl --url '/ngsi-ld/v1/entities?type=GtfsStation&options=keyValues' -H 'Link: <https://schema.lab.fiware.org/ld/context>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+orionCurl --url '/ngsi-ld/v1/entities?type=GtfsStation&options=keyValues' -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -218,7 +218,7 @@ HTTP/1.1 200 OK
 Content-Length: 547
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://schema.lab.fiware.org/ld/context>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 [
 #SORT_START
@@ -281,7 +281,7 @@ HTTP/1.1 200 OK
 Content-Length: 805
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://schema.lab.fiware.org/ld/context>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 [
 #SORT_START

--- a/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert_and_contexts.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert_and_contexts.test
@@ -70,7 +70,7 @@ payload='[
       }
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ],
     "id": "urn:ngsi-ld:WeatherObserved:BMP180:22828",
@@ -110,7 +110,7 @@ payload='[
       }
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ],
     "id": "urn:ngsi-ld:WeatherObserved:BMP180:15333",
@@ -150,7 +150,7 @@ payload='[
       }
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ],
     "id": "urn:ngsi-ld:WeatherObserved:BMP180:25514",
@@ -190,7 +190,7 @@ payload='[
       }
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ],
     "id": "urn:ngsi-ld:WeatherObserved:BMP180:18219",
@@ -230,7 +230,7 @@ payload='[
       }
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ],
     "id": "urn:ngsi-ld:WeatherObserved:BMP180:16956",
@@ -269,7 +269,7 @@ echo
 
 echo "03. Get the entities"
 echo "===================="
-orionCurl --url '/ngsi-ld/v1/entities?type=WeatherObserved&prettyPrint=yes' -H 'Link: <https://schema.lab.fiware.org/ld/context>; ""' -H 'Fiware-Service: smartmaas001' --noPayloadCheck
+orionCurl --url '/ngsi-ld/v1/entities?type=WeatherObserved&prettyPrint=yes' -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; ""' -H 'Fiware-Service: smartmaas001' --noPayloadCheck
 echo
 echo
 
@@ -309,7 +309,7 @@ payload='[
       }
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ],
     "id": "urn:ngsi-ld:WeatherObserved:BMP180:22828",
@@ -349,7 +349,7 @@ payload='[
       }
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ],
     "id": "urn:ngsi-ld:WeatherObserved:BMP180:15333",
@@ -389,7 +389,7 @@ payload='[
       }
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ],
     "id": "urn:ngsi-ld:WeatherObserved:BMP180:25514",
@@ -429,7 +429,7 @@ payload='[
       }
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ],
     "id": "urn:ngsi-ld:WeatherObserved:BMP180:18219",
@@ -469,7 +469,7 @@ payload='[
       }
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ],
     "id": "urn:ngsi-ld:WeatherObserved:BMP180:16956",
@@ -495,7 +495,7 @@ echo
 
 echo "06. Get the entities"
 echo "===================="
-orionCurl --url '/ngsi-ld/v1/entities?type=WeatherObserved&prettyPrint=yes' -H 'Link: <https://schema.lab.fiware.org/ld/context>; ""' -H 'Fiware-Service: smartmaas001' --noPayloadCheck
+orionCurl --url '/ngsi-ld/v1/entities?type=WeatherObserved&prettyPrint=yes' -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; ""' -H 'Fiware-Service: smartmaas001' --noPayloadCheck
 echo
 echo
 
@@ -537,7 +537,7 @@ HTTP/1.1 200 OK
 Content-Length: 4161
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://schema.lab.fiware.org/ld/context>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 [
   {
@@ -727,7 +727,7 @@ Link: <https://schema.lab.fiware.org/ld/context>; rel="http://www.w3.org/ns/json
 04. Get all contexts from the context cache
 ===========================================
 HTTP/1.1 200 OK
-Content-Length: 1596
+Content-Length: 1632
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -763,7 +763,7 @@ Date: REGEX(.*)
     }
   },
   {
-    "url": "https://schema.lab.fiware.org/ld/context",
+    "url": "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
     "id": "REGEX(.*)",
     "type": "array",
     "origin": "Downloaded",
@@ -792,7 +792,7 @@ HTTP/1.1 200 OK
 Content-Length: 4161
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://schema.lab.fiware.org/ld/context>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 [
   {
@@ -982,7 +982,7 @@ Link: <https://schema.lab.fiware.org/ld/context>; rel="http://www.w3.org/ns/json
 07. Get all contexts from the context cache
 ===========================================
 HTTP/1.1 200 OK
-Content-Length: 1596
+Content-Length: 1632
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -1018,7 +1018,7 @@ Date: REGEX(.*)
     }
   },
   {
-    "url": "https://schema.lab.fiware.org/ld/context",
+    "url": "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
     "id": "REGEX(.*)",
     "type": "array",
     "origin": "Downloaded",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert_crash_with_and_without_link_header.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert_crash_with_and_without_link_header.test
@@ -67,7 +67,7 @@ payload='[
             }
         },
         "@context": [
-            "https://schema.lab.fiware.org/ld/context",
+            "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
             "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
         ],
         "id": "urn:ngsi-ld:WeatherObserved:BMP180:22828",
@@ -116,7 +116,7 @@ payload='[
             }
         },
         "@context": [
-            "https://schema.lab.fiware.org/ld/context",
+            "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
             "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
         ],
         "id": "urn:ngsi-ld:WeatherObserved:BMP180:22828",
@@ -132,7 +132,7 @@ payload='[
         }
     }
 ]'
-orionCurl --url '/ngsi-ld/v1/entityOperations/upsert?prettyPrint=yes' --payload "$payload" --noPayloadCheck -H 'Fiware-Service: smartmaas001' --in jsonld  -H "Fiware-Servicepath: /" -H 'Link: <https://schema.lab.fiware.org/ld/context>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' 
+orionCurl --url '/ngsi-ld/v1/entityOperations/upsert?prettyPrint=yes' --payload "$payload" --noPayloadCheck -H 'Fiware-Service: smartmaas001' --in jsonld  -H "Fiware-Servicepath: /" -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' 
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0392.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0392.test
@@ -59,7 +59,7 @@ payload='{
     "observedAt": "2020-03-02T16:31:13.124Z"
   },
   "@context": [
-    "https://schema.lab.fiware.org/ld/context",
+    "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
     "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
   ]
 }'

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0393.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0393.test
@@ -63,7 +63,7 @@ payload=' [
       "object": "urn:ngsi-ld:PointOfInterest:RZ:HarbourDistrict"
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ]
   }
@@ -107,7 +107,7 @@ payload=' [
       "object": "urn:ngsi-ld:PointOfInterest:RZ:HarbourDistrict"
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ]
   }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0457.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0457.test
@@ -112,7 +112,7 @@ payload='[
   }
 ]'
 orionCurl --url '/ngsi-ld/v1/entityOperations/upsert?prettyPrint=yes' --payload "$payload" -H 'Fiware-Service: smartmaas001' -H 'Content-Type: application/json' -H 'fiware-service: smartmaas001' -H 'fiware-servicepath: /' \
--H 'Link: <https://schema.lab.fiware.org/ld/context>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' -H 'Content-Type: application/json' --noPayloadCheck
+-H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' -H 'Content-Type: application/json' --noPayloadCheck
 echo
 echo
 
@@ -128,7 +128,7 @@ echo
 echo "03. Update the 2 entities, with the exact same payload"
 echo "======================================================"
 orionCurl --url '/ngsi-ld/v1/entityOperations/upsert?prettyPrint=yes' --payload "$payload" -H 'Fiware-Service: smartmaas001' -H 'Content-Type: application/json' -H 'fiware-service: smartmaas001' -H 'fiware-servicepath: /' \
--H 'Link: <https://schema.lab.fiware.org/ld/context>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' -H 'Content-Type: application/json' --noPayloadCheck
+-H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' -H 'Content-Type: application/json' --noPayloadCheck
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_batch_upsert-many-geoproperties.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_batch_upsert-many-geoproperties.test
@@ -69,7 +69,7 @@ payload='[
       "observedAt": "2020-04-06T20:40:02.260Z"
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ]
   },
@@ -101,7 +101,7 @@ payload='[
       "observedAt": "2020-04-06T20:40:02.260Z"
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ]
   }
@@ -113,7 +113,7 @@ echo
 
 echo "02. GET the entities"
 echo "===================="
-orionCurl --url '/ngsi-ld/v1/entities?type=GtfsStation&options=keyValues' -H 'Link: <https://schema.lab.fiware.org/ld/context>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+orionCurl --url '/ngsi-ld/v1/entities?type=GtfsStation&options=keyValues' -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -150,7 +150,7 @@ payload='[
       "observedAt": "2020-04-06T20:40:02.260Z"
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ]
   },
@@ -182,7 +182,7 @@ payload='[
       "observedAt": "2020-04-06T20:40:02.260Z"
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ]
   }
@@ -194,7 +194,7 @@ echo
 
 echo "04. GET the entities"
 echo "===================="
-orionCurl --url '/ngsi-ld/v1/entities?type=GtfsStation&options=keyValues' -H 'Link: <https://schema.lab.fiware.org/ld/context>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+orionCurl --url '/ngsi-ld/v1/entities?type=GtfsStation&options=keyValues' -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -219,7 +219,7 @@ HTTP/1.1 200 OK
 Content-Length: 547
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://schema.lab.fiware.org/ld/context>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 [
 #SORT_START
@@ -278,7 +278,7 @@ HTTP/1.1 200 OK
 Content-Length: 805
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://schema.lab.fiware.org/ld/context>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 [
 #SORT_START

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_batch_upsert_and_attr_creDate.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_batch_upsert_and_attr_creDate.test
@@ -48,7 +48,7 @@ payload='[
       "value": "sensor.community"
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ]
   }
@@ -76,7 +76,7 @@ payload='[
       "value": "sensor.community"
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ]
   }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_batch_upsert_and_contexts.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_batch_upsert_and_contexts.test
@@ -72,7 +72,7 @@ payload='[
       }
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ],
     "id": "urn:ngsi-ld:WeatherObserved:BMP180:22828",
@@ -112,7 +112,7 @@ payload='[
       }
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ],
     "id": "urn:ngsi-ld:WeatherObserved:BMP180:15333",
@@ -152,7 +152,7 @@ payload='[
       }
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ],
     "id": "urn:ngsi-ld:WeatherObserved:BMP180:25514",
@@ -192,7 +192,7 @@ payload='[
       }
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ],
     "id": "urn:ngsi-ld:WeatherObserved:BMP180:18219",
@@ -232,7 +232,7 @@ payload='[
       }
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ],
     "id": "urn:ngsi-ld:WeatherObserved:BMP180:16956",
@@ -278,7 +278,7 @@ echo
 
 echo "03. Get the entities"
 echo "===================="
-orionCurl --url '/ngsi-ld/v1/entities?type=WeatherObserved&prettyPrint=yes' -H 'Link: <https://schema.lab.fiware.org/ld/context>; ""' -H 'Fiware-Service: smartmaas001' --noPayloadCheck
+orionCurl --url '/ngsi-ld/v1/entities?type=WeatherObserved&prettyPrint=yes' -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; ""' -H 'Fiware-Service: smartmaas001' --noPayloadCheck
 echo
 echo
 
@@ -318,7 +318,7 @@ payload='[
       }
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ],
     "id": "urn:ngsi-ld:WeatherObserved:BMP180:22828",
@@ -358,7 +358,7 @@ payload='[
       }
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ],
     "id": "urn:ngsi-ld:WeatherObserved:BMP180:15333",
@@ -398,7 +398,7 @@ payload='[
       }
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ],
     "id": "urn:ngsi-ld:WeatherObserved:BMP180:25514",
@@ -438,7 +438,7 @@ payload='[
       }
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ],
     "id": "urn:ngsi-ld:WeatherObserved:BMP180:18219",
@@ -478,7 +478,7 @@ payload='[
       }
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ],
     "id": "urn:ngsi-ld:WeatherObserved:BMP180:16956",
@@ -502,7 +502,7 @@ echo
 
 echo "06. Get the entities"
 echo "===================="
-orionCurl --url '/ngsi-ld/v1/entities?type=WeatherObserved&prettyPrint=yes' -H 'Link: <https://schema.lab.fiware.org/ld/context>; ""' -H 'Fiware-Service: smartmaas001' --noPayloadCheck
+orionCurl --url '/ngsi-ld/v1/entities?type=WeatherObserved&prettyPrint=yes' -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; ""' -H 'Fiware-Service: smartmaas001' --noPayloadCheck
 echo
 echo
 
@@ -641,7 +641,7 @@ HTTP/1.1 200 OK
 Content-Length: 4161
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://schema.lab.fiware.org/ld/context>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 [
   {
@@ -831,7 +831,7 @@ Link: <https://schema.lab.fiware.org/ld/context>; rel="http://www.w3.org/ns/json
 04. Get all contexts from the context cache
 ===========================================
 HTTP/1.1 200 OK
-Content-Length: 1595
+Content-Length: 1631
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -867,7 +867,7 @@ Date: REGEX(.*)
     }
   },
   {
-    "url": "https://schema.lab.fiware.org/ld/context",
+    "url": "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
     "id": "REGEX(.*)",
     "type": "array",
     "origin": "Downloaded",
@@ -896,7 +896,7 @@ HTTP/1.1 200 OK
 Content-Length: 4161
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://schema.lab.fiware.org/ld/context>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 [
   {
@@ -1176,7 +1176,7 @@ bye
 07. Get all contexts from the context cache
 ===========================================
 HTTP/1.1 200 OK
-Content-Length: 1596
+Content-Length: 1632
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -1212,7 +1212,7 @@ Date: REGEX(.*)
     }
   },
   {
-    "url": "https://schema.lab.fiware.org/ld/context",
+    "url": "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
     "id": "REGEX(.*)",
     "type": "array",
     "origin": "Downloaded",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_issue_0393.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_issue_0393.test
@@ -64,7 +64,7 @@ payload=' [
       "object": "urn:ngsi-ld:PointOfInterest:RZ:HarbourDistrict"
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ]
   }
@@ -108,7 +108,7 @@ payload=' [
       "object": "urn:ngsi-ld:PointOfInterest:RZ:HarbourDistrict"
     },
     "@context": [
-      "https://schema.lab.fiware.org/ld/context",
+      "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
       "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ]
   }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_issue_0457.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_issue_0457.test
@@ -113,7 +113,7 @@ payload='[
   }
 ]'
 orionCurl --url '/ngsi-ld/v1/entityOperations/upsert?prettyPrint=yes' --payload "$payload" -H 'Fiware-Service: smartmaas001' -H 'Content-Type: application/json' -H 'fiware-service: smartmaas001' -H 'fiware-servicepath: /' \
--H 'Link: <https://schema.lab.fiware.org/ld/context>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' -H 'Content-Type: application/json' --noPayloadCheck
+-H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' -H 'Content-Type: application/json' --noPayloadCheck
 echo
 echo
 
@@ -129,7 +129,7 @@ echo
 echo "03. Update the 2 entities, with the exact same payload"
 echo "======================================================"
 orionCurl --url '/ngsi-ld/v1/entityOperations/upsert?prettyPrint=yes' --payload "$payload" -H 'Fiware-Service: smartmaas001' -H 'Content-Type: application/json' -H 'fiware-service: smartmaas001' -H 'fiware-servicepath: /' \
--H 'Link: <https://schema.lab.fiware.org/ld/context>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' -H 'Content-Type: application/json' --noPayloadCheck
+-H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' -H 'Content-Type: application/json' --noPayloadCheck
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_patch_location_attribute.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_patch_location_attribute.test
@@ -49,7 +49,7 @@ payload='{
     }
   },
   "@context": [
-    "https://schema.lab.fiware.org/ld/context",
+    "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
     "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
   ]
 }'
@@ -62,7 +62,7 @@ echo "02. Patch the location property"
 echo "==============================="
 payload='{
   "@context": [
-    "https://schema.lab.fiware.org/ld/context",
+    "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
     "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
   ],
   "location": {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_registration_get_crash.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_registration_get_crash.test
@@ -55,7 +55,7 @@ payload='{
     }
   ],
   "endpoint": "http://context-provider:3000/static/tweets",
-  "@context": "https://schema.lab.fiware.org/ld/context"
+  "@context": "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld"
 }'
 orionCurl --url /ngsi-ld/v1/csourceRegistrations -X POST --payload "$payload" -H "Content-Type: application/ld+json"
 echo

--- a/test/functionalTest/cases/0000_ngsild/ngsild_patch_location_attribute.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_patch_location_attribute.test
@@ -48,7 +48,7 @@ payload='{
     }
   },
   "@context": [
-    "https://schema.lab.fiware.org/ld/context",
+    "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
     "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
   ]
 }'
@@ -61,7 +61,7 @@ echo "02. Patch the location property"
 echo "==============================="
 payload='{
   "@context": [
-    "https://schema.lab.fiware.org/ld/context",
+    "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld",
     "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
   ],
   "location": {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_registration_get_crash.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_registration_get_crash.test
@@ -54,7 +54,7 @@ payload='{
     }
   ],
   "endpoint": "http://context-provider:3000/static/tweets",
-  "@context": "https://schema.lab.fiware.org/ld/context"
+  "@context": "http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld"
 }'
 orionCurl --url /ngsi-ld/v1/csourceRegistrations -X POST --payload "$payload" -H "Content-Type: application/ld+json"
 echo

--- a/test/functionalTest/contexts/schema_lab_fiware_org_ld_context.jsonld
+++ b/test/functionalTest/contexts/schema_lab_fiware_org_ld_context.jsonld
@@ -1,0 +1,6 @@
+{
+   "@context": [
+     "https://fiware.github.io/data-models/context.jsonld",
+     "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
+   ]
+}


### PR DESCRIPTION
Implemented a tiny 'framework' to "mirror" 3rd party @contexts in the Context Server - to minimize dependencies.
For now, the only @context mirrored is: `https://schema.lab.fiware.org/ld/context`