### PR TITLE
Bug fix: It's OK to use arrays for both 'id' and 'type' URL parameters

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -37,3 +37,4 @@
 * Issue #1261  'lang' URI param support for PATCH /entities/{entityId}
 * Issue #1287  Fixed a bug in GET /entities/{entityId}?attrs=xxx, that always included 'location' in the response
 * Issue #280   Implemented the new format for LanguageProperty in Simplified Format (including the 'languageMap' field)
+* Issue #280   It's OK to use arrays for both 'id' and 'type' URL parameters

--- a/src/lib/orionld/serviceRoutines/orionldGetEntities.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntities.cpp
@@ -316,16 +316,6 @@ bool orionldGetEntities(void)
   if      (orionldState.in.typeList.items == 0) type = (char*) ".*";
   else if (orionldState.in.typeList.items == 1) type = orionldState.in.typeList.array[0];
 
-  //
-  // ID-list and Type-list at the same time is not supported
-  //
-  if ((orionldState.in.idList.items > 1) && (orionldState.in.typeList.items > 1))
-  {
-    LM_W(("Bad Input (URI params /id/ and /type/ are both lists - Not Permitted)"));
-    orionldError(OrionldBadRequestData, "URI params /id/ and /type/ are both lists", "Not Permitted", 400);
-    return false;
-  }
-
   OrionldGeoInfo geoInfo;
   if (geoCheck(&geoInfo) == false)
     return false;

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_uri_params_in_orionldState.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_uri_params_in_orionldState.test
@@ -61,16 +61,12 @@ echo
 --REGEXPECT--
 01. GET Entity with four URI Params: id, type, idPattern, and attrs, all four with valid values, but, two arrays
 ================================================================================================================
-HTTP/1.1 400 Bad Request
-Content-Length: 138
+HTTP/1.1 200 OK
+Content-Length: 2
 Content-Type: application/json
 Date: REGEX(.*)
 
-{
-    "detail": "Not Permitted",
-    "title": "URI params /id/ and /type/ are both lists",
-    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
-}
+[]
 
 
 02. GET Entity with 'id=' - no value for id


### PR DESCRIPTION
Bug fix: It's OK to use arrays for both 'id' and 'type' URL parameters