### PR TITLE
Hopefully fixed issue #1412

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,5 @@
 Fixed issues:
-#280  Protection for POST /temporal/entities against usage when troe is not enabled
-#280  Support for different core contexts via CLI parameter -coreContext <v1.0|v1.3|v1.4|v1.5|v1.6|v1.7> (v1.6 is default)
-#280  Re-implemented the propagation of subscription between brokers in HA (sub-cache synchronization)
+#280   Protection for POST /temporal/entities against usage when troe is not enabled
+#280   Support for different core contexts via CLI parameter -coreContext <v1.0|v1.3|v1.4|v1.5|v1.6|v1.7> (v1.6 is default)
+#280   Re-implemented the propagation of subscription between brokers in HA (sub-cache synchronization)
+#1412  Bug in the size of the postgres connection pool (a hardcoded size of 10 connection, instead of using the variable tied to the CLI option -troePoolSize, meant for this)

--- a/src/lib/orionld/troe/pgInit.cpp
+++ b/src/lib/orionld/troe/pgInit.cpp
@@ -29,10 +29,10 @@
 #include "logMsg/traceLevels.h"                                // Lmt*
 
 #include "orionld/common/pqHeader.h"                           // Postgres header
-#include "orionld/common/orionldState.h"                       // troePort
+#include "orionld/common/orionldState.h"                       // troePort, troePoolSize
 #include "orionld/troe/pgConnectionPoolInit.h"                 // pgConnectionPoolInit
 #include "orionld/troe/pgDatabasePrepare.h"                    // pgDatabasePrepare
-#include "orionld/troe/pgConnectionPoolsPresent.h"              // pgConnectionPoolsPresent
+#include "orionld/troe/pgConnectionPoolsPresent.h"             // pgConnectionPoolsPresent
 #include "orionld/troe/pgInit.h"                               // Own interface
 
 
@@ -45,7 +45,7 @@ bool pgInit(const char* dbPrefix)
 {
   snprintf(pgPortString, sizeof(pgPortString), "%d", troePort);
 
-  if (pgConnectionPoolInit(10) == false)
+  if (pgConnectionPoolInit(troePoolSize) == false)
     LM_RE(false, ("error initializing the postgres connection pools"));
 
   bool b = pgDatabasePrepare(dbPrefix);


### PR DESCRIPTION
Fixed a stupid bug in the size of the postgres connection pool (a hardcoded size of 10 connections, instead of using the variable tied to the CLI option -troePoolSize, meant for this)