### PR TITLE
Better error handling for PATCH Registration

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
 Fixed issues:
 #1368 - bug in subscription patch
 #280  - error handling in registration creation - making sure exclusive registrations specify entity id and attributes
+#280  - error handling in registration updated  - making sure exclusive registrations specify entity id and attributes

--- a/src/lib/orionld/legacyDriver/legacyPatchRegistration.cpp
+++ b/src/lib/orionld/legacyDriver/legacyPatchRegistration.cpp
@@ -569,8 +569,25 @@ bool legacyPatchRegistration(void)
     }
   }
 
+  KjNode* dbRegistrationP = mongoCppLegacyRegistrationGet(registrationId);
+
+  if (dbRegistrationP == NULL)
+  {
+    orionldError(OrionldResourceNotFound, "Registration not found", registrationId, 404);
+    return false;
+  }
+
+  //
+  // Get the registration mode
+  //
+  KjNode*      regModeNodeP = kjLookup(dbRegistrationP, "mode");
+  const char*  regMode      = (regModeNodeP != NULL)? regModeNodeP->value.s : "inclusive";
+
+  //
+  // Check the incoming payload body
+  //
   OrionldContext* contextP = NULL;  // Needed but not used in legacy implementation
-  if (pcheckRegistration(orionldState.requestTree, false, false, &propertyTree, &contextP) == false)
+  if (pcheckRegistration(regMode, orionldState.requestTree, registrationId, false, false, &propertyTree, &contextP) == false)
   {
     LM_E(("pcheckRegistration FAILED"));
     return false;
@@ -579,13 +596,6 @@ bool legacyPatchRegistration(void)
   if (contextP != NULL)
     LM_W(("Registration @context in place but this is not supported by the legacy implementation of PATCH Registration"));
 
-  KjNode* dbRegistrationP = mongoCppLegacyRegistrationGet(registrationId);
-
-  if (dbRegistrationP == NULL)
-  {
-    orionldError(OrionldResourceNotFound, "Registration not found", registrationId, 404);
-    return false;
-  }
 
   //
   // Now that we have the "original" registration, we can check that all registration properties

--- a/src/lib/orionld/payloadCheck/pcheckInformation.cpp
+++ b/src/lib/orionld/payloadCheck/pcheckInformation.cpp
@@ -43,7 +43,7 @@ extern "C"
 //
 // pcheckInformation -
 //
-bool pcheckInformation(RegistrationMode regMode, KjNode* informationArrayP)
+bool pcheckInformation(const char* currentRegId, RegistrationMode regMode, KjNode* informationArrayP)
 {
   if (informationArrayP->value.firstChildP == NULL)  // Empty Array
   {
@@ -56,7 +56,7 @@ bool pcheckInformation(RegistrationMode regMode, KjNode* informationArrayP)
     OBJECT_CHECK(informationP, "information[X]");
     EMPTY_OBJECT_CHECK(informationP, "information[X]");
 
-    if (pcheckInformationItem(regMode, informationP) == false)
+    if (pcheckInformationItem(currentRegId, regMode, informationP) == false)
       return false;
   }
 

--- a/src/lib/orionld/payloadCheck/pcheckInformation.h
+++ b/src/lib/orionld/payloadCheck/pcheckInformation.h
@@ -36,6 +36,6 @@ extern "C"
 //
 // pcheckInformation -
 //
-extern bool pcheckInformation(RegistrationMode regMode, KjNode* informationArrayP);
+extern bool pcheckInformation(const char* currentRegId, RegistrationMode regMode, KjNode* informationArrayP);
 
 #endif  // SRC_LIB_ORIONLD_PAYLOADCHECK_PCHECKINFORMATION_H_

--- a/src/lib/orionld/payloadCheck/pcheckInformationItem.cpp
+++ b/src/lib/orionld/payloadCheck/pcheckInformationItem.cpp
@@ -122,7 +122,14 @@ static bool attrsMatch(KjNode* propertiesP, KjNode* relationshipsP, KjNode* rciP
 //
 // pCheckOverlappingRegistrations -
 //
-bool pCheckOverlappingRegistrations(RegistrationMode regMode, KjNode* entitiesP, KjNode* propertiesP, KjNode* relationshipsP)
+static bool pCheckOverlappingRegistrations
+(
+  const char*       currentRegId,
+  RegistrationMode  regMode,
+  KjNode*           entitiesP,
+  KjNode*           propertiesP,
+  KjNode*           relationshipsP
+)
 {
   if (entitiesP == NULL)
   {
@@ -142,6 +149,10 @@ bool pCheckOverlappingRegistrations(RegistrationMode regMode, KjNode* entitiesP,
 
     for (RegCacheItem* rciP = orionldState.tenantP->regCache->regList; rciP != NULL; rciP = rciP->next)
     {
+      // In case it's an update, don't compare the registration with itself
+      if ((currentRegId != NULL) && (strcmp(currentRegId, rciP->regId) == 0))
+        continue;
+
       //
       // Conflict must be checked if any of the two regs are Exclusive, BUT not if the other is Auxiliary
       //
@@ -336,7 +347,7 @@ bool pCheckOverlappingEntities(KjNode* entitiesP, KjNode* propertiesP, KjNode* r
 // NOTE
 //   This function also expands ATTRIBUTE NAMES and ENTITY TYPES
 //
-bool pcheckInformationItem(RegistrationMode regMode, KjNode* informationP)
+bool pcheckInformationItem(const char* currentRegId, RegistrationMode regMode, KjNode* informationP)
 {
   KjNode* entitiesP      = NULL;
   KjNode* propertiesP    = NULL;
@@ -433,7 +444,7 @@ bool pcheckInformationItem(RegistrationMode regMode, KjNode* informationP)
   //
   // Check for local overlapping Registrations/Entities
   //
-  if (pCheckOverlappingRegistrations(regMode, entitiesP, propertiesP, relationshipsP) == true)
+  if (pCheckOverlappingRegistrations(currentRegId, regMode, entitiesP, propertiesP, relationshipsP) == true)
     return false;
 
   if (regMode == RegModeExclusive)

--- a/src/lib/orionld/payloadCheck/pcheckInformationItem.h
+++ b/src/lib/orionld/payloadCheck/pcheckInformationItem.h
@@ -38,6 +38,6 @@ extern "C"
 //
 // pcheckInformationItem -
 //
-extern bool pcheckInformationItem(RegistrationMode regMode, KjNode* informationP);
+extern bool pcheckInformationItem(const char* currentRegId, RegistrationMode regMode, KjNode* informationP);
 
 #endif  // SRC_LIB_ORIONLD_PAYLOADCHECK_PCHECKINFORMATIONITEM_H_

--- a/src/lib/orionld/payloadCheck/pcheckRegistration.h
+++ b/src/lib/orionld/payloadCheck/pcheckRegistration.h
@@ -56,6 +56,6 @@ extern "C"
 // as a KjNode tree, until we are able to perform this check.
 // The output parameter 'propertyTreeP' is used for this purpose.
 //
-extern bool pcheckRegistration(KjNode* registrationP, bool idCanBePresent, bool creation, KjNode**  propertyTreeP, OrionldContext** contextP);
+extern bool pcheckRegistration(const char* regMode, KjNode* registrationP, const char* currentRegId, bool idCanBePresent, bool creation, KjNode**  propertyTreeP, OrionldContext** contextP);
 
 #endif  // SRC_LIB_ORIONLD_PAYLOADCHECK_PCHECKREGISTRATION_H_

--- a/src/lib/orionld/serviceRoutines/orionldPatchRegistration.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchRegistration.cpp
@@ -620,6 +620,23 @@ bool orionldPatchRegistration(void)
     return false;
   }
 
+  RegCacheItem* rciP        = regCacheItemLookup(orionldState.tenantP->regCache, registrationId);
+  KjNode*       regPatch    = orionldState.requestTree;
+  KjNode*       dbRegP      = mongocRegistrationGet(registrationId);
+
+  if (dbRegP == NULL)
+  {
+    orionldError(OrionldResourceNotFound, "Registration Not Found", registrationId, 404);
+    return false;
+  }
+
+  //
+  // Get the registration mode
+  //
+  KjNode*      regModeNodeP = kjLookup(dbRegP, "mode");
+  const char*  regMode      = (regModeNodeP != NULL)? regModeNodeP->value.s : "inclusive";
+
+
   //
   // Check the validity of the incoming payload body - is it valid for a PATCH of a registration
   //
@@ -631,7 +648,7 @@ bool orionldPatchRegistration(void)
   //
   KjNode*         propertyTree = NULL;
   OrionldContext* fwdContextP  = NULL;
-  if (pcheckRegistration(orionldState.requestTree, false, false, &propertyTree, &fwdContextP) == false)
+  if (pcheckRegistration(regMode, orionldState.requestTree, registrationId, false, false, &propertyTree, &fwdContextP) == false)
     return false;
 
   //
@@ -660,15 +677,6 @@ bool orionldPatchRegistration(void)
   //   7. Replace the old cached registration
   //   8. Return 204 if all OK
   //
-  RegCacheItem* rciP        = regCacheItemLookup(orionldState.tenantP->regCache, registrationId);
-  KjNode*       regPatch    = orionldState.requestTree;
-  KjNode*       dbRegP      = mongocRegistrationGet(registrationId);
-
-  if (dbRegP == NULL)
-  {
-    orionldError(OrionldResourceNotFound, "Registration Not Found", registrationId, 404);
-    return false;
-  }
 
   //
   // modifiedAt

--- a/src/lib/orionld/serviceRoutines/orionldPostRegistrations.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostRegistrations.cpp
@@ -174,7 +174,8 @@ bool orionldPostRegistrations(void)
   }
 
   OrionldContext* fwdContextP = NULL;
-  bool            b           = pcheckRegistration(regP, false, true, &propertyTree, &fwdContextP);
+  bool            b           = pcheckRegistration(NULL, regP, NULL, false, true, &propertyTree, &fwdContextP);
+
   if (b == false)
     LM_RE(false, ("pCheckRegistration FAILED"));
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_exclusive_registration_error_handling.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_exclusive_registration_error_handling.test
@@ -30,6 +30,7 @@ orionldStart CB -experimental
 --SHELL--
 
 #
+# Creation:
 # 01. Attempt to create an exclusive registration without "information"
 # 02. Attempt to create an exclusive registration with an empty "information"
 # 03. Attempt to create an exclusive registration with an empty "information::entities"
@@ -38,6 +39,17 @@ orionldStart CB -experimental
 # 06. Attempt to create an exclusive registration without an "information::entities::type"
 # 07. Attempt to create an exclusive registration without an "information::entities::id"
 # 08. Attempt to create an exclusive registration without "information::propertyNames||relationshipNames"
+#
+# Modification
+# 10. Finally create the exclusive registration
+# 11. Attempt to patch the exclusive registration with an empty "information"
+# 12. Attempt to patch the exclusive registration with an empty "information::entities"
+# 13. Attempt to patch the exclusive registration with an empty "information::entities::id"
+# 14. Attempt to patch the exclusive registration with an "information::entities::id" that is not a string
+# 15. Attempt to patch the exclusive registration without an "information::entities::type"
+# 16. Attempt to patch the exclusive registration without an "information::entities::id"
+# 17. Attempt to patch the exclusive registration without "information::propertyNames||relationshipNames"
+# 
 #
 
 echo '01. Attempt to create an exclusive registration without "information"'
@@ -197,6 +209,147 @@ echo
 echo
 
 
+echo '10. Finally create the exclusive registration'
+echo '============================================='
+payload='{
+  "id": "urn:R1",
+  "type": "ContextSourceRegistration",
+  "information": [
+    {
+      "entities": [
+        {
+          "id": "urn:E1",
+          "type": "T"
+        }
+      ],
+      "propertyNames": [ "P1" ]
+    }
+  ],
+  "endpoint": "http://my.csource.org:1026",
+  "mode": "exclusive"
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations/ --payload "$payload"
+echo
+echo
+
+
+echo '11. Attempt to patch the exclusive registration with an empty "information"'
+echo '==========================================================================='
+payload='{
+  "information": []
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations/urn:R1 --payload "$payload" -X PATCH
+echo
+echo
+
+
+echo '12. Attempt to patch the exclusive registration with an empty "information::entities"'
+echo '====================================================================================='
+payload='{
+  "information": [
+    {
+      "entities": []
+    }
+  ]
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations/urn:R1 --payload "$payload" -X PATCH
+echo
+echo
+
+
+
+echo '13. Attempt to patch the exclusive registration with an empty "information::entities::id"'
+echo '========================================================================================='
+payload='{
+  "information": [
+    {
+      "entities": [
+        {
+          "id": ""
+        }
+      ]
+    }
+  ]
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations/urn:R1 --payload "$payload" -X PATCH
+echo
+echo
+
+
+echo '14. Attempt to patch the exclusive registration with an "information::entities::id" that is not a string'
+echo '========================================================================================================'
+payload='{
+  "information": [
+    {
+      "entities": [
+        {
+          "id": 14
+        }
+      ]
+    }
+  ]
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations/urn:R1 --payload "$payload" -X PATCH
+echo
+echo
+
+
+echo '15. Attempt to patch the exclusive registration without an "information::entities::type"'
+echo '========================================================================================'
+payload='{
+  "information": [
+    {
+      "entities": [
+        {
+          "id": "urn:E1"
+        }
+      ]
+    }
+  ]
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations/urn:R1 --payload "$payload" -X PATCH
+echo
+echo
+
+
+echo '16. Attempt to patch the exclusive registration without an "information::entities::id"'
+echo '======================================================================================'
+payload='{
+  "information": [
+    {
+      "entities": [
+        {
+          "type": "T"
+        }
+      ],
+      "propertyNames": [ "P1" ]
+    }
+  ]
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations/urn:R1 --payload "$payload" -X PATCH
+echo
+echo
+
+
+echo '17. Attempt to patch the exclusive registration without "information::propertyNames||relationshipNames"'
+echo '======================================================================================================='
+payload='{
+  "information": [
+    {
+      "entities": [
+        {
+          "id": "urn:E1",
+          "type": "T"
+        }
+      ]
+    }
+  ]
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations/urn:R1 --payload "$payload" -X PATCH
+echo
+echo
+
+
 --REGEXPECT--
 01. Attempt to create an exclusive registration without "information"
 =====================================================================
@@ -297,6 +450,113 @@ Date: REGEX(.*)
 
 
 08. Attempt to create an exclusive registration without "information::propertyNames||relationshipNames"
+=======================================================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 160
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "information item without specifying attributes",
+    "title": "Invalid exclusive registration",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+10. Finally create the exclusive registration
+=============================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/csourceRegistrations/urn:R1
+
+
+
+11. Attempt to patch the exclusive registration with an empty "information"
+===========================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 106
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "information",
+    "title": "Empty Array",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+12. Attempt to patch the exclusive registration with an empty "information::entities"
+=====================================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 133
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "Registration::information[X]::entities",
+    "title": "Empty Array",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+13. Attempt to patch the exclusive registration with an empty "information::entities::id"
+=========================================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 141
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "Registration::information[X]::entities[X]::id",
+    "title": "Empty String",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+14. Attempt to patch the exclusive registration with an "information::entities::id" that is not a string
+========================================================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 146
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "Registration::information[X]::entities[X]::id",
+    "title": "Not a JSON String",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+15. Attempt to patch the exclusive registration without an "information::entities::type"
+========================================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 154
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "Registration::information[X]::entities[X]::type",
+    "title": "Missing mandatory field",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+16. Attempt to patch the exclusive registration without an "information::entities::id"
+======================================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 159
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "information item without specifying entity id",
+    "title": "Invalid exclusive registration",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+17. Attempt to patch the exclusive registration without "information::propertyNames||relationshipNames"
 =======================================================================================================
 HTTP/1.1 400 Bad Request
 Content-Length: 160


### PR DESCRIPTION
Making sure you can't PATCH an Exclusive registration with an "information" item that does not specify the entity id or a set of attributes