### PR TITLE
Better error handling for Registration Creation

### DIFF
--- a/src/lib/orionld/payloadCheck/pCheckKeyValueArray.cpp
+++ b/src/lib/orionld/payloadCheck/pCheckKeyValueArray.cpp
@@ -107,6 +107,26 @@ bool pCheckKeyValueArray(KjNode* csiP, OrionldContext** fwdContextPP)
         return 0;
       }
     }
+    else if (strcmp(keyP->value.s, "NGSILD-Tenant") == 0)
+    {
+      orionldError(OrionldBadRequestData, "Invalid key in Registration::contextSourceInfo", keyP->value.s, 400);
+      return false;
+    }
+    else if (strcmp(keyP->value.s, "Date") == 0)
+    {
+      orionldError(OrionldBadRequestData, "Invalid key in Registration::contextSourceInfo", keyP->value.s, 400);
+      return false;
+    }
+    else if (strcmp(keyP->value.s, "Content-Length") == 0)
+    {
+      orionldError(OrionldBadRequestData, "Invalid key in Registration::contextSourceInfo", keyP->value.s, 400);
+      return false;
+    }
+    else if (strcmp(keyP->value.s, "User-Agent") == 0)
+    {
+      orionldError(OrionldBadRequestData, "Invalid key in Registration::contextSourceInfo", keyP->value.s, 400);
+      return false;
+    }
   }
 
   return true;

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_forward_http_headers.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_forward_http_headers.test
@@ -34,7 +34,7 @@ accumulatorStart --pretty-print --url /ngsi-ld/v1/entities 127.0.0.1 ${LISTENER_
 # 01. Create a registration (exclusive) for the accumulator, with all types of hjeaders inside Regostration::contextSourceInfo
 # 02. Send a request to create an Entity in the CB - will be forwarded to the accumulator (and fail, but that's OK)
 # 03. Dump the accumulator to see all the HTTP headers of the forwarded request
-# 04. PATCH the registration setting the contextSourceInfo with invalid values, see what happens in the forwarded request later
+# 04. PATCH the registration setting the contextSourceInfo, see what happens in the forwarded request later
 # 05. Send a request to create an Entity in the CB - will be forwarded to the accumulator (and fail, but that's OK)
 # 06. Dump the accumulator to see all the HTTP headers of the forwarded request
 #
@@ -96,21 +96,13 @@ echo
 echo
 
 
-echo "04. PATCH the registration setting the contextSourceInfo with invalid values, see what happens in the forwarded request later"
-echo "============================================================================================================================="
+echo "04. PATCH the registration setting the contextSourceInfo, see what happens in the forwarded request later"
+echo "========================================================================================================="
 payload='{
   "contextSourceInfo": [
     {
-      "key": "Content-Length",
-      "value": "12"
-    },
-    {
       "key": "Accept",
       "value": "application/ld+json"
-    },
-    {
-      "key": "User-Agent",
-      "value": "user-agent"
     },
     {
       "key": "Content-Type",
@@ -120,7 +112,6 @@ payload='{
       "key": "H1",
       "value": "Step 04"
     }
-    
   ]
 }'
 orionCurl --url /ngsi-ld/v1/csourceRegistrations/urn:R1 -X PATCH --payload "$payload"
@@ -132,7 +123,8 @@ echo "05. Send a request to create an Entity in the CB - will be forwarded to th
 echo "================================================================================================================="
 payload='{
   "id": "urn:E1",
-  "type": "T"
+  "type": "T",
+  "A1": 12
 }'
 orionCurl --url /ngsi-ld/v1/entities --payload "$payload" -H "FwdHeader: xyz"
 echo
@@ -185,8 +177,8 @@ Fwdheader: xyz
 =======================================
 
 
-04. PATCH the registration setting the contextSourceInfo with invalid values, see what happens in the forwarded request later
-=============================================================================================================================
+04. PATCH the registration setting the contextSourceInfo, see what happens in the forwarded request later
+=========================================================================================================
 HTTP/1.1 204 No Content
 Date: REGEX(.*)
 
@@ -204,8 +196,8 @@ Location: /ngsi-ld/v1/entities/urn:E1
 06. Dump the accumulator to see all the HTTP headers of the forwarded request
 =============================================================================
 POST http://REGEX(.*)/ngsi-ld/v1/entities
-Content-Length: 141
-User-Agent: user-agent,orionld/REGEX(.*)
+Content-Length: 222
+User-Agent: orionld/REGEX(.*)
 Host: REGEX(.*)
 Accept: application/ld+json
 Content-Type: application/json
@@ -214,6 +206,10 @@ X-Forwarded-For: REGEX(.*):9999
 H1: Step 04
 
 {
+    "https://uri.etsi.org/ngsi-ld/default-context/A1": {
+        "type": "Property",
+        "value": 12
+    },
     "id": "urn:E1",
     "type": "https://uri.etsi.org/ngsi-ld/default-context/T"
 }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_registration_create_errors.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_registration_create_errors.test
@@ -299,6 +299,12 @@ brokerStart CB 0 IPv4 -experimental
 # 175. Attempt to create a registration with a duplicated 'management:cooldown'
 # 176. Attempt to create a registration with a foreign field 'management:cooldownx'
 #
+# 177. Error if cSourceInfo contains "NGSILD-Tenant" and the Registration::tenant field is set as well
+# 178. Error if cSourceInfo contains "Content-Length"
+# 179. Error if cSourceInfo contains "Date"
+# 180. Error if cSourceInfo contains "User-Agent"
+# 
+#
 
 echo "01. Attempt to create a registration with a payload data that is not a JSON object - see failure"
 echo "================================================================================================"
@@ -2697,6 +2703,97 @@ payload='{
   "management": {
     "cooldownx": 5
   }
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload"
+echo
+echo
+
+
+echo '177. Error if cSourceInfo contains "NGSILD-Tenant" and the Registration::tenant field is set as well'
+echo '===================================================================================================='
+payload='{
+  "type": "ContextSourceRegistration",
+  "information": [ { "propertyNames": [ "P1" ] } ],
+  "endpoint": "http://a.b.c:8080/ok1",
+  "tenant": "T1",
+  "contextSourceInfo": [
+    {
+      "key": "NGSILD-Tenant",
+      "value": "T1"
+    }
+  ]
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload"
+echo
+echo
+
+
+echo '178. Error if cSourceInfo contains "Content-Length"'
+echo '==================================================='
+payload='{
+  "type": "ContextSourceRegistration",
+  "information": [ { "propertyNames": [ "P1" ] } ],
+  "endpoint": "http://a.b.c:8080/ok1",
+  "contextSourceInfo": [
+    {
+      "key": "Content-Length",
+      "value": "122"
+    }
+  ]
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload"
+echo
+echo
+
+
+echo '179. Error if cSourceInfo contains "Date"'
+echo '========================================='
+payload='{
+  "type": "ContextSourceRegistration",
+  "information": [ { "propertyNames": [ "P1" ] } ],
+  "endpoint": "http://a.b.c:8080/ok1",
+  "contextSourceInfo": [
+    {
+      "key": "Date",
+      "value": "Today"
+    }
+  ]
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload"
+echo
+echo
+
+
+echo '180. Error if cSourceInfo contains "User-Agent"'
+echo '==============================================='
+payload='{
+  "type": "ContextSourceRegistration",
+  "information": [ { "propertyNames": [ "P1" ] } ],
+  "endpoint": "http://a.b.c:8080/ok1",
+  "contextSourceInfo": [
+    {
+      "key": "User-Agent",
+      "value": "myself"
+    }
+  ]
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload"
+echo
+echo
+
+
+echo '181. No Error if cSourceInfo contains "User-HAgent" - it will be understood as a generic header'
+echo '==============================================================================================='
+payload='{
+  "type": "ContextSourceRegistration",
+  "information": [ { "propertyNames": [ "P1" ] } ],
+  "endpoint": "http://a.b.c:8080/ok1",
+  "contextSourceInfo": [
+    {
+      "key": "User-HAgent",
+      "value": "myself"
+    }
+  ]
 }'
 orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload"
 echo
@@ -5180,6 +5277,71 @@ Date: REGEX(.*)
     "title": "Unrecognized field in Registration::management",
     "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
 }
+
+
+177. Error if cSourceInfo contains "NGSILD-Tenant" and the Registration::tenant field is set as well
+====================================================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 143
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "NGSILD-Tenant",
+    "title": "Invalid key in Registration::contextSourceInfo",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+178. Error if cSourceInfo contains "Content-Length"
+===================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 144
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "Content-Length",
+    "title": "Invalid key in Registration::contextSourceInfo",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+179. Error if cSourceInfo contains "Date"
+=========================================
+HTTP/1.1 400 Bad Request
+Content-Length: 134
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "Date",
+    "title": "Invalid key in Registration::contextSourceInfo",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+180. Error if cSourceInfo contains "User-Agent"
+===============================================
+HTTP/1.1 400 Bad Request
+Content-Length: 140
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "User-Agent",
+    "title": "Invalid key in Registration::contextSourceInfo",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+181. No Error if cSourceInfo contains "User-HAgent" - it will be understood as a generic header
+===============================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/csourceRegistrations/urn:ngsi-ld:ContextSourceRegistration:REGEX(.*)
+
 
 
 --TEARDOWN--


### PR DESCRIPTION
Forbidding the following keys inside Registration::contextSourceInfo:
* NGSILD-Tenant
* Content-Length
* Date
* User-Agent

More needed, but for now ...
