### PR TITLE
Better error handling for registration creation

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
 Fixed issues:
 #1368 - bug in subscription patch
+#280  - error handling in registration creation - making sure exclusive registrations specify entity id and attributes

--- a/src/lib/orionld/payloadCheck/pCheckSubscription.cpp
+++ b/src/lib/orionld/payloadCheck/pCheckSubscription.cpp
@@ -164,7 +164,7 @@ bool pCheckSubscription
       PCHECK_ARRAY_EMPTY(subItemP, 0, NULL, SubscriptionEntitiesPath, 400);
       PCHECK_DUPLICATE(entitiesP,  subItemP, 0, NULL, SubscriptionEntitiesPath, 400);
 
-      if (pcheckEntityInfoArray(entitiesP, true, SubscriptionEntitiesPathV) == false)
+      if (pcheckEntityInfoArray(entitiesP, true, false, SubscriptionEntitiesPathV) == false)
         return false;
     }
     else if (strcmp(subItemP->name, "watchedAttributes") == 0)

--- a/src/lib/orionld/payloadCheck/pcheckEntityInfo.cpp
+++ b/src/lib/orionld/payloadCheck/pcheckEntityInfo.cpp
@@ -70,7 +70,7 @@ static bool regexCheck(const char* pattern)
 //
 // pcheckEntityInfo -
 //
-bool pcheckEntityInfo(KjNode* entityInfoP, bool typeMandatory, const char** fieldPathV)
+bool pcheckEntityInfo(KjNode* entityInfoP, bool typeMandatory, bool idMandatory, const char** fieldPathV)
 {
   KjNode* idP         = NULL;
   KjNode* idPatternP  = NULL;
@@ -133,6 +133,19 @@ bool pcheckEntityInfo(KjNode* entityInfoP, bool typeMandatory, const char** fiel
   if ((typeMandatory == true) && (typeP == NULL))
   {
     orionldError(OrionldBadRequestData, "Missing mandatory field", fieldPathV[4], 400);
+    return false;
+  }
+
+  //
+  // Only exclusive registrations use idMandatory=true, so, as we need a good error message,
+  // it is set right here.
+  //
+  // I know, it's a bit weird, as this function is also used for subscriptions.
+  // Not really a problem though.
+  //
+  if ((idMandatory == true) && (idP == NULL))
+  {
+    orionldError(OrionldBadRequestData, "Invalid exclusive registration", "information item without specifying entity id", 400);
     return false;
   }
 

--- a/src/lib/orionld/payloadCheck/pcheckEntityInfo.h
+++ b/src/lib/orionld/payloadCheck/pcheckEntityInfo.h
@@ -30,12 +30,14 @@ extern "C"
 #include "kjson/KjNode.h"                                      // KjNode
 }
 
+#include "orionld/types/RegistrationMode.h"                     // RegistrationMode
+
 
 
 // ----------------------------------------------------------------------------
 //
 // pcheckEntityInfo -
 //
-extern bool pcheckEntityInfo(KjNode* entityInfoP, bool typeMandatory, const char** fieldPathV);
+extern bool pcheckEntityInfo(KjNode* entityInfoP, bool typeMandatory, bool idMandatory, const char** fieldPathV);
 
 #endif  // SRC_LIB_ORIONLD_PAYLOADCHECK_PCHECKENTITYINFO_H_

--- a/src/lib/orionld/payloadCheck/pcheckEntityInfoArray.cpp
+++ b/src/lib/orionld/payloadCheck/pcheckEntityInfoArray.cpp
@@ -42,13 +42,13 @@ extern "C"
 // This function is used by the "POST Query" request, where the entity type is NOT mandatory.
 // It is also used for Subscriptions and Registrations, where entity type IS mandatory.
 //
-bool pcheckEntityInfoArray(KjNode* entityInfoArrayP, bool typeMandatory, const char** fieldPathV)
+bool pcheckEntityInfoArray(KjNode* entityInfoArrayP, bool typeMandatory, bool idMandatory, const char** fieldPathV)
 {
   for (KjNode* entityInfoP = entityInfoArrayP->value.firstChildP; entityInfoP != NULL; entityInfoP = entityInfoP->next)
   {
     PCHECK_OBJECT(entityInfoP, 0, NULL, fieldPathV[1], 400);
 
-    if (pcheckEntityInfo(entityInfoP, typeMandatory, fieldPathV) == false)
+    if (pcheckEntityInfo(entityInfoP, typeMandatory, idMandatory, fieldPathV) == false)
       return false;
   }
 

--- a/src/lib/orionld/payloadCheck/pcheckEntityInfoArray.h
+++ b/src/lib/orionld/payloadCheck/pcheckEntityInfoArray.h
@@ -36,6 +36,6 @@ extern "C"
 //
 // pcheckEntityInfoArray -
 //
-extern bool pcheckEntityInfoArray(KjNode* entityInfoArrayP, bool typeMandatory, const char** fieldPathV);
+extern bool pcheckEntityInfoArray(KjNode* entityInfoArrayP, bool typeMandatory, bool idMandatory, const char** fieldPathV);
 
 #endif  // SRC_LIB_ORIONLD_PAYLOADCHECK_PCHECKENTITYINFOARRAY_H_

--- a/src/lib/orionld/payloadCheck/pcheckInformationItem.cpp
+++ b/src/lib/orionld/payloadCheck/pcheckInformationItem.cpp
@@ -350,7 +350,7 @@ bool pcheckInformationItem(RegistrationMode regMode, KjNode* informationP)
       ARRAY_CHECK(entitiesP, RegistrationInformationEntitiesPath);
       EMPTY_ARRAY_CHECK(entitiesP, RegistrationInformationEntitiesPath);
 
-      if (pcheckEntityInfoArray(entitiesP, true, RegistrationInformationEntitiesPathV) == false)
+      if (pcheckEntityInfoArray(entitiesP, true, regMode == RegModeExclusive, RegistrationInformationEntitiesPathV) == false)
         return false;
     }
     else if ((strcmp(infoItemP->name, "propertyNames") == 0) || (strcmp(infoItemP->name, "properties") == 0))
@@ -386,6 +386,18 @@ bool pcheckInformationItem(RegistrationMode regMode, KjNode* informationP)
     else
     {
       orionldError(OrionldBadRequestData, "Invalid field for Registration::information[X]", infoItemP->name, 400);
+      return false;
+    }
+  }
+
+  //
+  // Exclusive registrations must have either properties or relationships
+  //
+  if (regMode == RegModeExclusive)
+  {
+    if ((propertiesP == NULL) && (relationshipsP == NULL))
+    {
+      orionldError(OrionldBadRequestData, "Invalid exclusive registration", "information item without specifying attributes", 400);
       return false;
     }
   }

--- a/src/lib/orionld/payloadCheck/pcheckQuery.cpp
+++ b/src/lib/orionld/payloadCheck/pcheckQuery.cpp
@@ -194,7 +194,7 @@ bool pcheckQuery(KjNode* tree, KjNode** entitiesPP, KjNode** attrsPP, QNode** qT
     return false;
   }
 
-  if ((entitiesP != NULL) && (pcheckEntityInfoArray(entitiesP, false, PostQueryEntitiesPathV) == false))
+  if ((entitiesP != NULL) && (pcheckEntityInfoArray(entitiesP, false, false, PostQueryEntitiesPathV) == false))
     return false;
   if ((attrsP != NULL) && (pcheckAttrs(attrsP) == false))
     return false;

--- a/src/lib/orionld/payloadCheck/pcheckSubscription.cpp
+++ b/src/lib/orionld/payloadCheck/pcheckSubscription.cpp
@@ -126,7 +126,7 @@ bool pcheckSubscription
       DUPLICATE_CHECK(entitiesP, "entities", nodeP);
       ARRAY_CHECK(entitiesP, "entities");
       EMPTY_ARRAY_CHECK(entitiesP, "entities");
-      if (pcheckEntityInfoArray(entitiesP, true, SubscriptionEntitiesPathV) == false)
+      if (pcheckEntityInfoArray(entitiesP, true, false, SubscriptionEntitiesPathV) == false)
         return false;
     }
     else if (strcmp(nodeP->name, "watchedAttributes") == 0)

--- a/test/functionalTest/cases/0000_ngsild/ngsild_exclusive_registration_error_handling.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_exclusive_registration_error_handling.test
@@ -1,0 +1,315 @@
+# Copyright 2023 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Error handling in creation of an exclusive registration
+
+--SHELL-INIT--
+dbInit CB
+orionldStart CB -experimental
+
+--SHELL--
+
+#
+# 01. Attempt to create an exclusive registration without "information"
+# 02. Attempt to create an exclusive registration with an empty "information"
+# 03. Attempt to create an exclusive registration with an empty "information::entities"
+# 04. Attempt to create an exclusive registration with an empty "information::entities::id"
+# 05. Attempt to create an exclusive registration with an "information::entities::id" that is not a string
+# 06. Attempt to create an exclusive registration without an "information::entities::type"
+# 07. Attempt to create an exclusive registration without an "information::entities::id"
+# 08. Attempt to create an exclusive registration without "information::propertyNames||relationshipNames"
+#
+
+echo '01. Attempt to create an exclusive registration without "information"'
+echo '====================================================================='
+payload='{
+  "type": "ContextSourceRegistration",
+  "tenant": "T1",
+  "endpoint": "http://my.csource.org:1026",
+  "mode": "exclusive"
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload"
+echo
+echo
+
+
+echo '02. Attempt to create an exclusive registration with an empty "information"'
+echo '==========================================================================='
+payload='{
+  "type": "ContextSourceRegistration",
+  "tenant": "T1",
+  "information": [],
+  "endpoint": "http://my.csource.org:1026",
+  "mode": "exclusive"
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload"
+echo
+echo
+
+
+echo '03. Attempt to create an exclusive registration with an empty "information::entities"'
+echo '====================================================================================='
+payload='{
+  "type": "ContextSourceRegistration",
+  "tenant": "T1",
+  "information": [
+    {
+      "entities": []
+    }
+  ],
+  "endpoint": "http://my.csource.org:1026",
+  "mode": "exclusive"
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload"
+echo
+echo
+
+
+echo '04. Attempt to create an exclusive registration with an empty "information::entities::id"'
+echo '========================================================================================='
+payload='{
+  "type": "ContextSourceRegistration",
+  "tenant": "T1",
+  "information": [
+    {
+      "entities": [
+        {
+          "id": ""
+        }
+      ]
+    }
+  ],
+  "endpoint": "http://my.csource.org:1026",
+  "mode": "exclusive"
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload"
+echo
+echo
+
+
+echo '05. Attempt to create an exclusive registration with an "information::entities::id" that is not a string'
+echo '========================================================================================================'
+payload='{
+  "type": "ContextSourceRegistration",
+  "tenant": "T1",
+  "information": [
+    {
+      "entities": [
+        {
+          "id": 14
+        }
+      ]
+    }
+  ],
+  "endpoint": "http://my.csource.org:1026",
+  "mode": "exclusive"
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload"
+echo
+echo
+
+
+echo '06. Attempt to create an exclusive registration without an "information::entities::type"'
+echo '========================================================================================'
+payload='{
+  "type": "ContextSourceRegistration",
+  "tenant": "T1",
+  "information": [
+    {
+      "entities": [
+        {
+          "id": "urn:E1"
+        }
+      ]
+    }
+  ],
+  "endpoint": "http://my.csource.org:1026",
+  "mode": "exclusive"
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload"
+echo
+echo
+
+
+echo '07. Attempt to create an exclusive registration without an "information::entities::id"'
+echo '======================================================================================'
+payload='{
+  "type": "ContextSourceRegistration",
+  "tenant": "T1",
+  "information": [
+    {
+      "entities": [
+        {
+          "type": "T"
+        }
+      ],
+      "propertyNames": [ "P1" ]
+    }
+  ],
+  "endpoint": "http://my.csource.org:1026",
+  "mode": "exclusive"
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload"
+echo
+echo
+
+
+echo '08. Attempt to create an exclusive registration without "information::propertyNames||relationshipNames"'
+echo '======================================================================================================='
+payload='{
+  "type": "ContextSourceRegistration",
+  "tenant": "T1",
+  "information": [
+    {
+      "entities": [
+        {
+          "id": "urn:E1",
+          "type": "T"
+        }
+      ]
+    }
+  ],
+  "endpoint": "http://my.csource.org:1026",
+  "mode": "exclusive"
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload"
+echo
+echo
+
+
+--REGEXPECT--
+01. Attempt to create an exclusive registration without "information"
+=====================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 135
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "information",
+    "title": "Missing mandatory field for Registration",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+02. Attempt to create an exclusive registration with an empty "information"
+===========================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 106
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "information",
+    "title": "Empty Array",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+03. Attempt to create an exclusive registration with an empty "information::entities"
+=====================================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 133
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "Registration::information[X]::entities",
+    "title": "Empty Array",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+04. Attempt to create an exclusive registration with an empty "information::entities::id"
+=========================================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 141
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "Registration::information[X]::entities[X]::id",
+    "title": "Empty String",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+05. Attempt to create an exclusive registration with an "information::entities::id" that is not a string
+========================================================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 146
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "Registration::information[X]::entities[X]::id",
+    "title": "Not a JSON String",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+06. Attempt to create an exclusive registration without an "information::entities::type"
+========================================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 154
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "Registration::information[X]::entities[X]::type",
+    "title": "Missing mandatory field",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+07. Attempt to create an exclusive registration without an "information::entities::id"
+======================================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 159
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "information item without specifying entity id",
+    "title": "Invalid exclusive registration",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+08. Attempt to create an exclusive registration without "information::propertyNames||relationshipNames"
+=======================================================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 160
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "information item without specifying attributes",
+    "title": "Invalid exclusive registration",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_forward_http_headers.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_forward_http_headers.test
@@ -30,7 +30,7 @@ accumulatorStart --pretty-print --url /ngsi-ld/v1/entities 127.0.0.1 ${LISTENER_
 
 --SHELL--
 #
-# 01. Create a registration (exclusive) for the accumulator, with all types of headers inside Regostration::contextSourceInfo
+# 01. Create a registration (inclusive) for the accumulator, with all types of headers inside Registration::contextSourceInfo
 # 02. Send a request to create an Entity in the CB - will be forwarded to the accumulator (and fail, but that's OK)
 # 03. Dump the accumulator to see all the HTTP headers of the forwarded request
 # 04. PATCH the registration setting the contextSourceInfo, see what happens in the forwarded request later
@@ -38,7 +38,7 @@ accumulatorStart --pretty-print --url /ngsi-ld/v1/entities 127.0.0.1 ${LISTENER_
 # 06. Dump the accumulator to see all the HTTP headers of the forwarded request
 #
 
-echo "01. Create a registration (exclusive) for the accumulator, with all types of headers inside Regostration::contextSourceInfo"
+echo "01. Create a registration (inclusive) for the accumulator, with all types of headers inside Registration::contextSourceInfo"
 echo "==========================================================================================================================="
 payload='{
   "id": "urn:R1",
@@ -47,7 +47,6 @@ payload='{
     {
       "entities": [
         {
-          "id": "urn:E1",
           "type": "T"
         }
       ]
@@ -69,7 +68,7 @@ payload='{
   ],
   "endpoint": "http://localhost:'$LISTENER_PORT'",
   "operations": [ "createEntity" ],
-  "mode": "exclusive"
+  "mode": "inclusive"
 }'
 orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload"
 echo
@@ -134,7 +133,7 @@ echo
 
 
 --REGEXPECT--
-01. Create a registration (exclusive) for the accumulator, with all types of headers inside Regostration::contextSourceInfo
+01. Create a registration (inclusive) for the accumulator, with all types of headers inside Registration::contextSourceInfo
 ===========================================================================================================================
 HTTP/1.1 201 Created
 Content-Length: 0

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_forward_with_idPattern.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_forward_with_idPattern.test
@@ -79,7 +79,7 @@ payload='{
     }
   ],
   "endpoint": "http://localhost:'$CP1_PORT'",
-  "mode": "exclusive",
+  "mode": "redirect",
   "operations": [ "createEntity" ]
 }'
 orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload"
@@ -104,7 +104,7 @@ payload='{
     }
   ],
   "endpoint": "http://localhost:'$CP2_PORT'",
-  "mode": "exclusive",
+  "mode": "redirect",
   "operations": [ "createEntity" ]
 }'
 orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload"
@@ -568,7 +568,7 @@ MongoDB server version: REGEX(.*)
 			"providingApplication" : "http://localhost:9801"
 		}
 	],
-	"mode" : "exclusive",
+	"mode" : "redirect",
 	"operations" : [
 		"createEntity"
 	],
@@ -583,7 +583,7 @@ bye
 17. GET R1 (from cache) - pay attention to the 'information' stuff ('contextRegistration in DB)
 ===============================================================================================
 HTTP/1.1 200 OK
-Content-Length: 264
+Content-Length: 263
 Content-Type: application/json
 Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
@@ -605,7 +605,7 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http:/
             ]
         }
     ],
-    "mode": "exclusive",
+    "mode": "redirect",
     "operations": [
         "createEntity"
     ],
@@ -653,7 +653,7 @@ MongoDB server version: REGEX(.*)
 			"providingApplication" : "http://localhost:9801"
 		}
 	],
-	"mode" : "exclusive",
+	"mode" : "redirect",
 	"operations" : [
 		"createEntity"
 	],
@@ -668,7 +668,7 @@ bye
 20. GET R1 (from cache) - pay attention to the 'information' stuff ('contextRegistration in DB) - should have been overwritten
 ==============================================================================================================================
 HTTP/1.1 200 OK
-Content-Length: 264
+Content-Length: 263
 Content-Type: application/json
 Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
@@ -690,7 +690,7 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http:/
             ]
         }
     ],
-    "mode": "exclusive",
+    "mode": "redirect",
     "operations": [
         "createEntity"
     ],

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_forwarding_entity_delete.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_forwarding_entity_delete.test
@@ -141,9 +141,11 @@ payload='{
     {
       "entities": [
         {
-          "type": "T"
+          "type": "T",
+          "id": "urn:E1"
         }
-      ]
+      ],
+      "propertyNames": [ "P1" ]
     }
   ],
   "endpoint": "http://localhost:'$CP1_PORT'",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_registration_create-collisions.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_registration_create-collisions.test
@@ -53,7 +53,8 @@ payload='{
     {
       "entities": [
         {
-          "type": "T"
+          "type": "T",
+          "id": "urn:E1"
         }
       ],
       "properties": [ "A1" ]
@@ -167,7 +168,8 @@ payload='{
     {
       "entities": [
         {
-          "type": "T"
+          "type": "T",
+          "id": "urn:E1"
         }
       ],
       "properties": [ "A2" ]
@@ -202,9 +204,11 @@ payload='{
     {
       "entities": [
         {
-          "type": "T2"
+          "type": "T2",
+          "id": "urn:E1"
         }
-      ]
+      ],
+      "propertyNames": [ "P1" ]
     }
   ],
   "endpoint": "http://my.csource.org:1026",
@@ -227,7 +231,8 @@ payload='{
           "id": "urn:E1",
           "type": "T2"
         }
-      ]
+      ],
+      "propertyNames": ["P1"]
     }
   ],
   "endpoint": "http://my.csource.org:1026",
@@ -375,13 +380,13 @@ Location: /ngsi-ld/v1/entities/urn:E1
 08. Attempt to create an exclusive registration on Entity Type T2 - see error
 =============================================================================
 HTTP/1.1 409 Conflict
-Content-Length: 143
+Content-Length: 135
 Content-Type: application/json
 Date: REGEX(.*)
 
 {
     "detail": "urn:E1",
-    "title": "Conflicting Entity (due to entity type and attributes)",
+    "title": "Conflicting Entity (due to entity id and type)",
     "type": "https://uri.etsi.org/ngsi-ld/errors/AlreadyExists"
 }
 


### PR DESCRIPTION
Exclusive registrations must specify entity id and attributes in the information array.
For some strange reason, I forgot to implement that ...