### PR TITLE
Aer os/array with one item

### DIFF
--- a/src/app/orionld/orionld.cpp
+++ b/src/app/orionld/orionld.cpp
@@ -244,6 +244,7 @@ uint32_t        cSubCounters;
 char            coreContextVersion[64];
 bool            triggerOperation = false;
 bool            noprom           = false;
+bool            noArrayReduction = false;
 
 
 
@@ -337,6 +338,7 @@ bool            noprom           = false;
 #define CSUBCOUNTERS_DESC      "number of subscription counter updates before flush from sub-cache to DB (0: never, 1: always)"
 #define CORE_CONTEXT_DESC      "core context version (v1.0|v1.3|v1.4|v1.5|v1.6|v1.7) - v1.6 is default"
 #define NO_PROM_DESC           "run without Prometheus metrics"
+#define NO_ARR_REDUCT_DESC     "skip JSON-LD Array Reduction"
 
 
 
@@ -441,6 +443,7 @@ PaArgument paArgs[] =
   { "-debugCurl",             &debugCurl,               "DEBUG_CURL",                PaBool,    PaHid,  false,           false,  true,             DEBUG_CURL_DESC          },
   { "-lmtmp",                 &lmtmp,                   "TMP_TRACES",                PaBool,    PaHid,  true,            false,  true,             TMPTRACES_DESC           },
   { "-noprom",                &noprom,                  "NO_PROM",                   PaBool,    PaHid,  false,           false,  true,             NO_PROM_DESC             },
+  { "-noArrayReduction",      &noArrayReduction,        "NO_ARRAY_REDUCTION",        PaBool,    PaHid,  false,           false,  true,             NO_ARR_REDUCT_DESC       },
 
   PA_END_OF_ARGS
 };

--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -613,6 +613,7 @@ extern uint32_t          cSubCounters;             // Number of subscription cou
 extern PernotSubCache    pernotSubCache;
 extern EntityMap*        entityMaps;               // Used by GET /entities in the distributed case, for pagination
 extern bool              entityMapsEnabled;
+extern bool              noArrayReduction;         // Used by arrayReduce in pCheckAttribute.cpp
 
 extern char                localIpAndPort[135];    // Local address for X-Forwarded-For (from orionld.cpp)
 extern unsigned long long  inReqPayloadMaxSize;

--- a/src/lib/orionld/payloadCheck/pCheckAttribute.cpp
+++ b/src/lib/orionld/payloadCheck/pCheckAttribute.cpp
@@ -125,6 +125,9 @@ static const char* attrTypeChangeTitle(OrionldAttributeType oldType, OrionldAttr
 //
 static void arrayReduce(KjNode* valueP)
 {
+  if (noArrayReduction == true)  // Global variable, from CLI
+    return;
+
   if (valueP->type != KjArray)
     return;
 
@@ -1254,7 +1257,8 @@ static bool pCheckAttributeObject
     {
       if (fieldP->type == KjArray)
       {
-        if ((fieldP->value.firstChildP != NULL) && (fieldP->value.firstChildP->next == NULL))
+        // Reduce the array?
+        if ((noArrayReduction != true) && (fieldP->value.firstChildP != NULL) && (fieldP->value.firstChildP->next == NULL))
         {
           fieldP->lastChild = fieldP->value.firstChildP->lastChild;  // Might be an array or object inside the array ...
           fieldP->type      = fieldP->value.firstChildP->type;

--- a/test/functionalTest/cases/0000_ngsild/ngsild_no-array-reduction-and-concise-format.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_no-array-reduction-and-concise-format.test
@@ -1,0 +1,94 @@
+# Copyright 2024 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Concise Attribute Format and Array Reduction
+
+--SHELL-INIT--
+dbInit CB
+orionldStart CB -experimental -noArrayReduction
+
+--SHELL--
+#
+# 01. Create an entity E1 with 2 attributes, that are arrays with ONE item
+# 02. GET E1 - see the arrays reduced
+#
+
+echo "01. Create an entity E1 with 2 attributes, that are arrays with ONE item"
+echo "========================================================================"
+payload='{
+  "id": "urn:E1",
+  "type": "T",
+  "A1": [ 1 ],
+  "A2": {
+    "value": [ 2 ]
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "02. GET E1 - see the arrays reduced"
+echo "==================================="
+orionCurl --url /ngsi-ld/v1/entities/urn:E1
+echo
+echo
+
+
+--REGEXPECT--
+01. Create an entity E1 with 2 attributes, that are arrays with ONE item
+========================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:E1
+
+
+
+02. GET E1 - see the arrays reduced
+===================================
+HTTP/1.1 200 OK
+Content-Length: 98
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+{
+    "A1": {
+        "type": "Property",
+        "value": 1
+    },
+    "A2": {
+        "type": "Property",
+        "value": [
+            2
+        ]
+    },
+    "id": "urn:E1",
+    "type": "T"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/unittests/main_UnitTest.cpp
+++ b/test/unittests/main_UnitTest.cpp
@@ -111,6 +111,7 @@ char            brokerId[136];
 unsigned long long  inReqPayloadMaxSize;
 unsigned long long  outReqMsgMaxSize;
 bool                triggerOperation = false;
+bool                noArrayReduction = false;
 
 
 


### PR DESCRIPTION
Added a CLI param `-noArrayReduction`, to ask the broker not to do JSON-LD array reduction.
It's a hidden parameter, as, frankly, it's not the best idea to go against JSON-LD rules ...

