### PR TITLE
Improve workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,6 +120,8 @@ jobs:
         with:
           image: ${{ env.IMAGE_ORG }}/${{ env.IMAGE_NAME }}
           oci: true
+          labels: |
+            quay.expires-after=1w
           tags: ${{ env.IMAGE_TAG_LATEST }} ${{ env.IMAGE_TAG_PRE }} ${{ github.sha }}
           dockerfiles: |
             ./docker/Dockerfile-ubi
@@ -141,6 +143,8 @@ jobs:
           image: ${{ env.IMAGE_ORG }}/${{ env.IMAGE_NAME }}
           tags: ${{ env.IMAGE_TAG_PRE }}-GDB
           oci: true
+          labels: |
+            quay.expires-after=1w
           dockerfiles: |
             ./docker/Dockerfile-gdb
           build-args: |
@@ -172,6 +176,8 @@ jobs:
           image: ${{ env.IMAGE_ORG }}/${{ env.IMAGE_NAME }}
           tags: ${{ env.IMAGE_TAG_PRE }}-${{ env.IMAGE_TAG_DEBUG }}
           oci: true
+          labels: |
+            quay.expires-after=1w
           dockerfiles: |
             ./docker/Dockerfile-debug
 

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -7,6 +7,11 @@ env:
   IMAGE_NAME: localhost:5000/orion-ld-test:latest
   IGNORE_TEST: '0706_direct_https_notifications/direct_https_notifications.test 0706_direct_https_notifications/direct_https_notifications_no_accept_selfsigned.test 2015_notification_templates/notification_templates_cache_refresh.test 0000_ipv6_support/ipv4_ipv6_both.test 0740_crash_with_json_object_for_attributes/json_object_format.test 0000_ngsild/ngsild_datasetId_entity_relationship_creation.test 0000_ngsild/ngsild_entities_get_by_type.test 0000_ngsild/ngsild_entity_creation_strange_chars_in_attr_names.test 0000_ngsild/ngsild_entity_creation_with_japanese_chars.test 0000_ngsild/ngsild_issue_0737.test 0000_ngsild/ngsild_query_entities_geo_error.test 2871_fwd_update_ok_but_not_found_response/fwd_update_ok_but_not_found_response.test'
 
+## Cancel running tests, get faster test-results for the latest commit
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-test-image:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Attempt to reduce the load of the build system:
- cancel running/waiting functional test runs when a new commit is pushed
- set label for quay.io to automatically delete non-release images after a given time