### PR TITLE
Fixed #1593 for broker running in legacy mode

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -5,6 +5,7 @@
   * #1551:  format=simplified for distribute GET /entities gave Normalized for entities from other brokers
   * #1573:  pagination not working when entities have the exact same creation date (sort also by entity id)
   * #1583:  If a 'q' contains an ampersand, that ampersand needs to be forwarded as a semicolon
+  * #1593:  Modify the type of an entity in a Replace operation (only working in legacy mode)
 
 ## New Features:
   * Support for attributes of type VocabularyProperty

--- a/src/lib/orionld/common/batchEntitiesFinalCheck.cpp
+++ b/src/lib/orionld/common/batchEntitiesFinalCheck.cpp
@@ -225,7 +225,7 @@ int batchEntitiesFinalCheck(KjNode* requestTree, KjNode* errorsArrayP, KjNode* d
     //
     if (dbEntityP != NULL)
     {
-      if (entityTypeCheck(dbEntityTypeNodeP->value.s, eP) == false)
+      if ((orionldState.uriParamOptions.replace == false) && (entityTypeCheck(dbEntityTypeNodeP->value.s, eP) == false))
       {
         entityErrorPush(errorsArrayP, entityId, OrionldBadRequestData, "Invalid Entity", "the Entity Type cannot be altered", 400);
         kjChildRemove(orionldState.requestTree, eP);
@@ -245,7 +245,7 @@ int batchEntitiesFinalCheck(KjNode* requestTree, KjNode* errorsArrayP, KjNode* d
       char* oldType = NULL;
       if (creationByPreviousInstance(creationArrayP, eP, entityId, &oldType) == true)
       {
-        if (entityTypeCheck(oldType, eP) == false)
+        if ((orionldState.uriParamOptions.replace == false) && (entityTypeCheck(oldType, eP) == false))
         {
           entityErrorPush(errorsArrayP, entityId, OrionldBadRequestData, "Invalid Entity", "the Entity Type cannot be altered", 400);
           kjChildRemove(orionldState.requestTree, eP);

--- a/src/lib/orionld/common/batchReplaceEntity.cpp
+++ b/src/lib/orionld/common/batchReplaceEntity.cpp
@@ -32,6 +32,8 @@ extern "C"
 #include "kjson/kjClone.h"                                     // kjClone
 }
 
+#include "logMsg/logMsg.h"                                     // LM_*
+
 #include "orionld/common/orionldState.h"                       // orionldState
 #include "orionld/dbModel/dbModelFromApiEntity.h"              // dbModelFromApiEntity
 #include "orionld/common/batchReplaceEntity.h"                 // Own interface
@@ -57,6 +59,9 @@ KjNode* batchReplaceEntity(KjNode* inEntityP, char* entityId, char* entityType, 
 
   if (dbModelFromApiEntity(dbFinalEntityP, NULL, true, entityId, entityType) == false)
     return NULL;
+
+  LM_T(LmtSR, ("entityType: '%s'", entityType));
+  kjTreeLog(dbFinalEntityP, "dbFinalEntity", LmtSR);
 
   //
   // Fix the entity's creDate (from the version of the entity that was fouind in the database)

--- a/src/lib/orionld/legacyDriver/legacyPostBatchUpsert.cpp
+++ b/src/lib/orionld/legacyDriver/legacyPostBatchUpsert.cpp
@@ -341,17 +341,20 @@ bool legacyPostBatchUpsert(void)
       //
       if (typeInPayload != NULL)
       {
-        if (strcmp(typeInPayload, typeInDb) != 0)
+        if (orionldState.uriParamOptions.replace == false)
         {
-          //
-          // As the entity type differed, this entity will not be updated in DB, nor will it be removed:
-          // - removed from incomingTree
-          // - not added to "removeArray"
-          //
-          LM_W(("Bad Input (orig entity type: '%s'. New entity type: '%s'", typeInDb, typeInPayload));
-          entityErrorPush(errorsArrayP, idInDb, OrionldBadRequestData, "non-matching entity type", typeInPayload, 400);
-          kjChildRemove(incomingTree, entityP);
-          continue;
+          if (strcmp(typeInPayload, typeInDb) != 0)
+          {
+            //
+            // As the entity type differed, this entity will not be updated in DB, nor will it be removed:
+            // - removed from incomingTree
+            // - not added to "removeArray"
+            //
+            LM_W(("Bad Input (orig entity type: '%s'. New entity type: '%s'", typeInDb, typeInPayload));
+            entityErrorPush(errorsArrayP, idInDb, OrionldBadRequestData, "non-matching entity type", typeInPayload, 400);
+            kjChildRemove(incomingTree, entityP);
+            continue;
+          }
         }
       }
       else

--- a/src/lib/orionld/mongoc/mongocEntitiesUpsert.cpp
+++ b/src/lib/orionld/mongoc/mongocEntitiesUpsert.cpp
@@ -92,7 +92,10 @@ bool mongocEntitiesUpsert(KjNode* createArrayP, KjNode* updateArrayP)
 
       bson_append_utf8(&match, "_id.id", 6, idP->value.s, -1);
 
+      //
       // Now that the entity id is known, the entire _id must be removed - can't update with _id present
+      // FIXME: This is a big problem if the entity type is being modified (issue #1593)
+      //
       kjChildRemove(entityP, _idP);
 
       mongocKjTreeToBson(entityP, &doc);  // The entity needs to be DB-Prepared !

--- a/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert-options=replace_payload_error_type_field.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert-options=replace_payload_error_type_field.test
@@ -30,6 +30,8 @@ orionldStart CB
 --SHELL--
 
 #
+# This test is no longer relevant as it is now allowed to chang ethe type of an entity with a REPLACE operation
+#
 # 01. POST /ngsi-ld/v1/entityOperations/upsert?options=replace - 4 entities
 # 02. Update all four entities. Vehicle:00001 with a entity::type that differs
 #
@@ -207,29 +209,9 @@ Date: REGEX(.*)
 
 02. Update all four entities. Vehicle:00001 with a entity::type that differs
 ============================================================================
-HTTP/1.1 207 Multi-Status
-Content-Length: 334
-Content-Type: application/json
+HTTP/1.1 204 No Content
 Date: REGEX(.*)
 
-{
-    "errors": [
-        {
-            "entityId": "urn:ngsi-ld:Vehicle:00001",
-            "error": {
-                "detail": "https://uri.etsi.org/ngsi-ld/default-context/Motorcycle",
-                "status": 400,
-                "title": "non-matching entity type",
-                "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
-            }
-        }
-    ],
-    "success": [
-        "urn:ngsi-ld:Vehicle:00002",
-        "urn:ngsi-ld:Vehicle:00003",
-        "urn:ngsi-ld:Vehicle:00004"
-    ]
-}
 
 
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_1593.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_1593.test
@@ -1,0 +1,110 @@
+# Copyright 2024 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Batch Upsert with REPLACE, allowing entity type to be modified (issue #1583)
+
+--SHELL-INIT--
+dbInit CB
+orionldStart CB
+
+--SHELL--
+
+#
+# 01. Create an entity 'urn:E1' of type T1
+# 02. Replace the entity 'urn:E1' using batch upsert, giving it a new type T2
+# 03. GET the entity, see the updated values
+#
+
+echo "01. Create an entity 'urn:E1' of type T1"
+echo "========================================"
+payload=' [
+  {
+    "id": "urn:E1",
+    "type": "T1",
+    "P1": 1
+  }
+]'
+orionCurl --url /ngsi-ld/v1/entityOperations/upsert --payload "$payload"
+echo
+echo
+
+
+echo "02. Replace the entity 'urn:E1' using batch upsert, giving it a new type T2"
+echo "==========================================================================="
+payload=' [
+  {
+    "id": "urn:E1",
+    "type": "T2",
+    "P1": 2
+  }
+]'
+orionCurl --url /ngsi-ld/v1/entityOperations/upsert?options=replace --payload "$payload"
+echo
+echo
+
+
+echo "03. GET the entity, see the updated values"
+echo "=========================================="
+orionCurl --url /ngsi-ld/v1/entities/urn:E1?format=simplified
+echo
+echo
+
+
+--REGEXPECT--
+01. Create an entity 'urn:E1' of type T1
+========================================
+HTTP/1.1 201 Created
+Content-Length: 10
+Content-Type: application/json
+Date: REGEX(.*)
+
+[
+    "urn:E1"
+]
+
+
+02. Replace the entity 'urn:E1' using batch upsert, giving it a new type T2
+===========================================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+03. GET the entity, see the updated values
+==========================================
+HTTP/1.1 200 OK
+Content-Length: 34
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+{
+    "P1": 2,
+    "id": "urn:E1",
+    "type": "T2"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_batch_upsert-options=replace_payload_error_type_field.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_batch_upsert-options=replace_payload_error_type_field.test
@@ -31,6 +31,8 @@ orionldStart CB -experimental
 --SHELL--
 
 #
+# ngsild_new_batch_upsert-options=replace_payload_error_type_field.test
+#
 # 01. POST /ngsi-ld/v1/entityOperations/upsert?options=replace - 4 entities
 # 02. Update all four entities. Vehicle:00001 with a entity::type that differs
 #
@@ -208,29 +210,9 @@ Date: REGEX(.*)
 
 02. Update all four entities. Vehicle:00001 with a entity::type that differs
 ============================================================================
-HTTP/1.1 207 Multi-Status
-Content-Length: 302
-Content-Type: application/json
+HTTP/1.1 204 No Content
 Date: REGEX(.*)
 
-{
-    "errors": [
-        {
-            "entityId": "urn:ngsi-ld:Vehicle:00001",
-            "error": {
-                "detail": "the Entity Type cannot be altered",
-                "status": 400,
-                "title": "Invalid Entity",
-                "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
-            }
-        }
-    ],
-    "success": [
-        "urn:ngsi-ld:Vehicle:00002",
-        "urn:ngsi-ld:Vehicle:00003",
-        "urn:ngsi-ld:Vehicle:00004"
-    ]
-}
 
 
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_issue_1593.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_issue_1593.test
@@ -1,0 +1,119 @@
+# Copyright 2024 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Batch Upsert with REPLACE, allowing entity type to be modified (issue #1583)
+
+--SHELL-INIT--
+dbInit CB
+orionldStart CB -mongocOnly
+
+--SHELL--
+
+#
+# Replacing an entity, modifying its entity type, work fine with the legacy mongo driver.
+# However, mongoc doesn't allow it !
+# At least not with the currently used mongoc function (mongoc_bulk_operation_replace_one+mongoc_bulk_operation_execute)
+# So, for now, this is a bug with the new driver, but, the feature is needed in legacy Orion-LD, so:
+#
+# FIXME: Make it possible to replace the entity type in a REPLACE operation with mongoc
+#
+# Until this bug is fixed, this functest assumes (in step 03) that the entity type has not been updated
+#
+# 01. Create an entity 'urn:E1' of type T1
+# 02. Replace the entity 'urn:E1' using batch upsert, giving it a new type T2
+# 03. GET the entity, see the updated values
+#
+
+echo "01. Create an entity 'urn:E1' of type T1"
+echo "========================================"
+payload=' [
+  {
+    "id": "urn:E1",
+    "type": "T1",
+    "P1": 1
+  }
+]'
+orionCurl --url /ngsi-ld/v1/entityOperations/upsert --payload "$payload"
+echo
+echo
+
+
+echo "02. Replace the entity 'urn:E1' using batch upsert, giving it a new type T2"
+echo "==========================================================================="
+payload=' [
+  {
+    "id": "urn:E1",
+    "type": "T2",
+    "P1": 2
+  }
+]'
+orionCurl --url /ngsi-ld/v1/entityOperations/upsert?options=replace --payload "$payload"
+echo
+echo
+
+
+echo "03. GET the entity, see the updated values"
+echo "=========================================="
+orionCurl --url /ngsi-ld/v1/entities/urn:E1?format=simplified
+echo
+echo
+
+
+--REGEXPECT--
+01. Create an entity 'urn:E1' of type T1
+========================================
+HTTP/1.1 201 Created
+Content-Length: 10
+Content-Type: application/json
+Date: REGEX(.*)
+
+[
+    "urn:E1"
+]
+
+
+02. Replace the entity 'urn:E1' using batch upsert, giving it a new type T2
+===========================================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+03. GET the entity, see the updated values
+==========================================
+HTTP/1.1 200 OK
+Content-Length: 34
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+{
+    "P1": 2,
+    "id": "urn:E1",
+    "type": "T1"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
Fixed issue #1593 
But only for Orion-LD running in legacy mode:

Replacing an entity, modifying its entity type, works fine now with the legacy mongo driver.
However, mongoc (the new mongo driver) doesn't allow it !
At least not with the currently used mongoc function: `mongoc_bulk_operation_replace_one+mongoc_bulk_operation_execute`.
So, for now, this is a bug with the new driver, but, the feature is needed in legacy Orion-LD, so PR anyway.
