### PR TITLE
issue #1412 re-connecting to postgres when connection is lost

### DIFF
--- a/src/lib/orionld/troe/pgConnectionGet.cpp
+++ b/src/lib/orionld/troe/pgConnectionGet.cpp
@@ -63,7 +63,7 @@ static char* wsTrim(char* s)
 //
 PgConnection* pgConnectionGet(const char* db)
 {
-  char* _db = (char*) db;
+  char* _db = (char*)db;
 
   //
   // Empty tenant => use default db name
@@ -92,44 +92,44 @@ PgConnection* pgConnectionGet(const char* db)
   // Search for a free but already connected PgConnection in the pool
   for (int ix = 0; ix < poolP->items; ix++)
   {
-      PgConnection* cP = poolP->connectionV[ix];
+    PgConnection* cP = poolP->connectionV[ix];
 
-      if ((cP == NULL) || (cP->busy == true))
-          continue;
+    if ((cP == NULL) || (cP->busy == true))
+      continue;
 
-      if (cP->connectionP != NULL)
+    if (cP->connectionP != NULL)
+    {
+      // check if we are still connected
+      ConnStatusType pgStatus = PQstatus(cP->connectionP);
+      if (pgStatus != CONNECTION_OK)
       {
-          // check if we are still connected
-          ConnStatusType pgStatus = PQstatus(cP->connectionP);
-          if (pgStatus != CONNECTION_OK)
-          {
-              LM_W(("Connection of item %d is lost, trying to re-connect...", ix));
-              // try to re-connect
-              PQreset(cP->connectionP);
-              // get status again
-              pgStatus = PQstatus(cP->connectionP);
+        LM_W(("Connection of item %d is lost, trying to re-connect...", ix));
+        // try to re-connect
+        PQreset(cP->connectionP);
+        // get status again
+        pgStatus = PQstatus(cP->connectionP);
 
-              // if still no connection
-              if (pgStatus != CONNECTION_OK)
-              {
-                  // we free this pointer that it can be used in the next call of pgConnectionGet
-                  free(poolP->connectionV[ix]);
-                  poolP->connectionV[ix] = NULL;
-                  LM_W(("Connection failed, pointer of item %d was re-set to NULL (%p)", ix, poolP->connectionV[ix]));
-                  // this time no success finding a connection that is working, try in the next loop
-                  continue;
-              }
-          }
-
-          // Great - found a free and already connected item - let's use it !
-          cP->busy = true;
-
-          sem_post(&poolP->poolSem);
-          sem_post(&poolP->queueSem);
-
-          cP->uses += 1;
-          return cP;
+        // if still no connection
+        if (pgStatus != CONNECTION_OK)
+        {
+          // we free this pointer that it can be used in the next call of pgConnectionGet
+          free(poolP->connectionV[ix]);
+          poolP->connectionV[ix] = NULL;
+          LM_W(("Connection failed, pointer of item %d was re-set to NULL (%p)", ix, poolP->connectionV[ix]));
+          // this time no success finding a connection that is working, try in the next loop
+          continue;
+        }
       }
+
+      // Great - found a free and already connected item - let's use it !
+      cP->busy = true;
+
+      sem_post(&poolP->poolSem);
+      sem_post(&poolP->queueSem);
+
+      cP->uses += 1;
+      return cP;
+    }
   }
 
   //
@@ -145,7 +145,7 @@ PgConnection* pgConnectionGet(const char* db)
       // Pity doing this with the semaphore taken ...
       // But, there's no other choice as the slot must be marked as 'busy' before the sem can be released
       //
-      poolP->connectionV[ix] = (PgConnection*) calloc(1, sizeof(PgConnection));
+      poolP->connectionV[ix] = (PgConnection*)calloc(1, sizeof(PgConnection));
       if (poolP->connectionV[ix] == NULL)
       {
         sem_post(&poolP->poolSem);
@@ -182,40 +182,40 @@ PgConnection* pgConnectionGet(const char* db)
 
   if (cP->connectionP == NULL)  // Virgin connection
   {
-      cP->connectionP = pgConnect(_db);
-      if (cP->connectionP == NULL)
+    cP->connectionP = pgConnect(_db);
+    if (cP->connectionP == NULL)
+    {
+      char* errMsg = PQerrorMessage(cP->connectionP);
+      cP->busy = false;  // So the slot can be used again!
+      LM_RE(NULL, ("Database Error (unable to connect to postgres(%s)): %s", _db, errMsg));
+    }
+    else
+    {
+      // check if we are connected
+      ConnStatusType pgStatus = PQstatus(cP->connectionP);
+      if (pgStatus != CONNECTION_OK)
       {
-          char* errMsg = PQerrorMessage(cP->connectionP);
-          cP->busy = false;  // So the slot can be used again!
-          LM_RE(NULL, ("Database Error (unable to connect to postgres(%s)): %s", _db, errMsg));
-      }
-      else
-      {
-          // check if we are connected
-          ConnStatusType pgStatus = PQstatus(cP->connectionP);
-          if (pgStatus != CONNECTION_OK)
+        sem_wait(&poolP->poolSem);
+        sem_wait(&poolP->queueSem);
+
+        // find the connection pointer in the pool and free it
+        for (int ix = 0; ix < poolP->items; ix++)
+        {
+          if (poolP->connectionV[ix] == cP)
           {
-              sem_wait(&poolP->poolSem);
-              sem_wait(&poolP->queueSem);
-
-              // find the connection pointer in the pool and free it
-              for (int ix = 0; ix < poolP->items; ix++)
-              {
-                  if (poolP->connectionV[ix] == cP)
-                  {
-                      free(poolP->connectionV[ix]);
-                      poolP->connectionV[ix] = NULL;
-                      break;
-                  }
-              }
-              sem_post(&poolP->poolSem);
-              sem_post(&poolP->queueSem);
-
-              // get PG error message for log file
-              char* errMsg = PQerrorMessage(cP->connectionP);
-              LM_RE(NULL, ("Database Connection could not be established (%s): %s ", _db, errMsg));
+            free(poolP->connectionV[ix]);
+            poolP->connectionV[ix] = NULL;
+            break;
           }
+        }
+        sem_post(&poolP->poolSem);
+        sem_post(&poolP->queueSem);
+
+        // get PG error message for log file
+        char* errMsg = PQerrorMessage(cP->connectionP);
+        LM_RE(NULL, ("Database Connection could not be established (%s): %s ", _db, errMsg));
       }
+    }
   }
 
   cP->uses += 1;


### PR DESCRIPTION
## Proposed changes

It fixes that the PostgreSQL connections where not re-connected once they are closed by the PostgreSQL server (e.q. restart of the server or network problems)

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/FIWARE/context.Orion-LD/blob/master/CONTRIBUTING.md) doc
-   [ ] I have signed the [CLA](https://fiware.github.io/contribution-requirements/individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...
