### PR TITLE
Creation of entities via REST are now published on DDS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,10 @@ SET (COMMON_STATIC_LIBS
 )
 
 SET (DYNAMIC_LIBS
+    fastrtps
+    fastcdr
+    foonathan_memory-0.7.3
+    tinyxml2
     prom
     promhttp
     curl

--- a/src/app/orionld/CMakeLists.txt
+++ b/src/app/orionld/CMakeLists.txt
@@ -33,6 +33,7 @@ SET (STATIC_LIBS
     ${ORION_LIBS}
     ${COMMON_STATIC_LIBS}
     kjson.a
+    ktrace.a
 )
 
 # Include directories

--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -614,6 +614,7 @@ extern PernotSubCache    pernotSubCache;
 extern EntityMap*        entityMaps;               // Used by GET /entities in the distributed case, for pagination
 extern bool              entityMapsEnabled;
 extern bool              noArrayReduction;         // Used by arrayReduce in pCheckAttribute.cpp
+extern bool              ddsSupport;               // Publish/Subscriba via DDS
 
 extern char                localIpAndPort[135];    // Local address for X-Forwarded-For (from orionld.cpp)
 extern unsigned long long  inReqPayloadMaxSize;

--- a/src/lib/orionld/dds/ddsPublish.cpp
+++ b/src/lib/orionld/dds/ddsPublish.cpp
@@ -37,7 +37,7 @@ extern "C"
 
 // -----------------------------------------------------------------------------
 //
-// namespacea ... (to be removed!)
+// namespaces ... (to be removed!)
 //
 using namespace eprosima::fastdds::dds;
 

--- a/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostEntities.cpp
@@ -27,6 +27,7 @@
 
 extern "C"
 {
+#include "ktrace/kTrace.h"                                       // KT_*
 #include "kalloc/kaAlloc.h"                                      // kaAlloc
 #include "kjson/KjNode.h"                                        // KjNode
 #include "kjson/kjBuilder.h"                                     // kjString, kjObject, ...
@@ -60,6 +61,7 @@ extern "C"
 #include "orionld/distOp/distOpResponses.h"                      // distOpResponses
 #include "orionld/kjTree/kjChildCount.h"                         // kjChildCount
 #include "orionld/kjTree/kjSort.h"                               // kjStringArraySort
+#include "orionld/dds/ddsPublish.h"                              // ddsPublish
 #include "orionld/serviceRoutines/orionldPostEntities.h"         // Own interface
 
 
@@ -254,6 +256,12 @@ bool orionldPostEntities(void)
   // Must add the sysAttrs to the "Final API Entity" as subscriptions may have "notification::sysAttrs" set to true ...
   //
   sysAttrsToEntity(orionldState.alterations->finalApiEntityWithSysAttrsP);
+
+  if (ddsSupport)
+  {
+    KT_V(("Publishing an entity on DDS"));
+    ddsPublish("NGSI-LD", "NGSI-LD", orionldState.alterations->finalApiEntityP);
+  }
 
   if (cloneForTroeP != NULL)
     orionldState.requestTree = cloneForTroeP;

--- a/test/functionalTest/cases/0000_cli/bool_option_with_value.test
+++ b/test/functionalTest/cases/0000_cli/bool_option_with_value.test
@@ -114,5 +114,6 @@ Usage: orionld  [option '-U' (extended usage)]
                 [option '-cSubCounters' <number of subscription counter updates before flush from sub-cache to DB (0: never, 1: always)>]
                 [option '-distributed' (turn on distributed operation)]
                 [option '-brokerId' <identity of this broker instance for registrations - for the Via header>]
+                [option '-dds' (turn on DDS support)]
 
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_cli/command_line_options.test
+++ b/test/functionalTest/cases/0000_cli/command_line_options.test
@@ -103,5 +103,6 @@ Usage: orionld  [option '-U' (extended usage)]
                 [option '-cSubCounters' <number of subscription counter updates before flush from sub-cache to DB (0: never, 1: always)>]
                 [option '-distributed' (turn on distributed operation)]
                 [option '-brokerId' <identity of this broker instance for registrations - for the Via header>]
+                [option '-dds' (turn on DDS support)]
 
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_dds/dds_0.test
+++ b/test/functionalTest/cases/0000_dds/dds_0.test
@@ -110,14 +110,14 @@ Location: /ngsi-ld/v1/entities/urn:ngsi-ld:E01
 03. Ask ftClient what it has received
 =====================================
 HTTP/1.1 200 OK
-Content-Length: 670
+Content-Length: REGEX(.*)
 Date: REGEX(.*)
 
 POST /notify?subscriptionId=urn:S1
 Content-Length: 238
 Content-Type: application/json
 User-Agent: orionld/post-v1.5.1
-Host: 127.0.0.1:7701
+Host: REGEX(.*)
 Accept: application/json
 Ngsild-Attribute-Format: Normalized
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)

--- a/test/functionalTest/cases/0000_dds/dds_1.test
+++ b/test/functionalTest/cases/0000_dds/dds_1.test
@@ -21,11 +21,10 @@
 # VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
 
 --NAME--
-Test of orionld version service, with branch name
+Two DDS test clients, one publishes, the other receives notifications
 
 --SHELL-INIT--
 dbInit CB
-#orionldStart CB -mongocOnly
 ftClientStart -v -t 0-5000
 ftClientStart -v -t 0-5000 --port $FT2_PORT --logDir $FT2_LOG_DIR
 
@@ -165,7 +164,5 @@ Date: REGEX(.*)
 
 
 --TEARDOWN--
-#brokerStop CB
 ftClientStop
 ftClientStop --port $FT2_PORT
-#dbDrop CB

--- a/test/functionalTest/cases/0000_dds/dds_broker_publishes_ftClient_receives.test
+++ b/test/functionalTest/cases/0000_dds/dds_broker_publishes_ftClient_receives.test
@@ -1,0 +1,136 @@
+# Copyright 2024 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Orion-LD + a DDS test client, the broker publishes, the test client receives notifications
+
+--SHELL-INIT--
+dbInit CB
+orionldStart CB -mongocOnly -dds
+ftClientStart -v -t 0-5000
+
+--SHELL--
+
+#
+# 01. Ask FT1 to create a DDS subscription on topic 'NGSI-LD'
+# 02. Create an entity in Orion-LD, which then publishes it on DDS, for FT1 to receive
+# 03. Ask FT1 what it has received
+# 04. Reset the DDS notification accumulation
+#
+
+echo "01. Ask FT1 to create a DDS subscription on topic 'NGSI-LD'"
+echo "==========================================================="
+payload='{
+  "id": "urn:s1",
+  "type": "Subscription"
+}'
+orionCurl --url '/dds/sub?ddsTopicType=NGSI-LD&ddsTopicName=NGSI-LD' --port $FT_PORT --payload "$payload"
+echo
+echo
+
+
+echo "02. Create an entity in Orion-LD, which then publishes it on DDS, for FT1 to receive"
+echo "===================================================================================="
+payload='{
+  "id": "urn:e1",
+  "type": "x",
+  "p1": 1,
+  "p2": 1,
+  "p3": 1
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "03. Ask FT1 what it has received"
+echo "================================"
+orionCurl --url /dds/dump --port $FT_PORT --noPayloadCheck
+echo
+echo
+
+
+echo "04. Reset the DDS notification accumulation"
+echo "==========================================="
+orionCurl --url /dds/dump --port $FT_PORT -X DELETE
+echo
+echo
+
+
+--REGEXPECT--
+01. Ask FT1 to create a DDS subscription on topic 'NGSI-LD'
+===========================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+
+
+
+02. Create an entity in Orion-LD, which then publishes it on DDS, for FT1 to receive
+====================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:e1
+
+
+
+03. Ask FT1 what it has received
+================================
+HTTP/1.1 200 OK
+Content-Length: 414
+Date: REGEX(.*)
+
+[
+  {
+    "id": "urn:e1",
+    "type": "https://uri.etsi.org/ngsi-ld/default-context/x",
+    "https://uri.etsi.org/ngsi-ld/default-context/p1": {
+      "type": "Property",
+      "value": 1
+    },
+    "https://uri.etsi.org/ngsi-ld/default-context/p2": {
+      "type": "Property",
+      "value": 1
+    },
+    "https://uri.etsi.org/ngsi-ld/default-context/p3": {
+      "type": "Property",
+      "value": 1
+    }
+  }
+]
+
+
+
+04. Reset the DDS notification accumulation
+===========================================
+HTTP/1.1 200 OK
+Content-Length: 0
+Date: REGEX(.*)
+
+
+
+--TEARDOWN--
+brokerStop CB
+ftClientStop
+ftClientStop --port $FT2_PORT
+dbDrop CB

--- a/test/functionalTest/ftClient/mhdRequestInit.cpp
+++ b/test/functionalTest/ftClient/mhdRequestInit.cpp
@@ -52,9 +52,6 @@ static MHD_Result headerReceive(void* cbDataP, MHD_ValueKind kind, const char* k
 {
   KT_V("Got an HTTP Header: '%s': '%s'", key, value);
 
-  if (httpHeaders == NULL)
-    httpHeaders = kjObject(NULL, "headers");
-
   KjNode* headerP = kjString(NULL, key, value);
   kjChildAdd(httpHeaders, headerP);
 
@@ -92,6 +89,8 @@ MHD_Result mhdRequestInit(MHD_Connection* connection, const char* url, const cha
   orionldState.verbString = (char*) method;
   orionldState.verb       = verbGet(method);
   orionldState.urlPath    = (char*) url;
+
+  httpHeaders = kjObject(NULL, "headers");
 
   MHD_get_connection_values(connection, MHD_HEADER_KIND,       headerReceive,   NULL);
   MHD_get_connection_values(connection, MHD_GET_ARGUMENT_KIND, uriParamReceive, NULL);

--- a/test/unittests/main_UnitTest.cpp
+++ b/test/unittests/main_UnitTest.cpp
@@ -112,6 +112,7 @@ unsigned long long  inReqPayloadMaxSize;
 unsigned long long  outReqMsgMaxSize;
 bool                triggerOperation = false;
 bool                noArrayReduction = false;
+bool                ddsSupport       = false;
 
 
 


### PR DESCRIPTION
Orion-LD now supports publishing of entities over DDS.
For now only the operation of Entity Creation, more to come,
The CLI option '-dds' needs to be used for this to be activated.
