### PR TITLE
Apichange/lang props and key values

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -36,3 +36,4 @@
 * Issue #1262  keyValues/simplified input format for PATCH /entities/{entityId}
 * Issue #1261  'lang' URI param support for PATCH /entities/{entityId}
 * Issue #1287  Fixed a bug in GET /entities/{entityId}?attrs=xxx, that always included 'location' in the response
+* Issue #280   Implemented the new format for LanguageProperty in Simplified Format (including the 'languageMap' field)

--- a/src/lib/orionld/dbModel/dbModelToApiEntity.cpp
+++ b/src/lib/orionld/dbModel/dbModelToApiEntity.cpp
@@ -289,10 +289,17 @@ KjNode* dbModelToApiEntity2(KjNode* dbEntityP, bool sysAttrs, RenderFormat rende
   //
   // Now the attributes
   //
-  for (KjNode* attrP = attrsP->value.firstChildP; attrP != NULL; attrP = attrP->next)
+  KjNode* attrP = attrsP->value.firstChildP;
+  KjNode* next;
+
+  while (attrP != NULL)
   {
-    if (strcmp(attrP->name, ".added")   == 0) continue;
-    if (strcmp(attrP->name, ".removed") == 0) continue;
+    next = attrP->next;
+    if ((strcmp(attrP->name, ".added")   == 0) || (strcmp(attrP->name, ".removed") == 0))
+    {
+      attrP = next;
+      continue;
+    }
 
     KjNode* attributeP;
     KjNode* datasetP = datasetExtract(datasetsP, attrP->name);  // datasetExtract removes the dataset from @datasets
@@ -304,6 +311,7 @@ KjNode* dbModelToApiEntity2(KjNode* dbEntityP, bool sysAttrs, RenderFormat rende
     }
 
     kjChildAdd(entityP, attributeP);
+    attrP = next;
   }
 
   //

--- a/src/lib/orionld/kjTree/kjAttributeNormalizedToSimplified.cpp
+++ b/src/lib/orionld/kjTree/kjAttributeNormalizedToSimplified.cpp
@@ -26,6 +26,7 @@ extern "C"
 {
 #include "kjson/KjNode.h"                                        // KjNode
 #include "kjson/kjLookup.h"                                      // kjLookup
+#include "kjson/kjBuilder.h"                                     // kjChildRemove
 }
 
 #include "logMsg/logMsg.h"                                       // LM_*
@@ -46,12 +47,25 @@ void kjAttributeNormalizedToSimplified(KjNode* attrP, const char* lang)
   KjNode* objectP      = kjLookup(attrP, "object");
   KjNode* languageMapP = kjLookup(attrP, "languageMap");
 
-  if (valueP == NULL) valueP = objectP;
-  if (valueP == NULL) valueP = languageMapP;
-
-  if (valueP != NULL)
+  if (languageMapP == NULL)
   {
-    attrP->type  = valueP->type;
-    attrP->value = valueP->value;
+    if (valueP == NULL)
+      valueP = objectP;
+
+    if (valueP != NULL)
+    {
+      attrP->type  = valueP->type;
+      attrP->value = valueP->value;
+    }
+  }
+  else
+  {
+    //
+    // LanguageMap in keyValues is less compact - due to JSON-LD that would expand the language tags otherwise
+    // Removing all fields except 'languageMap'
+    //
+    attrP->value.firstChildP = languageMapP;
+    attrP->lastChild         = languageMapP;
+    languageMapP->next = NULL;
   }
 }

--- a/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntity.cpp
@@ -221,12 +221,12 @@ bool orionldGetEntity(void)
           }
         }
 
-        if ((++loops >= 50) && ((loops % 10) == 0))
+        if ((++loops >= 50) && ((loops % 25) == 0))
           LM_W(("curl_multi_perform doesn't seem to finish ... (%d loops)", loops));
       }
 
-      if (loops >= 50)
-        LM_W(("curl_multi_perform finally finished!"));
+      if (loops >= 100)
+        LM_W(("curl_multi_perform finally finished!   (%d loops)", loops));
     }
   }
 

--- a/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
@@ -217,9 +217,12 @@ bool orionldPostEntities(void)
           }
         }
 
-        if ((++loops >= 10) && ((loops % 5) == 0))
+        if ((++loops >= 50) && ((loops % 25) == 0))
           LM_W(("curl_multi_perform doesn't seem to finish ... (%d loops)", loops));
       }
+
+      if (loops >= 100)
+        LM_W(("curl_multi_perform finally finished!   (%d loops)", loops));
 
       // Anything left for a local entity?
       if (orionldState.requestTree->value.firstChildP != NULL)
@@ -233,12 +236,6 @@ bool orionldPostEntities(void)
       else
         orionldState.requestTree = NULL;  // Meaning: nothing left for local DB
     }
-
-    //
-    // After sending all forwarded requests, we let the local DB access run
-    // After that is done (if anything left for local DB),
-    //   we select on the reponses and build the answer
-    //
   }
 
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_1289.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_1289.test
@@ -1,0 +1,194 @@
+# Copyright 2022 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+URI params - issue #1289
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+brokerStart CB 0 IPv4 -experimental
+
+--SHELL--
+
+#
+# 01. Create an Entity urn:ngsi-ld:Vehicle:AIS:211440340
+# 02. Create an Entity urn:ngsi-ld:Vehicle:AIS:211783270
+# 03. Create an Entity urn:ngsi-ld:Vehicle:AIS:211445200
+# 04. Query with geoproperty, see all 3
+#
+
+echo "01. Create an Entity urn:ngsi-ld:Vehicle:AIS:211440340"
+echo "======================================================"
+payload='{
+  "id": "urn:ngsi-ld:Vehicle:AIS:211440340",
+  "type": "Vehicle",
+  "location": {
+    "type": "GeoProperty",
+      "value": {
+        "coordinates": [
+          9.712908,
+          54.308173
+        ],
+      "type": "Point"
+    }
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "02. Create an Entity urn:ngsi-ld:Vehicle:AIS:211783270"
+echo "======================================================"
+payload='{
+  "id": "urn:ngsi-ld:Vehicle:AIS:211783270",
+  "type": "Vehicle",
+  "location": {
+    "type": "GeoProperty",
+    "value": {
+      "coordinates": [
+        10.026042,
+        54.582267
+      ],
+      "type": "Point"
+    }
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "03. Create an Entity urn:ngsi-ld:Vehicle:AIS:211445200"
+echo "======================================================"
+payload='{
+  "id": "urn:ngsi-ld:Vehicle:AIS:211445200",
+  "type": "Vehicle",
+  "location": {
+    "type": "GeoProperty",
+    "value": {
+      "coordinates": [
+        9.448432,
+        54.17357
+      ],
+      "type": "Point"
+    }
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "04. Query with geoproperty, see all 3"
+echo "====================================="
+orionCurl --url '/ngsi-ld/v1/entities?limit=3&attrs=id,location&idPattern=AIS&type=Vehicle&geometry=Point&coordinates=\[9.712908,54.308173\]&georel=near;maxDistance==36800'
+echo
+echo
+
+
+--REGEXPECT--
+01. Create an Entity urn:ngsi-ld:Vehicle:AIS:211440340
+======================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:Vehicle:AIS:211440340
+
+
+
+02. Create an Entity urn:ngsi-ld:Vehicle:AIS:211783270
+======================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:Vehicle:AIS:211783270
+
+
+
+03. Create an Entity urn:ngsi-ld:Vehicle:AIS:211445200
+======================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:Vehicle:AIS:211445200
+
+
+
+04. Query with geoproperty, see all 3
+=====================================
+HTTP/1.1 200 OK
+Content-Length: 463
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+[
+    {
+        "id": "urn:ngsi-ld:Vehicle:AIS:211440340",
+        "location": {
+            "type": "GeoProperty",
+            "value": {
+                "coordinates": [
+                    9.712908,
+                    54.308173
+                ],
+                "type": "Point"
+            }
+        },
+        "type": "Vehicle"
+    },
+    {
+        "id": "urn:ngsi-ld:Vehicle:AIS:211783270",
+        "location": {
+            "type": "GeoProperty",
+            "value": {
+                "coordinates": [
+                    10.026042,
+                    54.582267
+                ],
+                "type": "Point"
+            }
+        },
+        "type": "Vehicle"
+    },
+    {
+        "id": "urn:ngsi-ld:Vehicle:AIS:211445200",
+        "location": {
+            "type": "GeoProperty",
+            "value": {
+                "coordinates": [
+                    9.448432,
+                    54.17357
+                ],
+                "type": "Point"
+            }
+        },
+        "type": "Vehicle"
+    }
+]
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/0000_ngsild/ngsild_langprop-as-array-create-and-get-entity.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_langprop-as-array-create-and-get-entity.test
@@ -251,28 +251,30 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http:/
 05. GET entity in Simplified form
 =================================
 HTTP/1.1 200 OK
-Content-Length: 121
+Content-Length: 137
 Content-Type: application/json
 Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "L": {
-        "en": [
-            "one",
-            "two",
-            "three"
-        ],
-        "es": [
-            "uno",
-            "dos",
-            "tres"
-        ],
-        "sv": [
-            "ett",
-            "tvaa",
-            "tre"
-        ]
+        "languageMap": {
+            "en": [
+                "one",
+                "two",
+                "three"
+            ],
+            "es": [
+                "uno",
+                "dos",
+                "tres"
+            ],
+            "sv": [
+                "ett",
+                "tvaa",
+                "tre"
+            ]
+        }
     },
     "id": "urn:ngsi-ld:T:E1",
     "type": "T"

--- a/test/functionalTest/cases/0000_ngsild/ngsild_langprop-create-and-get-entity.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_langprop-create-and-get-entity.test
@@ -253,16 +253,18 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http:/
 05. GET entity in Simplified form
 =================================
 HTTP/1.1 200 OK
-Content-Length: 74
+Content-Length: 90
 Content-Type: application/json
 Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "L": {
-        "en": "el",
-        "es": "ele",
-        "sv": "ell"
+        "languageMap": {
+            "en": "el",
+            "es": "ele",
+            "sv": "ell"
+        }
     },
     "id": "urn:ngsi-ld:T:E1",
     "type": "T"

--- a/test/functionalTest/cases/0000_ngsild/ngsild_langprop-post_query.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_langprop-post_query.test
@@ -360,7 +360,7 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http:/
 05. POST Query to get entities in Simplified form
 =================================================
 HTTP/1.1 200 OK
-Content-Length: 76
+Content-Length: 92
 Content-Type: application/json
 Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
@@ -368,9 +368,11 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http:/
 [
     {
         "L": {
-            "en": "el",
-            "es": "ele",
-            "sv": "ell"
+            "languageMap": {
+                "en": "el",
+                "es": "ele",
+                "sv": "ell"
+            }
         },
         "id": "urn:ngsi-ld:T:E1",
         "type": "T"

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_entity_query-with-q-langprop-with-array-mongocOnly.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_entity_query-with-q-langprop-with-array-mongocOnly.test
@@ -317,7 +317,7 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http:/
 05. GET entities in Simplified form
 ===================================
 HTTP/1.1 200 OK
-Content-Length: 123
+Content-Length: 139
 Content-Type: application/json
 Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
@@ -325,21 +325,23 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http:/
 [
     {
         "L": {
-            "en": [
-                "one",
-                "two",
-                "three"
-            ],
-            "es": [
-                "uno",
-                "dos",
-                "tres"
-            ],
-            "sv": [
-                "ett",
-                "tvaa",
-                "tre"
-            ]
+            "languageMap": {
+                "en": [
+                    "one",
+                    "two",
+                    "three"
+                ],
+                "es": [
+                    "uno",
+                    "dos",
+                    "tres"
+                ],
+                "sv": [
+                    "ett",
+                    "tvaa",
+                    "tre"
+                ]
+            }
         },
         "id": "urn:ngsi-ld:T:E1",
         "type": "T"

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_forward_get_entity-with-clashing-attribute-instances.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_forward_get_entity-with-clashing-attribute-instances.test
@@ -504,24 +504,28 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http:/
 08. GET E1 on CB - see E1 with P1 from CB, P2 from CP1 and P3 from CP2, with keyValues
 ======================================================================================
 HTTP/1.1 200 OK
-Content-Length: 201
+Content-Length: 233
 Content-Type: application/json
 Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "L2": {
-        "en": "Local Food",
-        "es": "comida local",
-        "se": "Lokal mat"
+        "languageMap": {
+            "en": "Local Food",
+            "es": "comida local",
+            "se": "Lokal mat"
+        }
     },
     "P1": "local P1",
     "P2": "P2 in CP1",
     "P3": "P3 in CP2",
     "food": {
-        "en": "CP2 Food",
-        "es": "comida en CP2",
-        "se": "Mat i CP2"
+        "languageMap": {
+            "en": "CP2 Food",
+            "es": "comida en CP2",
+            "se": "Mat i CP2"
+        }
     },
     "id": "urn:E1",
     "type": "T"
@@ -806,7 +810,7 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http:/
 17. GET E1 on CB - as 06 plus G2, R1, and R2, with keyValues
 ============================================================
 HTTP/1.1 200 OK
-Content-Length: 291
+Content-Length: 323
 Content-Type: application/json
 Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
@@ -821,9 +825,11 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http:/
         "type": "Point"
     },
     "L2": {
-        "en": "Local Food",
-        "es": "comida local",
-        "se": "Lokal mat"
+        "languageMap": {
+            "en": "Local Food",
+            "es": "comida local",
+            "se": "Lokal mat"
+        }
     },
     "P1": "local P1",
     "P2": "P2 in CP1",
@@ -831,9 +837,11 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http:/
     "R1": "urn:local:E1:R1",
     "R2": "urn:local:E1:R2",
     "food": {
-        "en": "CP2 Food",
-        "es": "comida en CP2",
-        "se": "Mat i CP2"
+        "languageMap": {
+            "en": "CP2 Food",
+            "es": "comida en CP2",
+            "se": "Mat i CP2"
+        }
     },
     "id": "urn:E1",
     "type": "T"
@@ -1033,7 +1041,7 @@ Date: REGEX(.*)
 21. GET E1 on CB with Accept: application/geo+json and geoproperty==G2 AND with keyValues
 =========================================================================================
 HTTP/1.1 200 OK
-Content-Length: 446
+Content-Length: 478
 Content-Type: application/geo+json
 Date: REGEX(.*)
 
@@ -1058,9 +1066,11 @@ Date: REGEX(.*)
             "type": "Point"
         },
         "L2": {
-            "en": "Local Food",
-            "es": "comida local",
-            "se": "Lokal mat"
+            "languageMap": {
+                "en": "Local Food",
+                "es": "comida local",
+                "se": "Lokal mat"
+            }
         },
         "P1": "local P1",
         "P2": "P2 in CP1",
@@ -1068,9 +1078,11 @@ Date: REGEX(.*)
         "R1": "urn:local:E1:R1",
         "R2": "urn:local:E1:R2",
         "food": {
-            "en": "CP2 Food",
-            "es": "comida en CP2",
-            "se": "Mat i CP2"
+            "languageMap": {
+                "en": "CP2 Food",
+                "es": "comida en CP2",
+                "se": "Mat i CP2"
+            }
         },
         "type": "T"
     },

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_forward_get_entity.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_forward_get_entity.test
@@ -39,9 +39,9 @@ brokerStart CP4 0 IPv4 -experimental
 --SHELL--
 #
 # Test:
-# - Create E1 on CB with attribute P1
-# - Create E1 on CP1 with attribute P2
-# - Create E1 on CP2 with attribute P3
+# - Create E1 on CB with attribute P1, L1
+# - Create E1 on CP1 with attribute P2, L2
+# - Create E1 on CP2 with attribute P3, L3
 # - Create E1 on CP3 with attribute P4
 # - Create E1 on CP4 with attribute P1-P5
 # - Register CP1 (E1/P2) on CB as an Exclusive registration
@@ -50,50 +50,56 @@ brokerStart CP4 0 IPv4 -experimental
 # - Register CP4 (E1/P1-5) on CB as an Auxiliary registration
 # - GET E1 on CB - see E1 with P1-P5 (only P5 from CP4)
 #
-# 01. Create E1 on CB with attribute P1
-# 02. Create E1 on CP1 with attribute P2
-# 03. Create E1 on CP2 with attribute P3
+# 01. Create E1 on CB with attributes P1, L1
+# 02. Create E1 on CP1 with attributes P2, L2
+# 03. Create E1 on CP2 with attributes P3, L3
 # 04. Create E1 on CP3 with attribute P4
 # 05. Create E1 on CP4 with attribute P1-P5
 # 06. Register CP1 (E1/P2) on CB as an Exclusive registration
 # 07. Register CP2 (E1/P3) on CB as an Redirect registration
 # 08. Register CP3 (E1/P4) on CB as an Inclusive registration
 # 09. Register CP4 (E1/P1-5) on CB as an Auxiliary registration
-# 10. GET E1 on CB - see E1 with P1-P5 (only P5 from CP4)
+# 10. GET E1 on CB - see E1 with P1-P5, L1-L3 (only P5 from CP4)
 # 11. GET E1 on CB with attrs=P1,P3,P5,P7
 # 12. GET E1 on CB with attrs=P1,P2,P5,P7
+# 13. GET E1 on CB with options=keyValues
+# 14. GET E1 on CB with lang=es
+# 15. GET E1 on CB with options=keyValues AND lang=es
 #
 
-echo "01. Create E1 on CB with attribute P1"
-echo "====================================="
+echo "01. Create E1 on CB with attributes P1, L1"
+echo "=========================================="
 payload='{
   "id": "urn:E1",
   "type": "T",
-  "P1": "For local"
+  "P1": "For local",
+  "L1": { "languageMap": { "en": "yes", "es": "si" } }
 }'
 orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
 echo
 echo
 
 
-echo "02. Create E1 on CP1 with attribute P2"
-echo "======================================"
+echo "02. Create E1 on CP1 with attributes P2, L2"
+echo "==========================================="
 payload='{
   "id": "urn:E1",
   "type": "T",
-  "P2": "For CP1"
+  "P2": "For CP1",
+  "L2": { "languageMap": { "en": "yes", "es": "si" } }
 }'
 orionCurl --url /ngsi-ld/v1/entities --payload "$payload" --port $CP1_PORT
 echo
 echo
 
 
-echo "03. Create E1 on CP2 with attribute P3"
-echo "======================================"
+echo "03. Create E1 on CP2 with attributes P3, L3"
+echo "==========================================="
 payload='{
   "id": "urn:E1",
   "type": "T",
-  "P3": "For CP2"
+  "P3": "For CP2",
+  "L3": { "languageMap": { "en": "yes", "es": "si" } }
 }'
 orionCurl --url /ngsi-ld/v1/entities --payload "$payload" --port $CP2_PORT
 echo
@@ -141,7 +147,7 @@ payload='{
           "type": "T"
         }
       ],
-      "properties": [ "P2" ]
+      "properties": [ "P2", "L2" ]
     }
   ],
   "endpoint": "http://localhost:'$CP1_PORT'",
@@ -166,7 +172,7 @@ payload='{
           "type": "T"
         }
       ],
-      "properties": [ "P3" ]
+      "properties": [ "P3", "L3" ]
     }
   ],
   "endpoint": "http://localhost:'$CP2_PORT'",
@@ -228,8 +234,8 @@ echo
 echo
 
 
-echo "10. GET E1 on CB - see E1 with P1-P5 (only P5 from CP4)"
-echo "======================================================="
+echo "10. GET E1 on CB - see E1 with P1-P5, L1-L3 (only P5 from CP4)"
+echo "=============================================================="
 orionCurl --url /ngsi-ld/v1/entities/urn:E1
 echo
 echo
@@ -249,9 +255,30 @@ echo
 echo
 
 
+echo "13. GET E1 on CB with options=keyValues"
+echo "======================================="
+orionCurl --url /ngsi-ld/v1/entities/urn:E1?options=keyValues
+echo
+echo
+
+
+echo "14. GET E1 on CB with lang=es"
+echo "============================="
+orionCurl --url /ngsi-ld/v1/entities/urn:E1?lang=es
+echo
+echo
+
+
+echo "15. GET E1 on CB with options=keyValues AND lang=es"
+echo "==================================================="
+orionCurl --url '/ngsi-ld/v1/entities/urn:E1?options=keyValues&lang=es'
+echo
+echo
+
+
 --REGEXPECT--
-01. Create E1 on CB with attribute P1
-=====================================
+01. Create E1 on CB with attributes P1, L1
+==========================================
 HTTP/1.1 201 Created
 Content-Length: 0
 Date: REGEX(.*)
@@ -259,8 +286,8 @@ Location: /ngsi-ld/v1/entities/urn:E1
 
 
 
-02. Create E1 on CP1 with attribute P2
-======================================
+02. Create E1 on CP1 with attributes P2, L2
+===========================================
 HTTP/1.1 201 Created
 Content-Length: 0
 Date: REGEX(.*)
@@ -268,8 +295,8 @@ Location: /ngsi-ld/v1/entities/urn:E1
 
 
 
-03. Create E1 on CP2 with attribute P3
-======================================
+03. Create E1 on CP2 with attributes P3, L3
+===========================================
 HTTP/1.1 201 Created
 Content-Length: 0
 Date: REGEX(.*)
@@ -331,15 +358,36 @@ Location: /ngsi-ld/v1/csourceRegistrations/urn:R4
 
 
 
-10. GET E1 on CB - see E1 with P1-P5 (only P5 from CP4)
-=======================================================
+10. GET E1 on CB - see E1 with P1-P5, L1-L3 (only P5 from CP4)
+==============================================================
 HTTP/1.1 200 OK
-Content-Length: 243
+Content-Length: 453
 Content-Type: application/json
 Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
+    "L1": {
+        "languageMap": {
+            "en": "yes",
+            "es": "si"
+        },
+        "type": "LanguageProperty"
+    },
+    "L2": {
+        "languageMap": {
+            "en": "yes",
+            "es": "si"
+        },
+        "type": "LanguageProperty"
+    },
+    "L3": {
+        "languageMap": {
+            "en": "yes",
+            "es": "si"
+        },
+        "type": "LanguageProperty"
+    },
     "P1": {
         "type": "Property",
         "value": "For local"
@@ -412,6 +460,114 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http:/
         "type": "Property",
         "value": "For CP4"
     },
+    "id": "urn:E1",
+    "type": "T"
+}
+
+
+13. GET E1 on CB with options=keyValues
+=======================================
+HTTP/1.1 200 OK
+Content-Length: 235
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+{
+    "L1": {
+        "languageMap": {
+            "en": "yes",
+            "es": "si"
+        }
+    },
+    "L2": {
+        "languageMap": {
+            "en": "yes",
+            "es": "si"
+        }
+    },
+    "L3": {
+        "languageMap": {
+            "en": "yes",
+            "es": "si"
+        }
+    },
+    "P1": "For local",
+    "P2": "For CP1",
+    "P3": "For CP2",
+    "P4": "For CP3",
+    "P5": "For CP4",
+    "id": "urn:E1",
+    "type": "T"
+}
+
+
+14. GET E1 on CB with lang=es
+=============================
+HTTP/1.1 200 OK
+Content-Length: 393
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+{
+    "L1": {
+        "lang": "es",
+        "type": "Property",
+        "value": "si"
+    },
+    "L2": {
+        "lang": "es",
+        "type": "Property",
+        "value": "si"
+    },
+    "L3": {
+        "lang": "es",
+        "type": "Property",
+        "value": "si"
+    },
+    "P1": {
+        "type": "Property",
+        "value": "For local"
+    },
+    "P2": {
+        "type": "Property",
+        "value": "For CP1"
+    },
+    "P3": {
+        "type": "Property",
+        "value": "For CP2"
+    },
+    "P4": {
+        "type": "Property",
+        "value": "For CP3"
+    },
+    "P5": {
+        "type": "Property",
+        "value": "For CP4"
+    },
+    "id": "urn:E1",
+    "type": "T"
+}
+
+
+15. GET E1 on CB with options=keyValues AND lang=es
+===================================================
+HTTP/1.1 200 OK
+Content-Length: 133
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+{
+    "L1": "si",
+    "L2": "si",
+    "L3": "si",
+    "P1": "For local",
+    "P2": "For CP1",
+    "P3": "For CP2",
+    "P4": "For CP3",
+    "P5": "For CP4",
     "id": "urn:E1",
     "type": "T"
 }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_patch_entity2-and-delete-attribute-in-simplified.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_patch_entity2-and-delete-attribute-in-simplified.test
@@ -141,15 +141,17 @@ Date: REGEX(.*)
 03. GET E1 - make sure P1 is gone
 =================================
 HTTP/1.1 200 OK
-Content-Length: 69
+Content-Length: 85
 Content-Type: application/json
 Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "LP1": {
-        "en": "yes",
-        "es": "si"
+        "languageMap": {
+            "en": "yes",
+            "es": "si"
+        }
     },
     "R1": "urn:E1",
     "id": "urn:E1",
@@ -167,15 +169,17 @@ Date: REGEX(.*)
 05. GET E1 - make sure R1 is gone
 =================================
 HTTP/1.1 200 OK
-Content-Length: 55
+Content-Length: 71
 Content-Type: application/json
 Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "LP1": {
-        "en": "yes",
-        "es": "si"
+        "languageMap": {
+            "en": "yes",
+            "es": "si"
+        }
     },
     "id": "urn:E1",
     "type": "T"

--- a/test/functionalTest/cases/0000_ngsild/ngsild_patch_entity2-and-delete-attribute-inside-json-object-with-attr-type.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_patch_entity2-and-delete-attribute-inside-json-object-with-attr-type.test
@@ -152,15 +152,17 @@ Date: REGEX(.*)
 03. GET E1 - make sure P1 is gone
 =================================
 HTTP/1.1 200 OK
-Content-Length: 69
+Content-Length: 85
 Content-Type: application/json
 Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "LP1": {
-        "en": "yes",
-        "es": "si"
+        "languageMap": {
+            "en": "yes",
+            "es": "si"
+        }
     },
     "R1": "urn:E1",
     "id": "urn:E1",
@@ -178,15 +180,17 @@ Date: REGEX(.*)
 05. GET E1 - make sure R1 is gone
 =================================
 HTTP/1.1 200 OK
-Content-Length: 55
+Content-Length: 71
 Content-Type: application/json
 Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "LP1": {
-        "en": "yes",
-        "es": "si"
+        "languageMap": {
+            "en": "yes",
+            "es": "si"
+        }
     },
     "id": "urn:E1",
     "type": "T"

--- a/test/functionalTest/cases/0000_ngsild/ngsild_patch_entity2-and-delete-attribute-inside-json-object-without-attr-type.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_patch_entity2-and-delete-attribute-inside-json-object-without-attr-type.test
@@ -149,15 +149,17 @@ Date: REGEX(.*)
 03. GET E1 - make sure P1 is gone
 =================================
 HTTP/1.1 200 OK
-Content-Length: 69
+Content-Length: 85
 Content-Type: application/json
 Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "LP1": {
-        "en": "yes",
-        "es": "si"
+        "languageMap": {
+            "en": "yes",
+            "es": "si"
+        }
     },
     "R1": "urn:E1",
     "id": "urn:E1",
@@ -175,15 +177,17 @@ Date: REGEX(.*)
 05. GET E1 - make sure R1 is gone
 =================================
 HTTP/1.1 200 OK
-Content-Length: 55
+Content-Length: 71
 Content-Type: application/json
 Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "LP1": {
-        "en": "yes",
-        "es": "si"
+        "languageMap": {
+            "en": "yes",
+            "es": "si"
+        }
     },
     "id": "urn:E1",
     "type": "T"

--- a/test/functionalTest/cases/0000_ngsild/ngsild_patch_entity2-and-delete-attribute-inside-json-object.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_patch_entity2-and-delete-attribute-inside-json-object.test
@@ -176,7 +176,7 @@ Date: REGEX(.*)
 03. GET E1 - make sure P1 is gone
 =================================
 HTTP/1.1 200 OK
-Content-Length: 111
+Content-Length: 127
 Content-Type: application/json
 Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
@@ -190,8 +190,10 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http:/
         "type": "Point"
     },
     "LP1": {
-        "en": "yes",
-        "es": "si"
+        "languageMap": {
+            "en": "yes",
+            "es": "si"
+        }
     },
     "R1": "urn:E1",
     "id": "urn:E1",
@@ -209,7 +211,7 @@ Date: REGEX(.*)
 05. GET E1 - make sure R1 is gone
 =================================
 HTTP/1.1 200 OK
-Content-Length: 97
+Content-Length: 113
 Content-Type: application/json
 Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
@@ -223,8 +225,10 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http:/
         "type": "Point"
     },
     "LP1": {
-        "en": "yes",
-        "es": "si"
+        "languageMap": {
+            "en": "yes",
+            "es": "si"
+        }
     },
     "id": "urn:E1",
     "type": "T"

--- a/test/functionalTest/cases/0000_ngsild/ngsild_patch_entity2-and-delete-attribute-with-wrong-type.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_patch_entity2-and-delete-attribute-with-wrong-type.test
@@ -152,15 +152,17 @@ Date: REGEX(.*)
 03. GET E1 - make sure P1 is still there
 ========================================
 HTTP/1.1 200 OK
-Content-Length: 76
+Content-Length: 92
 Content-Type: application/json
 Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "LP1": {
-        "en": "yes",
-        "es": "si"
+        "languageMap": {
+            "en": "yes",
+            "es": "si"
+        }
     },
     "P1": 1,
     "R1": "urn:E1",
@@ -186,15 +188,17 @@ Date: REGEX(.*)
 05. GET E1 - make sure R1 is still there
 ========================================
 HTTP/1.1 200 OK
-Content-Length: 76
+Content-Length: 92
 Content-Type: application/json
 Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "LP1": {
-        "en": "yes",
-        "es": "si"
+        "languageMap": {
+            "en": "yes",
+            "es": "si"
+        }
     },
     "P1": 1,
     "R1": "urn:E1",
@@ -220,15 +224,17 @@ Date: REGEX(.*)
 07. GET E1 - make sure LP1 is still there
 =========================================
 HTTP/1.1 200 OK
-Content-Length: 76
+Content-Length: 92
 Content-Type: application/json
 Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "LP1": {
-        "en": "yes",
-        "es": "si"
+        "languageMap": {
+            "en": "yes",
+            "es": "si"
+        }
     },
     "P1": 1,
     "R1": "urn:E1",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_simplified_GET_Entity-II.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_simplified_GET_Entity-II.test
@@ -30,8 +30,13 @@ brokerStart CB 0 IPv4 -experimental
 
 --SHELL--
 
-echo "01. Create an Entity"
-echo "===================="
+#
+# 01. Create two entities
+# 02. GET one of the entities with ?options=keyValues
+#
+
+echo "01. Create two entities"
+echo "======================="
 payload='[
     {
         "id": "urn:ngsi-ld:City:001",
@@ -122,16 +127,16 @@ echo
 
 
 
-echo "02. GET the entity with ?options=keyValues"
-echo "=========================================="
-orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:City:001/?options=keyValues
+echo "02. GET one of the entities with ?options=keyValues"
+echo "==================================================="
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:City:001?options=keyValues
 echo
 echo
 
 
 --REGEXPECT--
-01. Create an Entity
-====================
+01. Create two entities
+=======================
 HTTP/1.1 201 Created
 Content-Length: 47
 Content-Type: application/json
@@ -143,10 +148,10 @@ Date: REGEX(.*)
 ]
 
 
-02. GET the entity with ?options=keyValues
-==========================================
+02. GET one of the entities with ?options=keyValues
+===================================================
 HTTP/1.1 200 OK
-Content-Length: 378
+Content-Length: 394
 Content-Type: application/json
 Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
@@ -167,8 +172,10 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http:/
         "type": "Point"
     },
     "name": {
-        "en": "Constantinople",
-        "tr": "Istanbul"
+        "languageMap": {
+            "en": "Constantinople",
+            "tr": "Istanbul"
+        }
     },
     "population": 15840900,
     "runBy": "urn:ngsi-ld:Adminstration:Cumhuriyet_Halk_Partisi",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_simplified_GET_Entity-II.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_simplified_GET_Entity-II.test
@@ -1,0 +1,183 @@
+# Copyright 2022 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+GET Entity in simplified output format
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+brokerStart CB 0 IPv4 -experimental
+
+--SHELL--
+
+echo "01. Create an Entity"
+echo "===================="
+payload='[
+    {
+        "id": "urn:ngsi-ld:City:001",
+        "type": "City",
+        "temperature": {
+            "type": "Property",
+            "value": 25,
+            "unitCode": "CEL",
+            "observedAt": "2022-06-30T00:00:00.000Z"
+        },
+        "location": {
+            "type": "GeoProperty",
+            "value": {
+                "type": "Point",
+                "coordinates": [
+                    28.955,
+                    41.0136
+                ]
+            }
+        },
+        "population": {
+            "type": "Property",
+            "value": 15840900,
+            "observedAt": "2022-12-31T00:00:00.000Z"
+        },
+        "address": {
+            "type": "Property",
+            "value": {
+                "streetAddress": "Kanlica Iskele Meydani",
+                "addressRegion": "Istanbul",
+                "addressLocality": "Besiktas",
+                "postalCode": "12345"
+            }
+        },
+        "name": {
+            "type": "LanguageProperty",
+            "languageMap": {
+                "en": "Constantinople",
+                "tr": "Istanbul"
+            }
+        },
+        "runBy": {
+            "type": "Relationship",
+            "object": "urn:ngsi-ld:Adminstration:Cumhuriyet_Halk_Partisi"
+        }
+    },
+    {
+        "id": "urn:ngsi-ld:City:002",
+        "type": "City",
+        "temperature": {
+            "value": 25,
+            "unitCode": "CEL",
+            "observedAt": "2022-06-30T00:00:00.000Z"
+        },
+        "address": {
+            "value": {
+                "streetAddress": "Viale di Valle Aurelia",
+                "addressRegion": "Lazio",
+                "addressLocality": "Roma",
+                "postalCode": "00138"
+            }
+        },
+        "location": {
+            "type": "Point",
+            "coordinates": [
+                12.482,
+                41.893
+            ]
+        },
+        "population": {
+            "value": 4342212,
+            "observedAt": "2021-01-01T00:00:00.000Z"
+        },
+        "name": {
+            "languageMap": {
+                "en": "Rome",
+                "it": "Roma"
+            }
+        },
+        "runBy": {
+            "object": "urn:ngsi-ld:Adminstration:Partito_Democratico"
+        }
+    }
+]'
+orionCurl --url /ngsi-ld/v1/entityOperations/upsert --payload "$payload"
+echo
+echo
+
+
+
+echo "02. GET the entity with ?options=keyValues"
+echo "=========================================="
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:City:001/?options=keyValues
+echo
+echo
+
+
+--REGEXPECT--
+01. Create an Entity
+====================
+HTTP/1.1 201 Created
+Content-Length: 47
+Content-Type: application/json
+Date: REGEX(.*)
+
+[
+    "urn:ngsi-ld:City:001",
+    "urn:ngsi-ld:City:002"
+]
+
+
+02. GET the entity with ?options=keyValues
+==========================================
+HTTP/1.1 200 OK
+Content-Length: 378
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+{
+    "address": {
+        "addressLocality": "Besiktas",
+        "addressRegion": "Istanbul",
+        "postalCode": "12345",
+        "streetAddress": "Kanlica Iskele Meydani"
+    },
+    "id": "urn:ngsi-ld:City:001",
+    "location": {
+        "coordinates": [
+            28.955,
+            41.0136
+        ],
+        "type": "Point"
+    },
+    "name": {
+        "en": "Constantinople",
+        "tr": "Istanbul"
+    },
+    "population": 15840900,
+    "runBy": "urn:ngsi-ld:Adminstration:Cumhuriyet_Halk_Partisi",
+    "temperature": 25,
+    "type": "City"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB
+

--- a/test/functionalTest/cases/0000_ngsild/ngsild_simplified_GET_Entity.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_simplified_GET_Entity.test
@@ -26,7 +26,7 @@ GET Entity in Concise Format
 --SHELL-INIT--
 export BROKER=orionld
 dbInit CB
-brokerStart CB
+brokerStart CB 0 IPv4 -experimental
 
 --SHELL--
 
@@ -44,6 +44,7 @@ brokerStart CB
 # 07. Attempt with Concise+KeyValues+Normalized
 # 08. Attempt with KeyValues+sysAttrs
 # 09. GET E1 in Concise output format w/ sysAttrs
+# 10. GET E1 in Simplified output format
 #
 
 echo "01. Create an entity E1 attributes of all types, and sub-attrs of all types"
@@ -126,6 +127,13 @@ echo
 echo "09. GET E1 in Concise output format w/ sysAttrs"
 echo "==============================================="
 orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entities:E1?options=concise,sysAttrs
+echo
+echo
+
+
+echo "10. GET E1 in Simplified output format"
+echo "======================================"
+orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:entities:E1?options=simplified&attrs=Geo,Int,Rel'
 echo
 echo
 
@@ -460,6 +468,29 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http:/
     "createdAt": "REGEX(.*)",
     "id": "urn:ngsi-ld:entities:E1",
     "modifiedAt": "REGEX(.*)",
+    "type": "T"
+}
+
+
+10. GET E1 in Simplified output format
+======================================
+HTTP/1.1 200 OK
+Content-Length: 126
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+{
+    "Geo": {
+        "coordinates": [
+            1,
+            2
+        ],
+        "type": "Point"
+    },
+    "Int": 1,
+    "Rel": "urn:ngsi-ld:entities:E2",
+    "id": "urn:ngsi-ld:entities:E1",
     "type": "T"
 }
 

--- a/test/functionalTest/testHarness.sh
+++ b/test/functionalTest/testHarness.sh
@@ -672,7 +672,6 @@ then
         echo "... Context Server Started"
         sleep 3  # Very slow - it doesn't work without this delay
     else
-        echo "The Context Server is already running."
         pushContexts=0                                 # Assuming the @contexts have been pushed already
     fi
 else


### PR DESCRIPTION
The format for LanguageProperty in Simplified Format has recently been changed in the NGSi-LD API.
This PR fixes that and the new format is now supported.

Instead of (old):
```
"L1": { "en": "yes", "es": "si" }
```
it is now:
```
"L1": { "languageMap": { "en": "yes", "es": "si" } }
```

The reason behind the modification of the API is that the language tags ("en", "es") are expanded due to JSON-LD rules.
The "languageMap" is defined in the core context to NOT expand the keys.