### PR TITLE
Four minor fixes

### DIFF
--- a/src/lib/logMsg/traceLevels.h
+++ b/src/lib/logMsg/traceLevels.h
@@ -47,7 +47,6 @@ typedef enum TraceLevels
   // Alterations and Notifications
   //
   LmtAlt = 40,                         // Notifications: Alterations
-  LmtRegMatch,                         // Distributed Operations: registration matching
   LmtWatchedAttributes,                // Watched attributes in subscriptions
   LmtNotificationMsg,                  // Notifications: Messages
   LmtNotificationStats,                // Errors and timestamps for subscriptions
@@ -85,6 +84,7 @@ typedef enum TraceLevels
   LmtDistOpResponseBuf,                // Specific debugging of the incoming response of a distributed message
   LmtDistOpResponseDetail,             // Details on responses to distributed requests
   LmtDistOpResponseHeaders,            // HTTP headers of responses to distributed requests
+  LmtRegMatch,                         // Distributed Operations: registration matching
 
   //
   // Distributed Operations - misc

--- a/src/lib/orionld/distOp/xForwardedForMatch.cpp
+++ b/src/lib/orionld/distOp/xForwardedForMatch.cpp
@@ -34,8 +34,8 @@
 //
 bool xForwardedForMatch(char* hostsHeader, char* host)
 {
-  LM_T(LmtDistOpLoop, ("Loop Detection: X-Forwarded-For header: '%s' (from 'forwarder')", hostsHeader));
-  LM_T(LmtDistOpLoop, ("Loop Detection: Forward to IP/port:     '%s' (next 'forwardee')", host));
+  // LM_T(LmtDistOpLoop, ("Loop Detection: X-Forwarded-For header: '%s' (from 'forwarder')", hostsHeader));
+  // LM_T(LmtDistOpLoop, ("Loop Detection: Forward to IP/port:     '%s' (next 'forwardee')", host));
 
   //
   // For example:
@@ -49,34 +49,34 @@ bool xForwardedForMatch(char* hostsHeader, char* host)
   //
   if (hostsHeader == NULL)
   {
-    LM_T(LmtDistOpLoop, ("Loop Detection: No X-Forwarded-For header present, so no loop detected"));
+    // LM_T(LmtDistOpLoop, ("Loop Detection: No X-Forwarded-For header present, so no loop detected"));
     return false;
   }
 
   char* subString = strstr(hostsHeader, host);
   if (subString == NULL)
   {
-    LM_T(LmtDistOpLoop, ("Loop Detection: IP/port (%s) not in X-Forwarded-For header, so no loop detected", host));
+    // LM_T(LmtDistOpLoop, ("Loop Detection: IP/port (%s) not in X-Forwarded-For header, so no loop detected", host));
     return false;
   }
 
   char charBefore = (subString == hostsHeader)? ' ' : subString[-1];
   char charAfter  = subString[strlen(host)];
 
-  LM_T(LmtDistOpLoop, ("Loop Detection: subString: '%s'", subString));
-  LM_T(LmtDistOpLoop, ("Loop Detection: charBefore=0x%x, charAfter=0x%x", charBefore & 0xFF, charAfter & 0xFF));
+  // LM_T(LmtDistOpLoop, ("Loop Detection: subString: '%s'", subString));
+  // LM_T(LmtDistOpLoop, ("Loop Detection: charBefore=0x%x, charAfter=0x%x", charBefore & 0xFF, charAfter & 0xFF));
   if ((charBefore != ' ') && (charBefore != ':') && (charBefore != ','))
   {
-    LM_T(LmtDistOpLoop, ("Loop Detection: No Match"));
+    // LM_T(LmtDistOpLoop, ("Loop Detection: No Match"));
     return false;
   }
 
   if ((charAfter != 0) && (charAfter != ',') && (charAfter != ' '))
   {
-    LM_T(LmtDistOpLoop, ("Loop Detection: No Match"));
+    // LM_T(LmtDistOpLoop, ("Loop Detection: No Match"));
     return false;
   }
 
-  LM_T(LmtDistOpLoop, ("Loop Detection: Detected a loop - must stop it!"));
+  // LM_T(LmtDistOpLoop, ("Loop Detection: Detected a loop - must stop it!"));
   return true;
 }

--- a/src/lib/orionld/service/orionldServiceInit.cpp
+++ b/src/lib/orionld/service/orionldServiceInit.cpp
@@ -261,15 +261,21 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
   {
     serviceP->options   |= ORIONLD_SERVICE_OPTION_CLONE_PAYLOAD;
     serviceP->options   |= ORIONLD_SERVICE_OPTION_EXPAND_ATTR;
+
+    serviceP->uriParams |= ORIONLD_URIPARAM_TYPELIST;
   }
   else if (serviceP->serviceRoutine == orionldPutAttribute)
   {
     serviceP->options   |= ORIONLD_SERVICE_OPTION_EXPAND_ATTR;
+
+    serviceP->uriParams |= ORIONLD_URIPARAM_TYPELIST;
   }
   else if (serviceP->serviceRoutine == orionldPatchEntity)
   {
     serviceP->options   |= ORIONLD_SERVICE_OPTION_PREFETCH_ID_AND_TYPE;
     serviceP->options   |= ORIONLD_SERVICE_OPTION_CLONE_PAYLOAD;
+
+    serviceP->uriParams |= ORIONLD_URIPARAM_TYPELIST;
   }
   else if (serviceP->serviceRoutine == orionldPatchEntity2)
   {
@@ -278,9 +284,11 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
 
     serviceP->uriParams |= ORIONLD_URIPARAM_OPTIONS;
     serviceP->uriParams |= ORIONLD_URIPARAM_OBSERVEDAT;
+    serviceP->uriParams |= ORIONLD_URIPARAM_TYPELIST;
   }
   else if (serviceP->serviceRoutine == orionldPutEntity)
   {
+    serviceP->uriParams |= ORIONLD_URIPARAM_TYPELIST;
   }
   else if (serviceP->serviceRoutine == orionldDeleteAttribute)
   {
@@ -288,6 +296,7 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
     serviceP->uriParams |= ORIONLD_URIPARAM_DELETEALL;
 
     serviceP->options   |= ORIONLD_SERVICE_OPTION_EXPAND_ATTR;
+    serviceP->uriParams |= ORIONLD_URIPARAM_TYPELIST;
   }
   else if (serviceP->serviceRoutine == orionldPostRegistrations)
   {

--- a/src/lib/orionld/types/DistOpType.cpp
+++ b/src/lib/orionld/types/DistOpType.cpp
@@ -147,7 +147,8 @@ const char* distOpTypeAlias[5] = {
 #define M(x) (1LL << x)
 uint64_t federationOpsMask   = M(DoRetrieveEntity)       | M(DoQueryEntity)       | M(DoCreateSubscription) | M(DoUpdateSubscription) |
                                M(DoRetrieveSubscription) | M(DoQuerySubscription) | M(DoDeleteSubscription);
-uint64_t updateOpsMask       = M(DoUpdateEntity)         | M(DoUpdateAttrs)       | M(DoReplaceEntity)      | M(DoReplaceAttr);
+uint64_t updateOpsMask       = M(DoUpdateEntity)         | M(DoUpdateAttrs)       | M(DoReplaceEntity)      | M(DoReplaceAttr)        |
+                               M(DoMergeEntity)          | M(DoAppendAttrs);
 uint64_t retrieveOpsMask     = M(DoRetrieveEntity)       | M(DoQueryEntity);
 uint64_t redirectionOpsMask  = M(DoCreateEntity)         | M(DoUpdateEntity)      | M(DoAppendAttrs)        | M(DoUpdateAttrs)        |
                                M(DoDeleteAttrs)          | M(DoDeleteEntity)      | M(DoMergeEntity)        | M(DoReplaceEntity)      |

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_1467.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_1467.test
@@ -38,6 +38,7 @@ orionldStart CP1 -experimental
 # 04. PATCH /entities/urn:E4/attrs/P1
 # 05. GET /entities/urn:E4 from CB - see the update (from CP1)
 # 06. GET /entities/urn:E4 from CP1 - see the update
+# 07. GET /entities/urn:E4 from CB with local=true - see 404
 #
 
 echo "01. Create an entity urn:E3, type T in CP1"
@@ -110,6 +111,13 @@ echo
 echo "06. GET /entities/urn:E4 from CP1 - see the update"
 echo "=================================================="
 orionCurl --url /ngsi-ld/v1/entities/urn:E4?type=T --port $CP1_PORT
+echo
+echo
+
+
+echo "07. GET /entities/urn:E4 from CB with local=true - see 404"
+echo "=========================================================="
+orionCurl --url "/ngsi-ld/v1/entities/urn:E4?type=T&local=true"
 echo
 echo
 
@@ -190,6 +198,20 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.6.jsonld>; rel="h
     },
     "id": "urn:E4",
     "type": "T"
+}
+
+
+07. GET /entities/urn:E4 from CB with local=true - see 404
+==========================================================
+HTTP/1.1 404 Not Found
+Content-Length: 108
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "urn:E4",
+    "title": "Entity Not Found",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/ResourceNotFound"
 }
 
 


### PR DESCRIPTION
Four minor fixes:
* Allowing `type` as URI param for a number of updating ops.
* Moved the trace level for 'no reg match' closer to other distop levels.
* Added a few operations to the alias 'updateOps'.
* Less logging for X-Forwarded-For, that is no longer in use (replaced by Via)
