### PR TITLE
Removed the check for mongoc only, as all operations now support mongoc

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -56,3 +56,4 @@
 * Issue #1322  Fixed an error in subscription stats (for -experimental)
 * Issue #1322  Implemented better notification response reception and much better log messages
 * Issue #1322  Default port for HTTPS is 443, for HTTP: 80
+* Issue #1338  Removed the check for mongoc only, as all operations now support mongoc

--- a/src/lib/orionld/rest/OrionLdRestService.h
+++ b/src/lib/orionld/rest/OrionLdRestService.h
@@ -108,7 +108,6 @@ typedef struct OrionLdRestServiceSimplifiedVector
 #define ORIONLD_SERVICE_OPTION_EXPAND_ATTR                           (1 << 9)
 #define ORIONLD_SERVICE_OPTION_ACCEPT_JSONLD_NULL                    (1 << 10)
 #define ORIONLD_SERVICE_OPTION_DATASET_SUPPORT                       (1 << 11)
-#define ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT                        (1 << 12)
 
 
 

--- a/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
@@ -1074,15 +1074,6 @@ MHD_Result orionldMhdConnectionInit
 
 
   //
-  // Is only mongoc supporting operations allowed?
-  //
-  if ((mongocOnly) && ((orionldState.serviceP->options & ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT) == 0) && (orionldState.verb != OPTIONS))
-  {
-    orionldError(OrionldOperationNotSupported, "Not Implemented", "this request does not support the new mongoc driver", 501);
-    return MHD_YES;
-  }
-
-  //
   // NGSI-LD only accepts the verbs POST, GET, DELETE, PATCH, PUT, and OPTIONS (if CORS is enabled)
   // If any other verb is used, even if a valid REST Verb, like HEAD, a generic error will be returned
   //

--- a/src/lib/orionld/rest/orionldServiceInit.cpp
+++ b/src/lib/orionld/rest/orionldServiceInit.cpp
@@ -198,13 +198,10 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
     serviceP->options    = ORIONLD_SERVICE_OPTION_PREFETCH_ID_AND_TYPE;
     serviceP->options   |= ORIONLD_SERVICE_OPTION_EXPAND_TYPE;
     serviceP->options   |= ORIONLD_SERVICE_OPTION_DATASET_SUPPORT;
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldPostNotify)
   {
     serviceP->uriParams |= ORIONLD_URIPARAM_SUBSCRIPTION_ID;
-
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldGetEntities)
   {
@@ -225,8 +222,6 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
     serviceP->uriParams |= ORIONLD_URIPARAM_GEOMETRYPROPERTY;
     serviceP->uriParams |= ORIONLD_URIPARAM_LANG;
     serviceP->uriParams |= ORIONLD_URIPARAM_LOCAL;
-
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldGetEntity)
   {
@@ -236,49 +231,39 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
     serviceP->uriParams |= ORIONLD_URIPARAM_LANG;
     serviceP->uriParams |= ORIONLD_URIPARAM_LOCAL;
     serviceP->uriParams |= ORIONLD_URIPARAM_TYPELIST;
-
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldDeleteEntity)
   {
     serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED;
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldPostEntity)
   {
     serviceP->uriParams |= ORIONLD_URIPARAM_OPTIONS;
-
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldPatchAttribute)
   {
     serviceP->options   |= ORIONLD_SERVICE_OPTION_CLONE_PAYLOAD;
     serviceP->options   |= ORIONLD_SERVICE_OPTION_EXPAND_ATTR;
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldPutAttribute)
   {
     serviceP->options   |= ORIONLD_SERVICE_OPTION_EXPAND_ATTR;
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldPatchEntity)
   {
     serviceP->options   |= ORIONLD_SERVICE_OPTION_PREFETCH_ID_AND_TYPE;
     serviceP->options   |= ORIONLD_SERVICE_OPTION_CLONE_PAYLOAD;
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldPatchEntity2)
   {
     serviceP->options   |= ORIONLD_SERVICE_OPTION_CLONE_PAYLOAD;
     serviceP->options   |= ORIONLD_SERVICE_OPTION_ACCEPT_JSONLD_NULL;
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
 
     serviceP->uriParams |= ORIONLD_URIPARAM_OPTIONS;
     serviceP->uriParams |= ORIONLD_URIPARAM_OBSERVEDAT;
   }
   else if (serviceP->serviceRoutine == orionldPutEntity)
   {
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldDeleteAttribute)
   {
@@ -286,7 +271,6 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
     serviceP->uriParams |= ORIONLD_URIPARAM_DELETEALL;
 
     serviceP->options   |= ORIONLD_SERVICE_OPTION_EXPAND_ATTR;
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldPostRegistrations)
   {
@@ -322,7 +306,7 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
   }
   else if (serviceP->serviceRoutine == orionldPatchRegistration)
   {
-    serviceP->options |= ORIONLD_SERVICE_OPTION_PREFETCH_ID_AND_TYPE;
+    serviceP->options   |= ORIONLD_SERVICE_OPTION_PREFETCH_ID_AND_TYPE;
   }
   else if (serviceP->serviceRoutine == orionldDeleteRegistration)
   {
@@ -334,12 +318,10 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
 
     serviceP->options |= ORIONLD_SERVICE_OPTION_PREFETCH_ID_AND_TYPE;
     serviceP->options |= ORIONLD_SERVICE_OPTION_CREATE_CONTEXT;
-    serviceP->options |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldGetSubscriptions)
   {
     serviceP->options   |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
 
     serviceP->uriParams |= ORIONLD_URIPARAM_OPTIONS;
     serviceP->uriParams |= ORIONLD_URIPARAM_COUNT;
@@ -349,37 +331,31 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
   else if (serviceP->serviceRoutine == orionldGetSubscription)
   {
     serviceP->options   |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
 
     serviceP->uriParams |= ORIONLD_URIPARAM_OPTIONS;
   }
   else if (serviceP->serviceRoutine == orionldPatchSubscription)
   {
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldDeleteSubscription)
   {
     serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED;
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldPostBatchCreate)
   {
     serviceP->options    = 0;  // Tenant will be created if necessary
     serviceP->options   |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldPostBatchUpdate)
   {
     serviceP->uriParams |= ORIONLD_URIPARAM_OPTIONS;
 
     serviceP->options   |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldPostBatchUpsert)
   {
     serviceP->options    = 0;  // Tenant will be created if necessary
     serviceP->options   |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
 
     serviceP->uriParams |= ORIONLD_URIPARAM_OPTIONS;
   }
@@ -387,7 +363,6 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
   {
     serviceP->options   |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
     serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED;
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldPostQuery)
   {
@@ -395,28 +370,20 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
     serviceP->uriParams |= ORIONLD_URIPARAM_COUNT;
     serviceP->uriParams |= ORIONLD_URIPARAM_LIMIT;
     serviceP->uriParams |= ORIONLD_URIPARAM_OFFSET;
-
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldGetEntityTypes)
   {
     serviceP->uriParams |= ORIONLD_URIPARAM_DETAILS;
-
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldGetEntityType)
   {
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldGetEntityAttributes)
   {
     serviceP->uriParams |= ORIONLD_URIPARAM_DETAILS;
-
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldGetEntityAttribute)
   {
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldPostTemporalEntities)
   {
@@ -424,7 +391,6 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
 
     serviceP->options |= ORIONLD_SERVICE_OPTION_PREFETCH_ID_AND_TYPE;
     serviceP->options |= ORIONLD_SERVICE_OPTION_EXPAND_TYPE;
-    serviceP->options |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldGetVersion)
   {
@@ -432,7 +398,6 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
 
     serviceP->options  = ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
     serviceP->options |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED;
-    serviceP->options |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldGetTenants)
   {
@@ -440,7 +405,6 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
 
     serviceP->options |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
     serviceP->options |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED;
-    serviceP->options |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldGetDbIndexes)
   {
@@ -448,7 +412,6 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
 
     serviceP->options |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
     serviceP->options |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED;
-    serviceP->options |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldGetContexts)
   {
@@ -459,14 +422,12 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
     serviceP->uriParams |= ORIONLD_URIPARAM_URL;
 
     serviceP->options   |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldGetContext)
   {
     serviceP->options  = 0;  // Tenant is Ignored
 
     serviceP->options   |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldPostContexts)
   {
@@ -475,7 +436,6 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
     serviceP->options   |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
     serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED;
     serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_TYPE_CHECK;
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
   }
   else if (serviceP->serviceRoutine == orionldDeleteContext)
   {
@@ -484,7 +444,6 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
     serviceP->options   |= ORIONLD_SERVICE_OPTION_DONT_ADD_CONTEXT_TO_RESPONSE_PAYLOAD;
     serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_NEEDED;
     serviceP->options   |= ORIONLD_SERVICE_OPTION_NO_CONTEXT_TYPE_CHECK;
-    serviceP->options   |= ORIONLD_SERVICE_OPTION_MONGOC_SUPPORT;
 
     serviceP->uriParams |= ORIONLD_URIPARAM_RELOAD;
   }


### PR DESCRIPTION
Fixed at least part of #1338:
Removed the check for mongoc only, as all operations now support mongoc