### PR TITLE
Issue #1260  Invalid longname of a attribute in error responses

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -39,3 +39,4 @@
 * Issue #280   Implemented the new format for LanguageProperty in Simplified Format (including the 'languageMap' field)
 * Issue #280   It's OK to use arrays for both 'id' and 'type' URL parameters
 * Issue #1297  Fixed a typo in a string (modifiededAt => modifiedAt)
+* Issue #1260  Invalid longname of a attribute in error responses (eq-sign instead of dot)

--- a/src/lib/orionld/legacyDriver/legacyPatchAttribute.cpp
+++ b/src/lib/orionld/legacyDriver/legacyPatchAttribute.cpp
@@ -646,7 +646,7 @@ static KjNode* attributeFromDb(char* entityId, char* attrName, char* attrNameExp
   if (dbEntityP == NULL)
   {
     char* pair = kaAlloc(&orionldState.kalloc, 1024);
-    snprintf(pair, 1024, "Entity '%s', Attribute '%s' (%s)", entityId, attrName, attrNameExpandedEq);
+    snprintf(pair, 1024, "Entity '%s', Attribute '%s' (%s)", entityId, attrName, attrNameExpanded);
     orionldError(OrionldResourceNotFound, "Entity/Attribute not found", pair, 404);
     return NULL;
   }
@@ -660,7 +660,7 @@ static KjNode* attributeFromDb(char* entityId, char* attrName, char* attrNameExp
   // Get the attribute named attrNameExpandedEq from the "attrs" field of the DB Entity
   KjNode* dbAttributeP = kjLookup(dbAttrs, attrNameExpandedEq);
   if (dbAttributeP == NULL)
-    DB_ERROR(NULL, "Database Error (attribute not found)", attrNameExpandedEq);
+    DB_ERROR(NULL, "Database Error (attribute not found)", attrNameExpanded);
 
   return dbAttributeP;
 }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_attribute_delete.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_attribute_delete.test
@@ -61,7 +61,7 @@ echo
 
 echo "02. Try to delete the attribute A1 of entity E2 - entity not found"
 echo "=================================================================="
-orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld/entities/E2/attrs/https://uri=etsi=org/ngsi-ld/default/A1 -X DELETE
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld/entities/E2/attrs/https://uri.etsi.org/ngsi-ld/default/A1 -X DELETE
 echo
 echo
 
@@ -120,7 +120,7 @@ Content-Type: application/json
 Date: REGEX(.*)
 
 {
-    "detail": "https://uri=etsi=org/ngsi-ld/default/A1",
+    "detail": "https://uri.etsi.org/ngsi-ld/default/A1",
     "title": "Entity/Attribute not found",
     "type": "https://uri.etsi.org/ngsi-ld/errors/ResourceNotFound"
 }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_attribute_patch.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_attribute_patch.test
@@ -1,0 +1,129 @@
+# Copyright 2023 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Attribute Delete
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+brokerStart CB 0-255
+
+--SHELL--
+
+#
+# 01. Create an entity E1 with attributes A1 and A2
+# 02. Attempt to patch attribute A3 - make sure the longname of the attribute is correct (dots, not equals)
+# 03. Attempt to patch attribute A3 on an entity E2 - make sure the longname of the attribute is correct (dots, not equals)
+#
+
+echo "01. Create an entity E1 with attributes A1 and A2"
+echo "================================================="
+payload='{
+  "id": "urn:ngsi-ld/entities/E1",
+  "type": "T",
+  "A1": {
+    "type": "Property",
+    "value": "A1"
+  },
+  "A2": {
+    "type": "Property",
+    "value": "A2"
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "02. Attempt to patch attribute A3 - make sure the longname of the attribute is correct (dots, not equals)"
+echo "========================================================================================================="
+payload='{
+  "A3": {
+    "type": "Property",
+    "value": "A3"
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld/entities/E1/attrs -X PATCH --payload "$payload"
+echo
+echo
+
+
+echo "03. Attempt to patch attribute A3 on an entity E2 - make sure the longname of the attribute is correct (dots, not equals)"
+echo "========================================================================================================================="
+payload='{
+  "A3": {
+    "type": "Property",
+    "value": "A3"
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld/entities/E2/attrs -X PATCH --payload "$payload"
+echo
+echo
+
+
+--REGEXPECT--
+01. Create an entity E1 with attributes A1 and A2
+=================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld/entities/E1
+
+
+
+02. Attempt to patch attribute A3 - make sure the longname of the attribute is correct (dots, not equals)
+=========================================================================================================
+HTTP/1.1 207 Multi-Status
+Content-Length: 136
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+{
+    "notUpdated": [
+        {
+            "attributeName": "A3",
+            "reason": "attribute doesn't exist: https://uri.etsi.org/ngsi-ld/default-context/A3"
+        }
+    ],
+    "updated": []
+}
+
+
+03. Attempt to patch attribute A3 on an entity E2 - make sure the longname of the attribute is correct (dots, not equals)
+=========================================================================================================================
+HTTP/1.1 404 Not Found
+Content-Length: 130
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "urn:ngsi-ld/entities/E2",
+    "title": "Entity does not exist",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/ResourceNotFound"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_1224.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_1224.test
@@ -1,0 +1,202 @@
+# Copyright 2023 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Issue #1224 without -experimental
+
+--SHELL-INIT--
+export BROKER=orionld
+dbInit CB
+brokerStart CB 0 IPv4 -experimental
+accumulatorStart --pretty-print 127.0.0.1 ${LISTENER_PORT}
+
+--SHELL--
+
+#
+# 01. Create an entity according to (1) of issue #1224
+# 02. Create a subscription according to (2) of issue #1224
+# 03. Patching the entity according to (3) of issue #1224
+# 04. Dump the accumulator, see no notification
+# 05. Patching the other attribute (pm10)
+# 06. Dump the accumulator, see one notification
+#
+
+echo "01. Create an entity TemperatureSensor:001 with two attributes"
+echo "=============================================================="
+payload='{
+   "id":"urn:ngsi-ld:AirQualityObserved:Guadalajara:ES1537A",
+   "type":"AirQualityObserved",
+   "pm10":{
+      "type":"Property",
+      "value": 1
+   },
+   "so2":{
+      "type":"Property",
+      "value": 2
+   },
+   "@context": ["https://smartdatamodels.org/context.jsonld"]
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload" --in jsonld
+echo
+echo
+
+
+echo "02. Create a subscription according to (2) of issue #1224"
+echo "========================================================="
+payload='{
+ "description": "A subscription to get air quality",
+  "type": "Subscription",
+  "entities": [
+    {
+      "type": "AirQualityObserved"
+    }
+  ],
+  "watchedAttributes": [ "pm10" ],
+  "notification": {
+    "endpoint": {
+      "uri": "http://localhost:'$LISTENER_PORT'/notify",
+      "accept": "application/json"
+    }
+  },
+  "@context": "https://smartdatamodels.org/context.jsonld"
+}'
+orionCurl --url /ngsi-ld/v1/subscriptions --payload "$payload" --in jsonld
+echo
+echo
+
+
+echo "03. Patching the entity according to (3) of issue #1224"
+echo "======================================================="
+payload='{
+  "so2":{
+    "type":"Property",
+    "value": 40
+  },
+  "@context": ["https://smartdatamodels.org/context.jsonld"]
+}'
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:AirQualityObserved:Guadalajara:ES1537A/attrs -X PATCH --payload "$payload" --in jsonld
+echo
+echo
+
+
+echo "04. Dump the accumulator, see no notification"
+echo "============================================="
+accumulatorDump
+echo
+echo
+
+
+echo "05. Patching the other attribute (pm10)"
+echo "======================================="
+payload='{
+  "pm10":{
+    "type":"Property",
+    "value": 2
+  },
+  "@context": ["https://smartdatamodels.org/context.jsonld"]
+}'
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:AirQualityObserved:Guadalajara:ES1537A/attrs -X PATCH --payload "$payload" --in jsonld
+echo
+echo
+
+
+echo "06. Dump the accumulator, see one notification"
+echo "=============================================="
+accumulatorDump
+echo
+echo
+
+
+--REGEXPECT--
+01. Create an entity TemperatureSensor:001 with two attributes
+==============================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:AirQualityObserved:Guadalajara:ES1537A
+
+
+
+02. Create a subscription according to (2) of issue #1224
+=========================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:subscription:REGEX(.*)
+
+
+
+03. Patching the entity according to (3) of issue #1224
+=======================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+04. Dump the accumulator, see no notification
+=============================================
+
+
+05. Patching the other attribute (pm10)
+=======================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+06. Dump the accumulator, see one notification
+==============================================
+POST http://127.0.0.1:9997/notify?subscriptionId=urn:ngsi-ld:subscription:REGEX(.*)
+Content-Length: 384
+User-Agent: orionld/REGEX(.*)
+Accept: application/json
+Content-Type: application/json
+Link: <https://smartdatamodels.org/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Ngsild-Attribute-Format: Normalized
+
+{
+    "data": [
+        {
+            "id": "urn:ngsi-ld:AirQualityObserved:Guadalajara:ES1537A",
+            "pm10": {
+                "type": "Property",
+                "value": 2
+            },
+            "so2": {
+                "type": "Property",
+                "value": 40
+            },
+            "type": "AirQualityObserved"
+        }
+    ],
+    "id": "urn:ngsi-ld:Notification:REGEX(.*)",
+    "notifiedAt": "202REGEX(.*)Z",
+    "subscriptionId": "urn:ngsi-ld:subscription:REGEX(.*)",
+    "type": "Notification"
+}
+=======================================
+
+
+--TEARDOWN--
+brokerStop CB
+accumulatorStop
+dbDrop CB


### PR DESCRIPTION
Hopefully fixed Issue #1260  Invalid longname of a attribute in error responses (eq-sign instead of dot)

I wasn't able to find the exact line that the issue #1260 describes. Might be the source code has changed slightly in develop (the issue was discovered in v1.1.1).
Anyway, I searched for all occurrences of "Entity/Attribute not found" in error responses and found ONE where the incorrect attribute long name (the one prepared for mongo db) and fixed it.