### PR TITLE
GET /version also in `-mongocOnly` mode

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       #max-parallel: 1
       matrix:
-        test: [ 'functional_0_632','functional_633_1003', 'functional_1004_1440', 'functional_1441_end', 'unit']
+        test: [ 'functional_0_700','functional_701_1200', 'functional_1201_1600', 'functional_1601_end' ]
 
     steps:
       - uses: actions/checkout@v2

--- a/src/lib/orionld/serviceRoutines/orionldGetVersion.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetVersion.cpp
@@ -53,6 +53,7 @@ extern "C"
 #include "orionld/common/orionldState.h"                       // orionldState, orionldVersion, postgresServerVersion, mongocServerVersion
 #include "orionld/common/branchName.h"                         // ORIONLD_BRANCH
 #include "orionld/common/pqHeader.h"                           // Postgres header
+#include "orionld/context/orionldCoreContext.h"                // orionldCoreContextP
 #include "orionld/troe/pgVersionGet.h"                         // pgVersionToString
 #include "orionld/mqtt/mqttConnectionList.h"                   // Mqtt Connection List
 #include "orionld/serviceRoutines/orionldGetVersion.h"         // Own Interface
@@ -183,8 +184,12 @@ bool orionldGetVersion(void)
   nodeP = kjString(orionldState.kjsonP, "branch", ORIONLD_BRANCH);
   kjChildAdd(orionldState.responseTree, nodeP);
 
-  // Number of item in the subscription cache
+  // Number of items in the subscription cache
   nodeP = kjInteger(orionldState.kjsonP, "cached subscriptions", subCacheItems());
+  kjChildAdd(orionldState.responseTree, nodeP);
+
+  // Version of the core context
+  nodeP = kjString(orionldState.kjsonP, "Core Context", orionldCoreContextP->url);
   kjChildAdd(orionldState.responseTree, nodeP);
 
   //

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -1361,10 +1361,10 @@ static MHD_Result connectionTreat
 
     ConnectionInfo* ciP = (ConnectionInfo*) *con_cls;
 
-    if ((mongocOnly == true) && (strcmp("/exit/harakiri", url) != 0))
+    if ((mongocOnly == true) && (strcmp("/exit/harakiri", url) != 0) && (strcmp("/version", url) != 0))
     {
-      OrionError error(SccNotImplemented, "NGSIv1/v2 request not supported if -mongocOnly is set");
-      LM_E(("NGSIv1/v2 request not supported if -mongocOnly is set"));
+      OrionError error(SccNotImplemented, "Non NGSI-LD requests are not supported with -mongocOnly is set");
+      LM_E(("Non NGSI-LD requests are not supported with -mongocOnly is set"));
 
       orionldState.httpStatusCode = 501;
       ciP->answer                 = error.smartRender(orionldState.apiVersion);

--- a/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert_crash_with_and_without_link_header.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert_crash_with_and_without_link_header.test
@@ -188,6 +188,7 @@ Content-Type: application/json
 Date: REGEX(.*)
 
 {
+    "Core Context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)",
     "Next File Descriptor": REGEX(.*),
     "Orion-LD version": "REGEX(.*)",
     "based on orion": "REGEX(.*)",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0065.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0065.test
@@ -75,6 +75,7 @@ Content-Type: application/json
 Date: REGEX(.*)
 
 {
+    "Core Context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)",
     "Next File Descriptor": REGEX(\d+),
     "Orion-LD version": "REGEX(.*)",
     "based on orion": "REGEX(.*)",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_1346_patch_non-existing-entity.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_1346_patch_non-existing-entity.test
@@ -73,6 +73,7 @@ Content-Type: application/json
 Date: REGEX(.*)
 
 {
+    "Core Context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)",
     "Next File Descriptor": REGEX(.*),
     "Orion-LD version": "REGEX(.*)",
     "based on orion": "REGEX(.*)",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_batch_upsert_crash_with_and_without_link_header.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_batch_upsert_crash_with_and_without_link_header.test
@@ -188,6 +188,7 @@ Content-Type: application/json
 Date: REGEX(.*)
 
 {
+    "Core Context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)",
     "Next File Descriptor": REGEX(.*),
     "Orion-LD version": "REGEX(.*)",
     "based on orion": "REGEX(.*)",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_subscription_delete.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_subscription_delete.test
@@ -321,6 +321,7 @@ Date: REGEX(.*)
   "openssl version": REGEX(.*),
   "branch": REGEX(.*),
   "cached subscriptions": 0,
+  "Core Context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)",
   "Next File Descriptor": REGEX(.*)
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_delete.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_delete.test
@@ -319,6 +319,7 @@ Date: REGEX(.*)
   "openssl version": REGEX(.*),
   "branch": REGEX(.*),
   "cached subscriptions": 0,
+  "Core Context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)",
   "Next File Descriptor": REGEX(.*)
 }
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_version.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_version.test
@@ -86,6 +86,7 @@ Date: REGEX(.*)
   "postgres server version": "12.REGEX(.*)",
   "branch": REGEX(.*),
   "cached subscriptions": 0,
+  "Core Context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)",
   "Next File Descriptor": REGEX(.*)
 }
 

--- a/test/functionalTest/cases/0000_troe/troe_post_temporal_entities2.test
+++ b/test/functionalTest/cases/0000_troe/troe_post_temporal_entities2.test
@@ -114,6 +114,7 @@ Content-Type: application/json
 Date: REGEX(.*)
 
 {
+    "Core Context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)",
     "Next File Descriptor": REGEX(.*),
     "Orion-LD version": "REGEX(.*)",
     "based on orion": "REGEX(.*)",


### PR DESCRIPTION
* Allowing GET /version when in `-mongocOnly` mode.
* Added the core context to the output of `GET /ngsi-ld/ex/v1/version`.
* GA: Removed unit test from the functests
* GA: Modified the functest indices