### PR TITLE
Null/delete

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -14,6 +14,7 @@
   * Support for JsonProperty attribute type
   * Fixed a possible crash for TRoE and attributes of type Vocab/Json/Language
   * Forbidden to DELETE the Core Context !!!  (it can be reloaded)
+  * Bug fix: JSON NULL literal is no longer forwarded!
 
 ## Notes
   * TRoE is still not prepared for attributes of type Vocab/Json/Language, so, attributes of those types are not stored in the historical database

--- a/src/lib/orionld/distOp/distOpSend.cpp
+++ b/src/lib/orionld/distOp/distOpSend.cpp
@@ -332,6 +332,13 @@ void subAttrsCompact(KjNode* requestBody, OrionldContext* fwdContextP)
 {
   for (KjNode* subAttrP = requestBody->value.firstChildP; subAttrP != NULL; subAttrP = subAttrP->next)
   {
+    // NULL => "urn:ngsi-ld:null"
+    if (subAttrP->type == KjNull)
+    {
+      subAttrP->type = KjString;
+      subAttrP->value.s = (char*) "urn:ngsi-ld:null";
+    }
+
     if (strcmp(subAttrP->name, "type")        == 0)   continue;
     if (strcmp(subAttrP->name, "value")       == 0)   continue;
     if (strcmp(subAttrP->name, "object")      == 0)   continue;
@@ -356,6 +363,13 @@ void bodyCompact(DistOpType operation, KjNode* requestBody, OrionldContext* fwdC
   {
     for (KjNode* attrP = requestBody->value.firstChildP; attrP != NULL; attrP = attrP->next)
     {
+      // NULL => "urn:ngsi-ld:null"
+      if (attrP->type == KjNull)
+      {
+        attrP->type = KjString;
+        attrP->value.s = (char*) "urn:ngsi-ld:null";
+      }
+
       if (strcmp(attrP->name, "id")       == 0)  continue;
       if (strcmp(attrP->name, "scope")    == 0)  continue;
       if (strcmp(attrP->name, "location") == 0)  continue;
@@ -367,8 +381,8 @@ void bodyCompact(DistOpType operation, KjNode* requestBody, OrionldContext* fwdC
       }
 
       attrP->name = orionldContextItemAliasLookup(fwdContextP, attrP->name, NULL, NULL);
-
-      subAttrsCompact(attrP, fwdContextP);
+      if (attrP->type == KjObject)
+        subAttrsCompact(attrP, fwdContextP);
     }
   }
 }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_null-delete-relationship-with-patch.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_null-delete-relationship-with-patch.test
@@ -1,0 +1,215 @@
+# Copyright 2024 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Update an entity using Real PATCH - delete one Property with attr: "urn:ngsi-ld:null"
+
+--SHELL-INIT--
+dbInit CB
+dbInit CP1
+orionldStart CB -experimental -forwarding
+orionldStart CP1 -experimental -forwarding
+
+
+--SHELL--
+
+#
+# 01. Create an entity urn:E1 with a Relationship R1, in CB
+# 02. Create an entity urn:E2 with a Relationship R2, in CP1
+# 03. PATCH urn:E1, deleting R1 of urn:E1, in CB
+# 04. GET urn:E1, from CB, see that the R1 relationship is no longer there
+# 05. Create a registration in CB, pointing to CP1
+# 06. PATCH urn:E2, deleting R2 of urn:E1, in CB, to be forwarded to CP1
+# 07. GET urn:E2, from CB, see that the R2 relationship is no longer there
+#
+
+echo "01. Create an entity urn:E1 with a Relationship R1, in CB"
+echo "========================================================="
+payload='{
+  "id": "urn:E1",
+  "type": "T",
+  "R1": {
+    "object": "urn:E1"
+  },
+  "P1": 1
+
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "02. Create an entity urn:E2 with a Relationship R2, in CP1"
+echo "=========================================================="
+payload='{
+  "id": "urn:E2",
+  "type": "T",
+  "R2": {
+    "object": "urn:E2"
+  },
+  "P2": 2
+
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload" --port $CP1_PORT
+echo
+echo
+
+
+echo "03. PATCH urn:E1, deleting R1 of urn:E1, in CB"
+echo "=============================================="
+payload='{
+  "R1": "urn:ngsi-ld:null"
+}'
+orionCurl --url /ngsi-ld/v1/entities/urn:E1 --payload "$payload" -X PATCH
+echo
+echo
+
+
+
+echo "04. GET urn:E1, from CB, see that the R1 relationship is no longer there"
+echo "========================================================================"
+orionCurl --url /ngsi-ld/v1/entities/urn:E1
+echo
+echo
+
+
+echo "05. Create a registration in CB, pointing to CP1"
+echo "================================================"
+payload='{
+  "id": "urn:R1",
+  "type": "ContextSourceRegistration",
+  "information": [
+    {
+      "entities": [
+        {
+          "type": "T"
+        }
+      ]
+    }
+  ],
+  "endpoint": "localhost:'$CP1_PORT'",
+  "operations": [ "mergeEntity", "retrieveEntity" ]
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload"
+echo
+echo
+
+
+echo "06. PATCH urn:E2, deleting R2 of urn:E1, in CB, to be forwarded to CP1"
+echo "======================================================================"
+payload='{
+  "R2": "urn:ngsi-ld:null"
+}'
+orionCurl --url /ngsi-ld/v1/entities/urn:E2 --payload "$payload" -X PATCH
+echo
+echo
+
+
+echo "07. GET urn:E2, from CB, see that the R2 relationship is no longer there"
+echo "========================================================================"
+orionCurl --url /ngsi-ld/v1/entities/urn:E2
+echo
+echo
+
+
+--REGEXPECT--
+01. Create an entity urn:E1 with a Relationship R1, in CB
+=========================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:E1
+
+
+
+02. Create an entity urn:E2 with a Relationship R2, in CP1
+==========================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:E2
+
+
+
+03. PATCH urn:E1, deleting R1 of urn:E1, in CB
+==============================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+04. GET urn:E1, from CB, see that the R1 relationship is no longer there
+========================================================================
+HTTP/1.1 200 OK
+Content-Length: 61
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+{
+    "P1": {
+        "type": "Property",
+        "value": 1
+    },
+    "id": "urn:E1",
+    "type": "T"
+}
+
+
+05. Create a registration in CB, pointing to CP1
+================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/csourceRegistrations/urn:R1
+
+
+
+06. PATCH urn:E2, deleting R2 of urn:E1, in CB, to be forwarded to CP1
+======================================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+07. GET urn:E2, from CB, see that the R2 relationship is no longer there
+========================================================================
+HTTP/1.1 200 OK
+Content-Length: 61
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+{
+    "P2": {
+        "type": "Property",
+        "value": 2
+    },
+    "id": "urn:E2",
+    "type": "T"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+accumulatorStop
+dbDrop CB


### PR DESCRIPTION
Bug fix: JSON NULL literal is no longer forwarded
They're converted to the string "urn:ngsi-ld:null" before forwarding.

(Internally the broker does the opposite conversion, for easier handling of deletion in PATCH Entity).
