### PR TITLE
hardening/getEntityLocalDbFirstRemoteLaterWithEntityType

### DIFF
--- a/src/lib/orionld/apiModel/ntocAttribute.cpp
+++ b/src/lib/orionld/apiModel/ntocAttribute.cpp
@@ -58,7 +58,7 @@ void ntocAttribute(KjNode* attrP, const char* lang, bool sysAttrs)
 
   // 1. Remove the sysAttrs, if so requested
   if (sysAttrs == false)
-    kjSysAttrsRemove(attrP);
+    kjSysAttrsRemove(attrP, 0);
 
 
   // 2. LanguageProperty?

--- a/src/lib/orionld/apiModel/ntocEntity.cpp
+++ b/src/lib/orionld/apiModel/ntocEntity.cpp
@@ -45,7 +45,7 @@ extern "C"
 void ntocEntity(KjNode* apiEntityP, const char* lang, bool sysAttrs)
 {
   if (sysAttrs == false)
-    kjSysAttrsRemove(apiEntityP);
+    kjSysAttrsRemove(apiEntityP, 0);
 
   for (KjNode* fieldP = apiEntityP->value.firstChildP; fieldP != NULL; fieldP = fieldP->next)
   {

--- a/src/lib/orionld/apiModel/ntocSubAttribute.cpp
+++ b/src/lib/orionld/apiModel/ntocSubAttribute.cpp
@@ -46,7 +46,7 @@ void ntocSubAttribute(KjNode* saP, const char* lang, bool sysAttrs)
 {
   // 1. Remove the sysAttrs, if so requested
   if (sysAttrs == false)
-    kjSysAttrsRemove(saP);
+    kjSysAttrsRemove(saP, 0);
 
 
   // 2. LanguageProperty?

--- a/src/lib/orionld/apiModel/ntonAttribute.cpp
+++ b/src/lib/orionld/apiModel/ntonAttribute.cpp
@@ -55,7 +55,7 @@ void ntonAttribute(KjNode* attrP, const char* lang, bool sysAttrs)
   }
 
   if (sysAttrs == false)
-    kjSysAttrsRemove(attrP);
+    kjSysAttrsRemove(attrP, 0);
 
   KjNode* typeP = kjLookup(attrP, "type");
   if ((lang != NULL) && (typeP != NULL) && (strcmp(typeP->value.s, "LanguageProperty") == 0))

--- a/src/lib/orionld/apiModel/ntonEntity.cpp
+++ b/src/lib/orionld/apiModel/ntonEntity.cpp
@@ -42,7 +42,7 @@ extern "C"
 void ntonEntity(KjNode* apiEntityP, const char* lang, bool sysAttrs)
 {
   if (sysAttrs == false)
-    kjSysAttrsRemove(apiEntityP);
+    kjSysAttrsRemove(apiEntityP, 0);
 
   for (KjNode* fieldP = apiEntityP->value.firstChildP; fieldP != NULL; fieldP = fieldP->next)
   {

--- a/src/lib/orionld/apiModel/ntonSubAttribute.cpp
+++ b/src/lib/orionld/apiModel/ntonSubAttribute.cpp
@@ -45,7 +45,7 @@ extern "C"
 void ntonSubAttribute(KjNode* saP, const char* lang, bool sysAttrs)
 {
   if (sysAttrs == false)
-    kjSysAttrsRemove(saP);
+    kjSysAttrsRemove(saP, 0);
 
   KjNode* typeP = kjLookup(saP, "type");
   if ((lang != NULL) && (typeP != NULL) && (strcmp(typeP->value.s, "LanguageProperty")))

--- a/src/lib/orionld/forwarding/ForwardPending.h
+++ b/src/lib/orionld/forwarding/ForwardPending.h
@@ -49,6 +49,7 @@ typedef struct ForwardPending
   KjNode*                 body;         // For Create/Update Requests (also used for GET - tree of response)
   char*                   rawResponse;  // Response buffer as raw ASCII as it was received by libcurl (parsed and stored as ForwardPending::body)
   char*                   entityId;     // Used by GET /entities/{entityId}
+  char*                   entityType;   // Used by GET /entities/{entityId}
   char*                   attrName;     // Used by PATCH /entities/{entityId}/attrs/{attrName}
   StringArray*            attrList;     // URI Param "attrs" for GET Requests
   char*                   geoProp;      // URI Param "geometryProperty" for GET Requests

--- a/src/lib/orionld/forwarding/regMatchForEntityGet.cpp
+++ b/src/lib/orionld/forwarding/regMatchForEntityGet.cpp
@@ -55,6 +55,7 @@ ForwardPending* regMatchForEntityGet  // FIXME: +entity-type
   RegistrationMode regMode,
   FwdOperation     operation,
   const char*      entityId,
+  const char*      entityType,
   StringArray*     attrV,
   const char*      geoProp
 )
@@ -91,7 +92,7 @@ ForwardPending* regMatchForEntityGet  // FIXME: +entity-type
       continue;
     }
 
-    ForwardPending* fwdPendingP = regMatchInformationArrayForGet(regP, entityId, attrV, geoProp);  // FIXME: +entity-type
+    ForwardPending* fwdPendingP = regMatchInformationArrayForGet(regP, entityId, entityType, attrV, geoProp);  // FIXME: +entity-type
     if (fwdPendingP == NULL)
     {
       LM(("%s: No Reg Match due to Information Array", regId));
@@ -99,8 +100,9 @@ ForwardPending* regMatchForEntityGet  // FIXME: +entity-type
     }
 
     // Add extra info in ForwardPending, needed by forwardRequestSend
-    fwdPendingP->entityId  = (char*) entityId;
-    fwdPendingP->operation = operation;
+    fwdPendingP->entityId   = (char*) entityId;
+    fwdPendingP->entityType = (char*) entityType;
+    fwdPendingP->operation  = operation;
 
     // Add fwdPendingP to the linked list
     if (fwdPendingHead == NULL)

--- a/src/lib/orionld/forwarding/regMatchForEntityGet.h
+++ b/src/lib/orionld/forwarding/regMatchForEntityGet.h
@@ -46,6 +46,7 @@ extern ForwardPending* regMatchForEntityGet
   RegistrationMode regMode,
   FwdOperation     operation,
   const char*      entityId,
+  const char*      entityType,
   StringArray*     attrV,
   const char*      geoProp
 );

--- a/src/lib/orionld/forwarding/regMatchInformationArrayForGet.cpp
+++ b/src/lib/orionld/forwarding/regMatchInformationArrayForGet.cpp
@@ -42,18 +42,18 @@ extern "C"
 //
 // regMatchInformationArrayForGet -
 //
-ForwardPending* regMatchInformationArrayForGet(RegCacheItem* regP, const char* entityId, StringArray* attrV, const char* geoProp)
+ForwardPending* regMatchInformationArrayForGet(RegCacheItem* regP, const char* entityId, const char* entityType, StringArray* attrV, const char* geoProp)
 {
   KjNode* informationV = kjLookup(regP->regTree, "information");
 
   for (KjNode* infoP = informationV->value.firstChildP; infoP != NULL; infoP = infoP->next)
   {
-    StringArray* attrList = regMatchInformationItemForGet(regP, infoP, entityId, attrV, geoProp);
+    StringArray* attrList = regMatchInformationItemForGet(regP, infoP, entityId, entityType, attrV, geoProp);
 
-    if ((attrV != NULL) && (attrList == NULL))  // No match
+    if (attrList == NULL)  // No match
       continue;
 
-    // If we get this far, then it's a match and we can return
+    // If we get this far, then it's a match and we can create the ForwardPending item and return
     ForwardPending* fwdPendingP = (ForwardPending*) kaAlloc(&orionldState.kalloc, sizeof(ForwardPending));
 
     fwdPendingP->regP     = regP;

--- a/src/lib/orionld/forwarding/regMatchInformationArrayForGet.h
+++ b/src/lib/orionld/forwarding/regMatchInformationArrayForGet.h
@@ -40,6 +40,6 @@ extern "C"
 //
 // regMatchInformationArrayForGet -
 //
-extern ForwardPending* regMatchInformationArrayForGet(RegCacheItem* regP, const char* entityId, StringArray* attrV, const char* geoProp);
+extern ForwardPending* regMatchInformationArrayForGet(RegCacheItem* regP, const char* entityId, const char* entityType, StringArray* attrV, const char* geoProp);
 
 #endif  // SRC_LIB_ORIONLD_FORWARDING_REGMATCHINFORMATIONARRAYFORGET_H_

--- a/src/lib/orionld/forwarding/regMatchInformationItemForGet.cpp
+++ b/src/lib/orionld/forwarding/regMatchInformationItemForGet.cpp
@@ -42,7 +42,15 @@ extern "C"
 //
 // regMatchInformationItemForGet -
 //
-StringArray* regMatchInformationItemForGet(RegCacheItem* regP, KjNode* infoP, const char* entityId, StringArray* attrV, const char* geoProp)
+StringArray* regMatchInformationItemForGet
+(
+  RegCacheItem* regP,
+  KjNode*       infoP,
+  const char*   entityId,
+  const char*   entityType,
+  StringArray*  attrV,
+  const char*   geoProp
+)
 {
   KjNode* entities = kjLookup(infoP, "entities");
 
@@ -51,7 +59,7 @@ StringArray* regMatchInformationItemForGet(RegCacheItem* regP, KjNode* infoP, co
     bool match = false;
     for (KjNode* entityInfoP = entities->value.firstChildP; entityInfoP != NULL; entityInfoP = entityInfoP->next)
     {
-      if (regMatchEntityInfo(regP, entityInfoP, entityId, NULL) == true)
+      if (regMatchEntityInfo(regP, entityInfoP, entityId, entityType) == true)
       {
         match = true;
         break;

--- a/src/lib/orionld/forwarding/regMatchInformationItemForGet.h
+++ b/src/lib/orionld/forwarding/regMatchInformationItemForGet.h
@@ -39,6 +39,6 @@ extern "C"
 //
 // regMatchInformationItemForGet -
 //
-extern StringArray* regMatchInformationItemForGet(RegCacheItem* regP, KjNode* infoP, const char* entityId, StringArray* attrV, const char* geoProp);
+extern StringArray* regMatchInformationItemForGet(RegCacheItem* regP, KjNode* infoP, const char* entityId, const char* entityType, StringArray* attrV, const char* geoProp);
 
 #endif  // SRC_LIB_ORIONLD_FORWARDING_REGMATCHINFORMATIONITEMFORGET_H_

--- a/src/lib/orionld/kjTree/kjSysAttrsRemove.cpp
+++ b/src/lib/orionld/kjTree/kjSysAttrsRemove.cpp
@@ -23,6 +23,7 @@
 * Author: Ken Zangelin
 */
 #include <unistd.h>                                            // NULL
+#include <string.h>                                            // strcmp
 
 extern "C"
 {
@@ -39,7 +40,11 @@ extern "C"
 //
 // kjSysAttrsRemove -
 //
-void kjSysAttrsRemove(KjNode* container)
+// PARAMETERS
+//   container      - the toplevel KjNode from where to remove the sysAttrs (createdAt+modifiedAt)
+//   recursionLevel - while it is > 0, we go down one level (0 => single level, no recursion)
+//
+void kjSysAttrsRemove(KjNode* container, int recursionLevel)
 {
   KjNode* createdAtP  = kjLookup(container, "createdAt");
   KjNode* modifiedAtP = kjLookup(container, "modifiedAt");
@@ -49,4 +54,13 @@ void kjSysAttrsRemove(KjNode* container)
 
   if (modifiedAtP != NULL)
     kjChildRemove(container, modifiedAtP);
+
+  if (recursionLevel > 0)
+  {
+    for (KjNode* childP = container->value.firstChildP; childP != NULL; childP = childP->next)
+    {
+      if ((childP->type == KjObject) && (strcmp(childP->name, "value") != 0) && (strcmp(childP->name, "languageMap") != 0))
+        kjSysAttrsRemove(childP, recursionLevel - 1);
+    }
+  }
 }

--- a/src/lib/orionld/kjTree/kjSysAttrsRemove.h
+++ b/src/lib/orionld/kjTree/kjSysAttrsRemove.h
@@ -36,6 +36,6 @@ extern "C"
 //
 // kjSysAttrsRemove -
 //
-extern void kjSysAttrsRemove(KjNode* container);
+extern void kjSysAttrsRemove(KjNode* container, int recursionLevel);
 
 #endif  // SRC_LIB_ORIONLD_KJTREE_KJSYSATTRSREMOVE_H_

--- a/src/lib/orionld/mongoc/mongocEntityLookup.cpp
+++ b/src/lib/orionld/mongoc/mongocEntityLookup.cpp
@@ -56,7 +56,7 @@ extern "C"
 // The other one, mongocEntityRetrieve, does much more than just DB. It needs to be be REMOVED.
 // mongocEntityRetrieve is only used by legacyGetEntity() which is being deprecated anyway.
 //
-KjNode* mongocEntityLookup(const char* entityId, StringArray* attrsV, const char* geojsonGeometry)
+KjNode* mongocEntityLookup(const char* entityId, const char* entityType, StringArray* attrsV, const char* geojsonGeometry)
 {
   bson_t                mongoFilter;
   const bson_t*         mongoDocP;
@@ -71,7 +71,14 @@ KjNode* mongocEntityLookup(const char* entityId, StringArray* attrsV, const char
   // Create the filter for the query
   //
   bson_init(&mongoFilter);
+
   bson_append_utf8(&mongoFilter, "_id.id", 6, entityId, -1);
+
+  if (entityType != NULL)
+  {
+    LM(("Adding the entity type to the query: '%s'", entityType));
+    bson_append_utf8(&mongoFilter, "_id.type", 8, entityType, -1);
+  }
 
   mongocConnectionGet();
 

--- a/src/lib/orionld/mongoc/mongocEntityLookup.h
+++ b/src/lib/orionld/mongoc/mongocEntityLookup.h
@@ -49,6 +49,6 @@ extern "C"
 // The other one, mongocEntityRetrieve, does much more than just DB. It should be REMOVED.
 // mongocEntityRetrieve is only used by legacyGetEntity() which is being deprecated anyway.
 //
-extern KjNode* mongocEntityLookup(const char* entityId, StringArray* attrsV, const char* geojsonGeometry);
+extern KjNode* mongocEntityLookup(const char* entityId, const char* entityType, StringArray* attrsV, const char* geojsonGeometry);
 
 #endif  // SRC_LIB_ORIONLD_MONGOC_MONGOCENTITYLOOKUP_H_

--- a/src/lib/orionld/rest/orionldServiceInit.cpp
+++ b/src/lib/orionld/rest/orionldServiceInit.cpp
@@ -233,6 +233,7 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
     serviceP->uriParams |= ORIONLD_URIPARAM_GEOMETRYPROPERTY;
     serviceP->uriParams |= ORIONLD_URIPARAM_LANG;
     serviceP->uriParams |= ORIONLD_URIPARAM_LOCAL;
+    serviceP->uriParams |= ORIONLD_URIPARAM_TYPELIST;
 
     serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }

--- a/src/lib/orionld/serviceRoutines/orionldDeleteEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldDeleteEntity.cpp
@@ -43,12 +43,13 @@
 //
 bool orionldDeleteEntity(void)
 {
-  char* entityId = orionldState.wildcard[0];
+  char* entityId   = orionldState.wildcard[0];
+  char* entityType = orionldState.uriParams.type;
 
   // Make sure the Entity ID is a valid URI
   PCHECK_URI(entityId, true, 0, "Invalid Entity ID", "Must be a valid URI", 400);
 
-  if (mongocEntityLookup(entityId, NULL, NULL) == NULL)  // FIXME: Overkill to extract the entire entity from the DB
+  if (mongocEntityLookup(entityId, entityType, NULL, NULL) == NULL)  // FIXME: Overkill to extract the entire entity from the DB
   {
     orionldError(OrionldResourceNotFound, "Entity not found", entityId, 404);
     return false;

--- a/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
@@ -74,11 +74,80 @@ bool orionldGetEntity(void)
   if ((experimental == false) || (orionldState.in.legacy != NULL))                      // If Legacy header - use old implementation
     return legacyGetEntity();
 
-  const char* entityId = orionldState.wildcard[0];
+  bool         distributed = (forwarding == true) && (orionldState.uriParams.local == false);
+  bool         sysAttrs    = orionldState.uriParamOptions.sysAttrs;
+  char*        lang        = orionldState.uriParams.lang;
+  char*        entityType  = NULL;  // If the entity is found locally, its type will be included as help in the forwarded requests
+  const char*  entityId    = orionldState.wildcard[0];
+
   if (pCheckUri(entityId, "Entity ID in URL PATH", true) == false)
     return false;
 
-  bool             distributed    = (forwarding == true) && (orionldState.uriParams.local == false);
+  //
+  // If the entity type is set as URI param (only ONE), then it will be used, but first it needs to be expanded.
+  // In the case the entity "entityId" exists, but with another type, it is not considered a hit - 404
+  //
+  if (orionldState.in.typeList.items > 0)
+  {
+    if (orionldState.in.typeList.items == 1)
+      entityType = orionldState.in.typeList.array[0];
+    else
+    {
+      orionldError(OrionldBadRequestData, "Invalid URI param (type)", "more than one entity type", 400);
+      return false;
+    }
+  }
+
+  LM(("TYPE: entityType: '%s' (from URI param)", entityType));
+
+  KjNode* dbEntityP      = mongocEntityLookup(entityId, entityType, &orionldState.in.attrList, orionldState.uriParams.geometryProperty);
+  KjNode* apiEntityP     = NULL;
+  bool    forcedSysAttrs = false;
+
+  if (dbEntityP != NULL)  // Convert from DB to API Entity + GET the entity type
+  {
+    // In the distributed case, one and the same attribute may come from different providers,
+    // and we'll have to pick ONE of them.
+    // The algorithm to pick one is;
+    // 1. Newest observedAt
+    // 2. If none of the attributes has an observedAt:  newest modifiedAt
+    // 3. If none of the attributes has an modifiedAt - pick the first one
+    //
+    // So, in order for this to work, in a distributed GET, we can't get rid of the sysAttrs in dbModelToApiEntity2.
+    // We also cannot get rid of the sub-attrs (observedAt may be needed) - that would be if orionldState.out.format == Simplified
+    // We might need those two for the attribute-instance-decision
+    //
+    // For the very same reason, all forwarded GET requests must carry the URI-params "?options=sysAttrs,normalized" + type=X is available
+    //
+
+    if (entityType == NULL)
+    {
+      //
+      // As we need the expanded entity type, we look it up in the DB Model version of the entity, not the API model version
+      // AND, we must do this before calling dbModelToApiEntity2 as "id"/"type" are removed from "_id".
+      //
+      kjTreeLog(dbEntityP, "TYPE: dbEntityP");
+      KjNode* _idP        = kjLookup(dbEntityP, "_id");
+      LM(("TYPE: _idP at %p", _idP));
+      KjNode* entityTypeP = (_idP != NULL)? kjLookup(_idP, "type") : NULL;
+      LM(("TYPE: entityTypeP at %p", entityTypeP));
+
+      if (entityTypeP != NULL)
+        entityType = entityTypeP->value.s;
+      LM(("TYPE: entityType: '%s' (from DB)", entityType));
+    }
+    else
+      LM(("TYPE: The entity type is already set in URL param: '%s'", entityType));
+
+    if (distributed == true)
+    {
+      forcedSysAttrs = true;
+      apiEntityP = dbModelToApiEntity2(dbEntityP, true, RF_NORMALIZED, lang, true, &orionldState.pd);
+    }
+    else
+      apiEntityP = dbModelToApiEntity2(dbEntityP, sysAttrs, orionldState.out.format, lang, true, &orionldState.pd);
+  }
+
   ForwardPending*  fwdPendingList = NULL;
   int              forwards       = 0;
 
@@ -104,10 +173,10 @@ bool orionldGetEntity(void)
     // We want EVERYTHING from Auxiliary regs (and we may throw it all away in the end),
     // so we create the ForwardPending list FIRST, before any attrs are removed
     //
-    ForwardPending* auxiliarList  = regMatchForEntityGet(RegModeAuxiliary, FwdRetrieveEntity, entityId, attrV, geoProp);
-    ForwardPending* exclusiveList = regMatchForEntityGet(RegModeExclusive, FwdRetrieveEntity, entityId, attrV, geoProp);
-    ForwardPending* redirectList  = regMatchForEntityGet(RegModeRedirect,  FwdRetrieveEntity, entityId, attrV, geoProp);
-    ForwardPending* inclusiveList = regMatchForEntityGet(RegModeInclusive, FwdRetrieveEntity, entityId, attrV, geoProp);
+    ForwardPending* auxiliarList  = regMatchForEntityGet(RegModeAuxiliary, FwdRetrieveEntity, entityId, entityType, attrV, geoProp);
+    ForwardPending* exclusiveList = regMatchForEntityGet(RegModeExclusive, FwdRetrieveEntity, entityId, entityType, attrV, geoProp);
+    ForwardPending* redirectList  = regMatchForEntityGet(RegModeRedirect,  FwdRetrieveEntity, entityId, entityType, attrV, geoProp);
+    ForwardPending* inclusiveList = regMatchForEntityGet(RegModeInclusive, FwdRetrieveEntity, entityId, entityType, attrV, geoProp);
 
     fwdPendingList = forwardingListsMerge(exclusiveList,  redirectList);
     fwdPendingList = forwardingListsMerge(fwdPendingList, inclusiveList);
@@ -169,9 +238,6 @@ bool orionldGetEntity(void)
     }
   }
 
-  KjNode* dbEntityP  = mongocEntityLookup(entityId, &orionldState.in.attrList, orionldState.uriParams.geometryProperty);
-  KjNode* apiEntityP = NULL;
-
   if (dbEntityP == NULL)
   {
     if (forwards == 0)
@@ -179,41 +245,16 @@ bool orionldGetEntity(void)
       const char* title = (orionldState.in.attrList.items != 0)? "Combination Entity/Attributes Not Found" : "Entity Not Found";
       orionldError(OrionldResourceNotFound, title, entityId, 404);
 
-#if 0
-      LM(("@context is: '%s'", orionldState.contextP->url));
-
-      for (int ix = 0; ix < orionldState.in.attrList.items; ix++)
-      {
-        LM(("Attr %d: '%s'", ix, orionldState.in.attrList.array[ix]));
-      }
-#endif
       return false;
     }
   }
-  else
-  {
-    // In the distributed case, one and the same attribute may come from different providers,
-    // and we'll have to pick ONE of them.
-    // The algorithm to pick one is;
-    // 1. Newest observedAt
-    // 2. If none of the attributes has an observedAt:  newest modifiedAt
-    // 3. If none of the attributes has an modifiedAt - pick the first one
-    //
-    // So, in order for this to work, in a distributed GET, we can't get rid of the sysAttrs in dbModelToApiEntity2.
-    // We also cannot get rid of the sub-attrs (observedAt may be needed) - that would be if orionldState.out.format == Simplified
-    // We might need those two for the attribute-instance-decision
-    //
-    // For the very same reason, all forwarded GET requests must carry the URI-params "?options=sysAttrs,normalized"
-    //
-    if (forwards > 0)  // Need Normalized and sysattrs if the operation has parts of the entity distributed (to help pick attr instances)
-      apiEntityP = dbModelToApiEntity2(dbEntityP, true, RF_NORMALIZED, orionldState.uriParams.lang, true, &orionldState.pd);
-    else
-      apiEntityP = dbModelToApiEntity2(dbEntityP, orionldState.uriParamOptions.sysAttrs, orionldState.out.format, orionldState.uriParams.lang, true, &orionldState.pd);
-  }
+
 
   //
-  // Now read responses to the forwarded requests
+  // Read the responses to the forwarded requests
   //
+  int fwdMerges = 0;
+
   if (forwards > 0)
   {
     CURLMsg* msgP;
@@ -228,7 +269,6 @@ bool orionldGetEntity(void)
       {
         ForwardPending* fwdPendingP = fwdPendingLookupByCurlHandle(fwdPendingList, msgP->easy_handle);
 
-        LM(("Got a response: %s", fwdPendingP->rawResponse));
         fwdPendingP->body = kjParse(orionldState.kjsonP, fwdPendingP->rawResponse);
         if (fwdPendingP->body != NULL)
         {
@@ -254,7 +294,10 @@ bool orionldGetEntity(void)
           if (apiEntityP == NULL)
             apiEntityP = fwdPendingP->body;
           else
-            fwdEntityMerge(apiEntityP, fwdPendingP->body, orionldState.uriParamOptions.sysAttrs, fwdPendingP->regP->mode == RegModeAuxiliary);
+          {
+            fwdEntityMerge(apiEntityP, fwdPendingP->body, sysAttrs, fwdPendingP->regP->mode == RegModeAuxiliary);
+            fwdMerges += 1;
+          }
         }
         else
           LM_E(("Internal Error (parse error for the received response of a forwarded request)"));
@@ -270,8 +313,6 @@ bool orionldGetEntity(void)
   {
     kjTreeLog(apiEntityP, "API Entity to transform");
     // Transform the apiEntityP according to in case orionldState.out.format, lang, and sysAttrs
-    bool  sysAttrs = orionldState.uriParamOptions.sysAttrs;
-    char* lang     = orionldState.uriParams.lang;
 
     if (orionldState.out.format == RF_KEYVALUES)
       ntosEntity(apiEntityP, lang);
@@ -279,6 +320,11 @@ bool orionldGetEntity(void)
       ntocEntity(apiEntityP, lang, sysAttrs);
     else
       ntonEntity(apiEntityP, lang, sysAttrs);
+  }
+
+  if ((dbEntityP != NULL) && (fwdMerges == 0) && (forcedSysAttrs == true) && (sysAttrs == false))
+  {
+    kjSysAttrsRemove(apiEntityP, 2);
   }
 
   if (orionldState.out.contentType == GEOJSON)

--- a/src/lib/orionld/serviceRoutines/orionldPatchEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchEntity.cpp
@@ -107,7 +107,8 @@ bool orionldPatchEntity(void)
   if ((experimental == false) || (orionldState.in.legacy != NULL))                      // If Legacy header - use old implementation
     return legacyPatchEntity();
 
-  const char* entityId = orionldState.wildcard[0];
+  const char* entityId   = orionldState.wildcard[0];
+  const char* entityType = orionldState.uriParams.type;
 
   //
   // Initial Validity Checks;
@@ -121,7 +122,7 @@ bool orionldPatchEntity(void)
   //
   // Get the entity from mongo (only really need creDate and type of the attributes ...)
   //
-  KjNode* dbEntityP = mongocEntityLookup(entityId, NULL, NULL);
+  KjNode* dbEntityP = mongocEntityLookup(entityId, entityType, NULL, NULL);
   if (dbEntityP == NULL)
   {
     orionldError(OrionldResourceNotFound, "Entity does not exist", entityId, 404);
@@ -133,7 +134,8 @@ bool orionldPatchEntity(void)
   // [ It is already extracted (by orionldMhdConnectionTreat) and checked for String ]
   //
   KjNode*     dbTypeNodeP = dbEntityTypeExtract(dbEntityP);
-  const char* entityType  = dbTypeNodeP->value.s;
+
+  entityType  = dbTypeNodeP->value.s;  // FIXME: What if entityType was given as URI param?
 
   if (orionldState.payloadTypeNode != NULL)
   {

--- a/src/lib/orionld/serviceRoutines/orionldPatchEntity2.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchEntity2.cpp
@@ -529,6 +529,7 @@ bool orionldPatchEntity2(void)
   }
 
   char*    entityId    = orionldState.wildcard[0];
+  char*    entityType  = orionldState.uriParams.type;
   KjNode*  dbEntityP;
 
   //
@@ -546,7 +547,7 @@ bool orionldPatchEntity2(void)
   //        Not really worth it.
   //        At least, postponed (not forgotten) for now.
   //
-  dbEntityP = mongocEntityLookup(entityId, NULL, NULL);
+  dbEntityP = mongocEntityLookup(entityId, entityType, NULL, NULL);
 
   if (dbEntityP == NULL)
   {
@@ -555,7 +556,6 @@ bool orionldPatchEntity2(void)
   }
 
 
-  char*   entityType  = NULL;
   KjNode* dbAttrsP    = NULL;
 
   if (dbEntityFields(dbEntityP, entityId, &entityType, &dbAttrsP) == false)

--- a/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
@@ -247,7 +247,7 @@ bool orionldPostEntities(void)
   //
   if (orionldState.requestTree != NULL)
   {
-    if (mongocEntityLookup(entityId, NULL, NULL) != NULL)
+    if (mongocEntityLookup(entityId, NULL, NULL, NULL) != NULL)
     {
       if (fwdPendingList == NULL)  // Purely local request
       {

--- a/src/lib/orionld/serviceRoutines/orionldPostEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntity.cpp
@@ -126,7 +126,7 @@ bool orionldPostEntity(void)
     return legacyPostEntity();
 
   char* entityId                  = orionldState.wildcard[0];
-  char* entityType                = NULL;
+  char* entityType                = orionldState.uriParams.type;
   bool  ignoreExistingAttributes  = (orionldState.uriParamOptions.noOverwrite == true)? true : false;
 
   PCHECK_OBJECT(orionldState.requestTree, 0, NULL, "Entity Fragment", 400);
@@ -136,7 +136,7 @@ bool orionldPostEntity(void)
   //
   // Get the entity from the database
   //
-  KjNode* dbEntityP = mongocEntityLookup(entityId, NULL, NULL);
+  KjNode* dbEntityP = mongocEntityLookup(entityId, entityType, NULL, NULL);
   if (dbEntityP == NULL)
   {
     orionldError(OrionldResourceNotFound, "Entity does not exist", entityId, 404);

--- a/src/lib/orionld/serviceRoutines/orionldPutEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPutEntity.cpp
@@ -268,7 +268,7 @@ bool orionldPutEntity(void)
   //
   // Check Entity Type
   //
-  char*   entityType = NULL;  // Set by pCheckEntityType
+  char*   entityType = orionldState.uriParams.type;  // Set by pCheckEntityType - need to look at that ...
   KjNode* typeNodeP  = kjLookup(orionldState.requestTree, "type");
 
   if (pCheckEntityType(typeNodeP, true, &entityType) == false)
@@ -277,7 +277,7 @@ bool orionldPutEntity(void)
   //
   // Get the entity from the database
   //
-  KjNode* oldDbEntityP = mongocEntityLookup(entityId, NULL, NULL);
+  KjNode* oldDbEntityP = mongocEntityLookup(entityId, NULL, NULL, NULL);
   if (oldDbEntityP == NULL)
   {
     orionldError(OrionldResourceNotFound, "Entity does not exist", entityId, 404);

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_forward_get_entity_with_entityType.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_forward_get_entity_with_entityType.test
@@ -1,0 +1,216 @@
+# Copyright 2022 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Retrieve a distributed entity, giving the type of the entity
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+dbInit CP1
+brokerStart CB  0 IPv4 -experimental -forwarding
+brokerStart CP1 0 IPv4 -experimental
+
+--SHELL--
+
+#
+# We found a "funny" problem, really it's a user error, but the broker needs to protect itself against it.
+# Scenario:
+#   1. CP1 registers (in CB) entities of type "Vehicle" - no more hints in the registration - Registration R1
+#   2. An entity urn:E1 is created in CP1, with type "Building"
+#   3. CB receives an Entity Retieve request for the entity urn:E1, from an "end-user"
+#      - There's no entity type info, just the Entity ID, so, the registration R1 matches, as it has no Entity ID info, just the Entity Type
+#   4. CB sends the forwarded request to GET /entities/urn:E1
+#   5. CP1 responds with urn:E1, exactly what was asked for
+#   6. CB responds to the "end-user" with the entity urn:E1 - all good?
+#
+#   No, it's NOT "all good", as CP1 only retgistered entities of type "Vehicle", but urn:E1 is of the type "Building" ...
+#
+#   In order to fix this problem, we've added the URI param "type" to GET /entities/{entityId}
+#   If the entity exists in CB, the entity type will be added to the forwarded request and the "misunderstanding" is fixed.
+#   If the entity DOES NOT exists in CB, the problem will still occur, BUT, the initial request can be sent with the URI param type=Building.
+#   That fixes the probem, because R1 is no longer a match, as CB now knows the entity type "Building" and "R1" only exposes entities of type "Vehicle"
+#
+# TEST 1 - the "failure"
+# 01. Registration R1 in CB, for CP1, entity type "Vehicle"
+# 02. Create entity urn:E1 in CP1, with entity type "Building"
+# 03. GET /entities/urn:E1 in CB, get urn:E1 (with type Building) from CP1
+#
+# TEST 2 - fixing it by doing the GET with the entity type 'Building'
+# 04. GET /entities/urn:E1?type=Building in CB - see nothing
+#
+# TEST 3 - fixing it by having the entity locally
+# 05. Create entity urn:E1 in CB, with entity type "Building"
+# 06. GET /entities/urn:E1 - see only local data
+#
+
+echo "01. Registration R1 in CB, for CP1, entity type 'Vehicle'"
+echo "========================================================="
+payload='{
+  "id": "urn:R1",
+  "type": "ContextSourceRegistration",
+  "information": [
+    {
+      "entities": [
+        {
+          "type": "Vehicle"
+        }
+      ]
+    }
+  ],
+  "endpoint": "http://localhost:'$CP1_PORT'",
+  "operations": [ "retrieveEntity" ],
+  "mode": "inclusive"
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload"
+echo
+echo
+
+
+echo "02. Create entity urn:E1 in CP1, with entity type 'Building'"
+echo "============================================================"
+payload='{
+  "id": "urn:E1",
+  "type": "Building",
+  "P1": "In CP1"
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload" --port $CP1_PORT
+echo
+echo
+
+
+echo "03. GET /entities/urn:E1 in CB, get urn:E1 (with type Building) from CP1"
+echo "========================================================================"
+orionCurl --url /ngsi-ld/v1/entities/urn:E1
+echo
+echo
+
+
+echo "04. GET /entities/urn:E1?type=Building in CB - see nothing"
+echo "=========================================================="
+orionCurl --url /ngsi-ld/v1/entities/urn:E1?type=Building
+echo
+echo
+
+
+echo '05. Create entity urn:E1 in CB, with entity type "Building"'
+echo '==========================================================='
+payload='{
+  "id": "urn:E1",
+  "type": "Building",
+  "P2": "In CB"
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "06. GET /entities/urn:E1 - see only local data"
+echo "=============================================="
+orionCurl --url /ngsi-ld/v1/entities/urn:E1
+echo
+echo
+
+
+--REGEXPECT--
+01. Registration R1 in CB, for CP1, entity type 'Vehicle'
+=========================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/csourceRegistrations/urn:R1
+
+
+
+02. Create entity urn:E1 in CP1, with entity type 'Building'
+============================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:E1
+
+
+
+03. GET /entities/urn:E1 in CB, get urn:E1 (with type Building) from CP1
+========================================================================
+HTTP/1.1 200 OK
+Content-Length: 75
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+{
+    "P1": {
+        "type": "Property",
+        "value": "In CP1"
+    },
+    "id": "urn:E1",
+    "type": "Building"
+}
+
+
+04. GET /entities/urn:E1?type=Building in CB - see nothing
+==========================================================
+HTTP/1.1 404 Not Found
+Content-Length: 108
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "urn:E1",
+    "title": "Entity Not Found",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/ResourceNotFound"
+}
+
+
+05. Create entity urn:E1 in CB, with entity type "Building"
+===========================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:E1
+
+
+
+06. GET /entities/urn:E1 - see only local data
+==============================================
+HTTP/1.1 200 OK
+Content-Length: 74
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+{
+    "P2": {
+        "type": "Property",
+        "value": "In CB"
+    },
+    "id": "urn:E1",
+    "type": "Building"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+brokerStop CP1
+#dbDrop CB
+dbDrop CP1


### PR DESCRIPTION
Sending entity type in forwarded GET /entities/{entityId} to avoid problems with non-matching entity types of entities in forwarded respopnses. 
