### PR TITLE
New 'hidden' CLI: -triggerOperation to make the broker add a field 't…

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -9,3 +9,4 @@ Fixed issues:
   * #280  - Highly experimental feature for subscriptions: allowing a wildcard as value for entity type, to not filter on entity type
   * #280  - Implemented Periodic Notifications (subscriptions with a 'timeInterval')
   * #280  - Fixed a crash in the subscription cache for subscriptions with empty URL paths in the notification::endpoint::uri field
+  * #280  - New CLI (hidden) for extra field in notifications (trigger: "VERB URL PATH"): -triggerOperation

--- a/src/app/orionld/orionld.cpp
+++ b/src/app/orionld/orionld.cpp
@@ -258,6 +258,7 @@ bool            mongocOnly   = false;
 bool            debugCurl    = false;
 uint32_t        cSubCounters;
 char            coreContextVersion[64];
+bool            triggerOperation = false;
 
 
 
@@ -337,6 +338,7 @@ char            coreContextVersion[64];
 #define ID_INDEX_DESC          "automatic mongo index on _id.id"
 #define NOSWAP_DESC            "no swapping - for testing only!!!"
 #define NO_NOTIFY_FALSE_UPDATE_DESC  "turn off notifications on non-updates"
+#define TRIGGER_OPERATION_DESC "include the operation that triggered the notification"
 #define EXPERIMENTAL_DESC      "enable experimental implementation - use at own risk - see release notes of Orion-LD v1.1.0"
 #define MONGOCONLY_DESC        "enable experimental implementation + turn off mongo legacy driver"
 #define DBAUTHDB_DESC          "database used for authentication"
@@ -435,6 +437,7 @@ PaArgument paArgs[] =
   { "-troePoolSize",          &troePoolSize,            "TROE_POOL_SIZE",            PaInt,     PaOpt,  10,              0,      1000,             TROE_POOL_DESC           },
   { "-distributed",           &distributed,             "DISTRIBUTED",               PaBool,    PaOpt,  false,           false,  true,             DISTRIBUTED_DESC         },
   { "-noNotifyFalseUpdate",   &noNotifyFalseUpdate,     "NO_NOTIFY_FALSE_UPDATE",    PaBool,    PaOpt,  false,           false,  true,             NO_NOTIFY_FALSE_UPDATE_DESC  },
+  { "-triggerOperation",      &triggerOperation,        "TRIGGER_OPERATION",         PaBool,    PaHid,  false,           false,  true,             TRIGGER_OPERATION_DESC   },
   { "-experimental",          &experimental,            "EXPERIMENTAL",              PaBool,    PaOpt,  false,           false,  true,             EXPERIMENTAL_DESC        },
   { "-mongocOnly",            &mongocOnly,              "MONGOCONLY",                PaBool,    PaOpt,  false,           false,  true,             MONGOCONLY_DESC          },
   { "-cSubCounters",          &cSubCounters,            "CSUB_COUNTERS",             PaInt,     PaOpt,  20,              0,      PaNL,             CSUBCOUNTERS_DESC        },

--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -582,6 +582,7 @@ extern OrionldPhase      orionldPhase;
 extern bool              orionldStartup;           // For now, only used inside sub-cache routines
 extern bool              idIndex;                  // From orionld.cpp
 extern bool              noNotifyFalseUpdate;      // From orionld.cpp
+extern bool              triggerOperation;         // From orionld.cpp
 extern char              mongoServerVersion[32];
 extern bool              experimental;             // From orionld.cpp
 extern bool              mongocOnly;               // From orionld.cpp

--- a/src/lib/orionld/notifications/notificationSend.cpp
+++ b/src/lib/orionld/notifications/notificationSend.cpp
@@ -554,6 +554,15 @@ static KjNode* notificationTree(OrionldAlterationMatch* matchList)
   kjChildAdd(notificationP, notifiedAtNodeP);
   kjChildAdd(notificationP, dataNodeP);
 
+  // Reason for the notification
+  if (triggerOperation == true)
+  {
+    char trigger[128];
+    snprintf(trigger, sizeof(trigger) - 1, "%s %s", orionldState.verbString, orionldState.urlPath);
+    KjNode* triggerP = kjString(orionldState.kjsonP, "trigger", trigger);
+    kjChildAdd(notificationP, triggerP);
+  }
+
   for (OrionldAlterationMatch* matchP = matchList; matchP != NULL; matchP = matchP->next)
   {
     KjNode* apiEntityP = (subP->sysAttrs == false)? matchP->altP->finalApiEntityP : matchP->altP->finalApiEntityWithSysAttrsP;

--- a/test/functionalTest/cases/0000_ngsild/ngsild_showChanges.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_showChanges.test
@@ -25,7 +25,7 @@ showChanges in Subscription - provoke a notification and see the previousValue
 
 --SHELL-INIT--
 dbInit CB
-orionldStart CB -experimental
+orionldStart CB -experimental -triggerOperation
 accumulatorStart --pretty-print
 
 --SHELL--
@@ -130,7 +130,7 @@ echo
 echo "08. Restart broker"
 echo "=================="
 brokerStop CB
-orionldStart CB -experimental
+orionldStart CB -experimental -triggerOperation
 echo
 echo
 
@@ -303,7 +303,7 @@ Date: REGEX(.*)
 05. Dump/Reset accumulator, see A1's value and previousValue
 ============================================================
 POST http://REGEX(.*)/notify?subscriptionId=urn:ngsi-ld:subs:S1
-Content-Length: 265
+Content-Length: 320
 User-Agent: orionld/REGEX(.*)
 Host: REGEX(.*)
 Accept: application/json
@@ -326,6 +326,7 @@ Ngsild-Attribute-Format: Normalized
     "id": "urn:ngsi-ld:Notification:REGEX(.*)",
     "notifiedAt": "20REGEX(.*)Z",
     "subscriptionId": "urn:ngsi-ld:subs:S1",
+    "trigger": "PATCH /ngsi-ld/v1/entities/urn:E1/attrs/A1",
     "type": "Notification"
 }
 =======================================
@@ -483,7 +484,7 @@ Date: REGEX(.*)
 12. Dump/Reset accumulator, see A1's value and previousValue
 ============================================================
 POST http://REGEX(.*)/notify?subscriptionId=urn:ngsi-ld:subs:S1
-Content-Length: 266
+Content-Length: 321
 User-Agent: orionld/REGEX(.*)
 Host: REGEX(.*)
 Accept: application/json
@@ -506,6 +507,7 @@ Ngsild-Attribute-Format: Normalized
     "id": "urn:ngsi-ld:Notification:REGEX(.*)",
     "notifiedAt": "20REGEX(.*)Z",
     "subscriptionId": "urn:ngsi-ld:subs:S1",
+    "trigger": "PATCH /ngsi-ld/v1/entities/urn:E1/attrs/A1",
     "type": "Notification"
 }
 =======================================

--- a/test/unittests/main_UnitTest.cpp
+++ b/test/unittests/main_UnitTest.cpp
@@ -109,6 +109,7 @@ uint32_t        cSubCounters            = 0;
 char            localIpAndPort[135];
 unsigned long long  inReqPayloadMaxSize;
 unsigned long long  outReqMsgMaxSize;
+bool                triggerOperation = false;
 
 
 


### PR DESCRIPTION
New 'hidden' CLI: `-triggerOperation` to make the broker add a field
`"trigger": "VERB URL-PATH"`
 in notifications
