### PR TITLE
Use correct max size in strftime to avoid possible out of bounds access

### DIFF
--- a/src/lib/logMsg/logMsg.cpp
+++ b/src/lib/logMsg/logMsg.cpp
@@ -2066,7 +2066,7 @@ LmStatus lmFdRegister
       char  dt[128];
       int   sz;
 
-      strftime(dt, 256, "%A %d %h %H:%M:%S %Y", &tmP);
+      strftime(dt, 128, "%A %d %h %H:%M:%S %Y", &tmP);
       snprintf(startMsg, sizeof(startMsg),
                "%s log\n-----------------\nStarted %s\nCleared at ...\n",
                progName, dt);


### PR DESCRIPTION
## Proposed changes

The max size in strftime is for the dt variable and not for startMsg.  (See https://man7.org/linux/man-pages/man3/strftime.3.html ) This was likely just a typo. Cppcheck was throwing an error "Buffer is accessed out of bounds: dt" for this as the dt buffer is only 128 chars not 256.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/FIWARE/context.Orion-LD/blob/master/CONTRIBUTING.md) doc
-   [x] I have signed the [CLA](https://fiware.github.io/contribution-requirements/individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature works (I think those are not relevant here? But please correct me otherwise)
-   [ ] I have added necessary documentation (if appropriate)
-   [x] Any dependent changes have been merged and published in downstream modules