### PR TITLE
Trace messages for URL incoming params and HTTP headers

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -63,3 +63,6 @@
 * Issue #1348  Unsupported value added mongodb url
 * Issue #1353  properties/relationships in regs now also supported as propertyNames/relationshipNames in requests for non experimental
 * Issue #1353  properties/relationships in regs is now propertyNames/relationshipNames in all responses for GET Regs
+* Issue #280   Implemented trace messages for incoming URL parameters (trace level LmtUriParams (-t 33))
+* Issue #280   Implemented trace messages for incoming HTTP headers (trace level LmtHeaders (-t 32))
+ 

--- a/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
+++ b/src/lib/orionld/rest/orionldMhdConnectionInit.cpp
@@ -178,7 +178,7 @@ static void optionsParse(const char* options)
 
       *cP = 0;  // Zero-terminate
 
-      LM_T(LmtUriParamOptions, ("Got a value for options: %s", optionStart));
+      LM_T(LmtUriParamOptions, ("Got a value for the 'options' URI param: %s", optionStart));
 
       if      (strcmp(optionStart, "update")        == 0)  orionldState.uriParamOptions.update        = true;
       else if (strcmp(optionStart, "replace")       == 0)  orionldState.uriParamOptions.replace       = true;
@@ -225,19 +225,9 @@ static void optionsParse(const char* options)
   else if (orionldState.uriParamOptions.keyValues && orionldState.uriParamOptions.sysAttrs)
     orionldError(OrionldBadRequestData, "Incoherent value for /options/ URI param", "Can't have system attributes when /simplified/ output format is selected", 400);
   else if (orionldState.uriParamOptions.keyValues == true)
-  {
     orionldState.out.format = RF_KEYVALUES;
-    LM_T(LmtUriParamOptions, ("Set orionldState.out.format to RF_KEYVALUES"));
-  }
   else if (orionldState.uriParamOptions.concise == true)
-  {
     orionldState.out.format = RF_CONCISE;
-    LM_T(LmtUriParamOptions, ("Set orionldState.out.format to RF_CONCISE"));
-  }
-
-  LM_T(LmtUriParamOptions, ("orionldState.uriParamOptions.keyValues:  %s", (orionldState.uriParamOptions.keyValues == true)? "ON" : "OFF"));
-  LM_T(LmtUriParamOptions, ("orionldState.uriParamOptions.concise:    %s", (orionldState.uriParamOptions.concise   == true)? "ON" : "OFF"));
-  LM_T(LmtUriParamOptions, ("orionldState.uriParamOptions.normalized: %s", (orionldState.uriParamOptions.concise   == true)? "ON" : "OFF"));
 }
 
 
@@ -413,6 +403,8 @@ bool pCheckTenantName(const char* dbName)
 //
 static MHD_Result orionldHttpHeaderReceive(void* cbDataP, MHD_ValueKind kind, const char* key, const char* value)
 {
+  LM_T(LmtHeaders, ("Got an HTTP Header: '%s': '%s'", key, value));
+
   //
   // Need to keep track of ALL incoming headers, in case they're asked for in forwarded requests
   // This is copying information, but as it is not a default behaviour, that's OK.
@@ -520,6 +512,8 @@ static MHD_Result orionldHttpHeaderReceive(void* cbDataP, MHD_ValueKind kind, co
 //
 MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* key, const char* value)
 {
+  LM_T(LmtUriParams, ("Got a URI param '%s': '%s'", key, value));
+
   // NULL/empty URI param value
   if ((value == NULL) || (*value == 0))
   {


### PR DESCRIPTION
Implemented trace messages for incoming URL parameters and HTTP headers.
* Use `-t 33` for URL parameters.
* Use `-t 32` for HTTP headers.
* Use `-t32,33` or `-t32-33` for both of them
