### PR TITLE
Bug/keys in arrays

### DIFF
--- a/src/lib/orionld/mongoc/CMakeLists.txt
+++ b/src/lib/orionld/mongoc/CMakeLists.txt
@@ -71,6 +71,7 @@ SET (SOURCES
     mongocAuxAttributesFilter.cpp
     mongocWriteLog.cpp
     mongocAttributeReplace.cpp
+    mongocIndexString.cpp
 )
 
 # Include directories

--- a/src/lib/orionld/mongoc/mongocAttributesAdd.cpp
+++ b/src/lib/orionld/mongoc/mongocAttributesAdd.cpp
@@ -37,8 +37,8 @@ extern "C"
 #include "orionld/mongoc/mongocConnectionGet.h"                  // mongocConnectionGet
 #include "orionld/mongoc/mongocWriteLog.h"                       // mongocWriteLog
 #include "orionld/mongoc/mongocKjTreeToBson.h"                   // mongocKjTreeToBson
+#include "orionld/mongoc/mongocIndexString.h"                    // mongocIndexString
 #include "orionld/mongoc/mongocAttributesAdd.h"                  // Own interface
-
 
 
 
@@ -92,9 +92,14 @@ bool mongocAttributesAdd
     bson_append_document_begin(&push, "attrNames", 9,  &eachBson);
     bson_append_array_begin(&eachBson, "$each", 5, &commaArrayBson);
 
+    int ix = 0;
     for (KjNode* attrNameP = newDbAttrNamesV->value.firstChildP; attrNameP != NULL; attrNameP = attrNameP->next)
     {
-      bson_append_utf8(&commaArrayBson, "0", 1, attrNameP->value.s, -1);  // Always index "0" ... seems to work !
+      char buf[16];
+      int  bufLen = mongocIndexString(ix, buf);
+
+      bson_append_utf8(&commaArrayBson, buf, bufLen, attrNameP->value.s, -1);
+      ++ix;
     }
 
     bson_append_array_end(&eachBson, &commaArrayBson);

--- a/src/lib/orionld/mongoc/mongocEntityInsert.cpp
+++ b/src/lib/orionld/mongoc/mongocEntityInsert.cpp
@@ -35,6 +35,7 @@ extern "C"
 #include "orionld/common/orionldState.h"                         // orionldState
 #include "orionld/mongoc/mongocConnectionGet.h"                  // mongocConnectionGet
 #include "orionld/mongoc/mongocKjTreeToBson.h"                   // mongocKjTreeToBson
+#include "orionld/mongoc/mongocWriteLog.h"                       // MONGOC_WLOG
 #include "orionld/mongoc/mongocEntityInsert.h"                   // Own interface
 
 
@@ -60,6 +61,7 @@ bool mongocEntityInsert(KjNode* dbEntityP, const char* entityId)
 
   mongocKjTreeToBson(dbEntityP, &document);
 
+  MONGOC_WLOG("Creating Entity", orionldState.tenantP->mongoDbName, "entities", NULL, &document, LmtMongoc);
   bool b = mongoc_collection_insert_one(orionldState.mongoc.entitiesP, &document, NULL, &reply, &orionldState.mongoc.error);
   if (b == false)
   {

--- a/src/lib/orionld/mongoc/mongocEntityLookup.cpp
+++ b/src/lib/orionld/mongoc/mongocEntityLookup.cpp
@@ -36,6 +36,7 @@ extern "C"
 #include "orionld/mongoc/mongocConnectionGet.h"                  // mongocConnectionGet
 #include "orionld/mongoc/mongocKjTreeFromBson.h"                 // mongocKjTreeFromBson
 #include "orionld/mongoc/mongocAuxAttributesFilter.h"            // mongocAuxAttributesFilter
+#include "orionld/mongoc/mongocWriteLog.h"                       // MONGOC_RLOG
 #include "orionld/mongoc/mongocEntityLookup.h"                   // Own interface
 
 
@@ -116,6 +117,7 @@ KjNode* mongocEntityLookup(const char* entityId, const char* entityType, StringA
   //
   // Run the query
   //
+  MONGOC_RLOG("Entity Lookup", orionldState.tenantP->mongoDbName, "entities", &mongoFilter, LmtMongoc);
   if ((mongoCursorP = mongoc_collection_find_with_opts(orionldState.mongoc.entitiesP, &mongoFilter, &options, readPrefs)) == NULL)
   {
     LM_E(("Internal Error (mongoc_collection_find_with_opts ERROR)"));

--- a/src/lib/orionld/mongoc/mongocIndexString.cpp
+++ b/src/lib/orionld/mongoc/mongocIndexString.cpp
@@ -1,0 +1,36 @@
+/*
+*
+* Copyright 2023 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+#include <stdio.h>                         // snprintf
+
+
+
+// -----------------------------------------------------------------------------
+//
+// mongocIndexString -
+//
+int mongocIndexString(int ix, char* buf)
+{
+  return snprintf(buf, 10, "%d", ix);
+}

--- a/src/lib/orionld/mongoc/mongocIndexString.h
+++ b/src/lib/orionld/mongoc/mongocIndexString.h
@@ -1,0 +1,37 @@
+#ifndef SRC_LIB_ORIONLD_MONGOC_MONGOCINDEXSTRING_H_
+#define SRC_LIB_ORIONLD_MONGOC_MONGOCINDEXSTRING_H_
+
+/*
+*
+* Copyright 2023 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+
+
+
+// -----------------------------------------------------------------------------
+//
+// mongocIndexString -
+//
+extern int mongocIndexString(int ix, char* buf);
+
+#endif  // SRC_LIB_ORIONLD_MONGOC_MONGOCINDEXSTRING_H_


### PR DESCRIPTION
DocumentDB has a problem with BSON  arrays if the "index name" is always "0".
As mongo is OK with that, I never bothered to fix it, but, now with AWS and DocumentDB, it needed to be fixed.
