### PR TITLE
Fixed issue #1573

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -3,6 +3,7 @@
   * #1542:  Array Reduction (arrays of one single element are "flattened" to that very element)
   * SOF:    https://stackoverflow.com/questions/77911109/fiware-to-payload-too-large
   * #1551:  format=simplified for distribute GET /entities gave Normalized for entities from other brokers
+  * #1573:  pagination not working when entities have the exact same creation date (sort also by entity id)
 
 ## New Features:
   * Support for attributes of type VocabularyProperty

--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -1355,7 +1355,9 @@ bool entitiesQuery
 
   if (sortOrderList == NULL)
   {
-    query.sort(BSON(ENT_CREATION_DATE << 1));
+    // query.sort(BSON(ENT_CREATION_DATE << 1));
+    BSONObj sort2 = BSON("creDate" << 1 << "_id.id" << 1);
+    query.sort(sort2);
   }
   else if (strcmp(sortOrderList, ORDER_BY_PROXIMITY) == 0)
   {

--- a/src/lib/orionld/mongoc/mongocEntitiesGet.cpp
+++ b/src/lib/orionld/mongoc/mongocEntitiesGet.cpp
@@ -64,6 +64,7 @@ KjNode* mongocEntitiesGet(char** fieldV, int fields, bool entityIdPresent)
   bson_init(&sortDoc);
 
   bson_append_int32(&sortDoc, "creDate", 7, 1);
+  bson_append_int32(&sortDoc, "_id.id", 6, 1);
   bson_append_document(&options, "sort", 4, &sortDoc);
   bson_destroy(&sortDoc);
 

--- a/src/lib/orionld/mongoc/mongocEntitiesQuery.cpp
+++ b/src/lib/orionld/mongoc/mongocEntitiesQuery.cpp
@@ -696,6 +696,7 @@ KjNode* mongocEntitiesQuery
     bson_init(&sortDoc);
 
     bson_append_int32(&sortDoc, "creDate", 7, 1);
+    bson_append_int32(&sortDoc, "_id.id", 6, 1);
     bson_append_document(&options, "sort", 4, &sortDoc);
     bson_destroy(&sortDoc);
 

--- a/src/lib/orionld/mongoc/mongocEntitiesQuery2.cpp
+++ b/src/lib/orionld/mongoc/mongocEntitiesQuery2.cpp
@@ -287,6 +287,7 @@ KjNode* mongocEntitiesQuery2
   bson_init(&sortDoc);
 
   bson_append_int32(&sortDoc, "creDate", 7, 1);
+  bson_append_int32(&sortDoc, "_id.id", 6, 1);
   bson_append_document(&options, "sort", 4, &sortDoc);
   bson_destroy(&sortDoc);
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_1573-batch-create.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_1573-batch-create.test
@@ -21,43 +21,46 @@
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
 --NAME--
-Entity pagination
+Batch Create 22 entities, all with same creDate, then try pagination
 
 --SHELL-INIT--
 dbInit CB
-orionldStart CB -experimental
+orionldStart CB
 
 --SHELL--
 
 #
-# 01. Create 22 entities
+# 01. Batch create 22 entities
 # 02. GET the first 10
 # 03. GET the next 10
 # 04. GET the first 11
 # 05. GET the next 11
 #
 
-echo "01. Create 22 entities"
-echo "====================="
+echo "01. Batch create 22 entities"
+echo "============================"
 typeset -i eNo
 eNo=1
-
+entities="["
 while [ $eNo -le 22 ]
 do
   eId=$(printf "urn:E%02d" $eNo)
-  eNo=$eNo+1
-
-  payload='{
+  entity='{
     "id": "'$eId'",
     "type": "T",
-    "A1": {
-      "type": "Property",
-      "value": "E'$eNo':A1"
-    }
+    "A": '$eNo'
   }'
-  sleep .01
-  orionCurl --url /ngsi-ld/v1/entities --payload "$payload" | grep 'Location:'
+  entities=$entities$entity
+  if [ $eNo != 22 ]
+  then
+    entities=$entities","
+  fi
+  eNo=$eNo+1
 done
+entities=$entities"]"
+echo $entities > /tmp/entities
+
+orionCurl --url /ngsi-ld/v1/entityOperations/create --payload "$entities"
 echo
 echo
 
@@ -91,30 +94,37 @@ echo
 
 
 --REGEXPECT--
-01. Create 22 entities
-=====================
-Location: /ngsi-ld/v1/entities/urn:E01
-Location: /ngsi-ld/v1/entities/urn:E02
-Location: /ngsi-ld/v1/entities/urn:E03
-Location: /ngsi-ld/v1/entities/urn:E04
-Location: /ngsi-ld/v1/entities/urn:E05
-Location: /ngsi-ld/v1/entities/urn:E06
-Location: /ngsi-ld/v1/entities/urn:E07
-Location: /ngsi-ld/v1/entities/urn:E08
-Location: /ngsi-ld/v1/entities/urn:E09
-Location: /ngsi-ld/v1/entities/urn:E10
-Location: /ngsi-ld/v1/entities/urn:E11
-Location: /ngsi-ld/v1/entities/urn:E12
-Location: /ngsi-ld/v1/entities/urn:E13
-Location: /ngsi-ld/v1/entities/urn:E14
-Location: /ngsi-ld/v1/entities/urn:E15
-Location: /ngsi-ld/v1/entities/urn:E16
-Location: /ngsi-ld/v1/entities/urn:E17
-Location: /ngsi-ld/v1/entities/urn:E18
-Location: /ngsi-ld/v1/entities/urn:E19
-Location: /ngsi-ld/v1/entities/urn:E20
-Location: /ngsi-ld/v1/entities/urn:E21
-Location: /ngsi-ld/v1/entities/urn:E22
+01. Batch create 22 entities
+============================
+HTTP/1.1 201 Created
+Content-Length: 221
+Content-Type: application/json
+Date: REGEX(.*)
+
+[
+    "urn:E01",
+    "urn:E02",
+    "urn:E03",
+    "urn:E04",
+    "urn:E05",
+    "urn:E06",
+    "urn:E07",
+    "urn:E08",
+    "urn:E09",
+    "urn:E10",
+    "urn:E11",
+    "urn:E12",
+    "urn:E13",
+    "urn:E14",
+    "urn:E15",
+    "urn:E16",
+    "urn:E17",
+    "urn:E18",
+    "urn:E19",
+    "urn:E20",
+    "urn:E21",
+    "urn:E22"
+]
 
 
 02. GET the first 10

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_issue_1573-batch-create.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_issue_1573-batch-create.test
@@ -21,7 +21,7 @@
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
 --NAME--
-Entity pagination
+Batch Create 22 entities, all with same creDate, then try pagination
 
 --SHELL-INIT--
 dbInit CB
@@ -30,34 +30,37 @@ orionldStart CB -experimental
 --SHELL--
 
 #
-# 01. Create 22 entities
+# 01. Batch create 22 entities
 # 02. GET the first 10
 # 03. GET the next 10
 # 04. GET the first 11
 # 05. GET the next 11
 #
 
-echo "01. Create 22 entities"
-echo "====================="
+echo "01. Batch create 22 entities"
+echo "============================"
 typeset -i eNo
 eNo=1
-
+entities="["
 while [ $eNo -le 22 ]
 do
   eId=$(printf "urn:E%02d" $eNo)
-  eNo=$eNo+1
-
-  payload='{
+  entity='{
     "id": "'$eId'",
     "type": "T",
-    "A1": {
-      "type": "Property",
-      "value": "E'$eNo':A1"
-    }
+    "A": '$eNo'
   }'
-  sleep .01
-  orionCurl --url /ngsi-ld/v1/entities --payload "$payload" | grep 'Location:'
+  entities=$entities$entity
+  if [ $eNo != 22 ]
+  then
+    entities=$entities","
+  fi
+  eNo=$eNo+1
 done
+entities=$entities"]"
+echo $entities > /tmp/entities
+
+orionCurl --url /ngsi-ld/v1/entityOperations/create --payload "$entities"
 echo
 echo
 
@@ -91,30 +94,37 @@ echo
 
 
 --REGEXPECT--
-01. Create 22 entities
-=====================
-Location: /ngsi-ld/v1/entities/urn:E01
-Location: /ngsi-ld/v1/entities/urn:E02
-Location: /ngsi-ld/v1/entities/urn:E03
-Location: /ngsi-ld/v1/entities/urn:E04
-Location: /ngsi-ld/v1/entities/urn:E05
-Location: /ngsi-ld/v1/entities/urn:E06
-Location: /ngsi-ld/v1/entities/urn:E07
-Location: /ngsi-ld/v1/entities/urn:E08
-Location: /ngsi-ld/v1/entities/urn:E09
-Location: /ngsi-ld/v1/entities/urn:E10
-Location: /ngsi-ld/v1/entities/urn:E11
-Location: /ngsi-ld/v1/entities/urn:E12
-Location: /ngsi-ld/v1/entities/urn:E13
-Location: /ngsi-ld/v1/entities/urn:E14
-Location: /ngsi-ld/v1/entities/urn:E15
-Location: /ngsi-ld/v1/entities/urn:E16
-Location: /ngsi-ld/v1/entities/urn:E17
-Location: /ngsi-ld/v1/entities/urn:E18
-Location: /ngsi-ld/v1/entities/urn:E19
-Location: /ngsi-ld/v1/entities/urn:E20
-Location: /ngsi-ld/v1/entities/urn:E21
-Location: /ngsi-ld/v1/entities/urn:E22
+01. Batch create 22 entities
+============================
+HTTP/1.1 201 Created
+Content-Length: 221
+Content-Type: application/json
+Date: REGEX(.*)
+
+[
+    "urn:E01",
+    "urn:E02",
+    "urn:E03",
+    "urn:E04",
+    "urn:E05",
+    "urn:E06",
+    "urn:E07",
+    "urn:E08",
+    "urn:E09",
+    "urn:E10",
+    "urn:E11",
+    "urn:E12",
+    "urn:E13",
+    "urn:E14",
+    "urn:E15",
+    "urn:E16",
+    "urn:E17",
+    "urn:E18",
+    "urn:E19",
+    "urn:E20",
+    "urn:E21",
+    "urn:E22"
+]
 
 
 02. GET the first 10


### PR DESCRIPTION
Pagination doesn't work for entities with the exact same creation date, as the pagination algorithm is based on ordering entities by their creation date.
Now, if entities are created using batch create - create many entities in a single request, they all get the very same creation date.
To fix the problem, entities are now ordered on both creation date AND entity id.

Fun fact:
This "pagination idea" was invented some time in 2013, in Orion (the NGSIv2 broker), and it took us no more than 11 years to find the flaw :)))
A pretty obvious flaw I must say ...
