### PR TITLE
Support for new CLI parameter '-pageSize'

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -8,6 +8,7 @@
     - One more URL parameter '?reverse=true' to reverse the sorting order
   * Support for GET /ngsi-ld/v1/info/sourceIdentity
   * Support for management::localOnly in registrations
+  * Support for new CLI parameter '-pageSize' to set the default pagination limit (default is 20 if -pageSize is not used)
 
 ## Notes
   * Lots of improvements for subordinate subscriptions - still not 100% ready, but a lot better.

--- a/src/app/orionld/orionld.cpp
+++ b/src/app/orionld/orionld.cpp
@@ -247,6 +247,7 @@ bool            triggerOperation = false;
 bool            noprom           = false;
 bool            noArrayReduction = false;
 char            subordinateEndpoint[256];
+int             pageSize         = 20;
 
 
 
@@ -342,6 +343,7 @@ char            subordinateEndpoint[256];
 #define NO_PROM_DESC           "run without Prometheus metrics"
 #define NO_ARR_REDUCT_DESC     "skip JSON-LD Array Reduction"
 #define SUBORDINATE_ENDPOINT_DESC  "endpoint URL for reception of notificatiopns from subordinate subscriptions (distributed subscriptions)"
+#define PAGE_SIZE_DESC         "default page size (no of entities, subscriptions, registrations)"
 
 
 
@@ -448,6 +450,7 @@ PaArgument paArgs[] =
   { "-noprom",                &noprom,                  "NO_PROM",                   PaBool,    PaHid,  false,           false,  true,             NO_PROM_DESC             },
   { "-noArrayReduction",      &noArrayReduction,        "NO_ARRAY_REDUCTION",        PaBool,    PaHid,  false,           false,  true,             NO_ARR_REDUCT_DESC       },
   { "-subordinateEndpoint",   &subordinateEndpoint,     "SUBORDINATE_ENDPOINT",      PaStr,     PaOpt,  _i "",           PaNL,   PaNL,             SUBORDINATE_ENDPOINT_DESC },
+  { "-pageSize",              &pageSize,                "PAGE_SIZE",                 PaInt,     PaOpt,  20,              1,      1000,             PAGE_SIZE_DESC            },
 
   PA_END_OF_ARGS
 };

--- a/src/lib/orionld/common/orionldState.cpp
+++ b/src/lib/orionld/common/orionldState.cpp
@@ -172,7 +172,7 @@ void orionldStateInit(MHD_Connection* connection)
 
   // Pagination
   orionldState.uriParams.offset        = 0;
-  orionldState.uriParams.limit         = 20;
+  orionldState.uriParams.limit         = pageSize;
 
   // orionldState.delayedKjFreeVecSize    = sizeof(orionldState.delayedKjFreeVec) / sizeof(orionldState.delayedKjFreeVec[0]);
 

--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -618,6 +618,7 @@ extern EntityMap*        entityMaps;               // Used by GET /entities in t
 extern bool              entityMapsEnabled;        // Enable Entity Maps
 extern bool              distSubsEnabled;          // Enable distributed subscriptions
 extern bool              noArrayReduction;         // Used by arrayReduce in pCheckAttribute.cpp
+extern int               pageSize;                 // Pagination limit
 
 extern char                localIpAndPort[135];    // Local address for X-Forwarded-For (from orionld.cpp)
 extern unsigned long long  inReqPayloadMaxSize;

--- a/test/functionalTest/cases/0000_cli/bool_option_with_value.test
+++ b/test/functionalTest/cases/0000_cli/bool_option_with_value.test
@@ -115,5 +115,6 @@ Usage: orionld  [option '-U' (extended usage)]
                 [option '-distributed' (turn on distributed operation)]
                 [option '-brokerId' <identity of this broker instance for registrations - for the Via header>]
                 [option '-subordinateEndpoint' <endpoint URL for reception of notificatiopns from subordinate subscriptions (distributed subscriptions)>]
+                [option '-pageSize' <default page size (no of entities, subscriptions, registrations)>]
 
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_cli/command_line_options.test
+++ b/test/functionalTest/cases/0000_cli/command_line_options.test
@@ -104,5 +104,6 @@ Usage: orionld  [option '-U' (extended usage)]
                 [option '-distributed' (turn on distributed operation)]
                 [option '-brokerId' <identity of this broker instance for registrations - for the Via header>]
                 [option '-subordinateEndpoint' <endpoint URL for reception of notificatiopns from subordinate subscriptions (distributed subscriptions)>]
+                [option '-pageSize' <default page size (no of entities, subscriptions, registrations)>]
 
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_ngsild/ngsild_pagination_limit.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_pagination_limit.test
@@ -1,0 +1,93 @@
+# Copyright 2024 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Default pagination limit (page size)
+
+--SHELL-INIT--
+dbInit CB
+orionldStart CB -experimental -pageSize 8
+
+typeset -i eNo
+eNo=1
+
+while [ $eNo -le 10 ]
+do
+  eId=$(printf "urn:ngsi-ld:entities:E%02d" $eNo)
+  
+  payload='{
+    "id": "'$eId'",
+    "type": "T",
+    "A1": {
+      "type": "Property",
+      "value": "E'$eNo':A1"
+    }
+  }'
+  orionCurl --url /ngsi-ld/v1/entities --payload "$payload" | grep 'Location:'
+  eNo=$eNo+1
+done
+
+--SHELL--
+
+#
+# 01. Query entities - get 8 as pageSize is set to 8 on orion-ld startup
+# 02. Query entities with limit URL param set to 4 - see 4 entities
+#
+
+echo "01. Query entities - get 8 as pageSize is set to 8 on orion-ld startup"
+echo "======================================================================"
+orionCurl --url /ngsi-ld/v1/entities?type=T | grep '"id"'
+echo
+echo
+
+
+echo "02. Query entities with limit URL param set to 4 - see 4 entities"
+echo "================================================================="
+orionCurl --url '/ngsi-ld/v1/entities?type=T&limit=4' | grep '"id"'
+echo
+echo
+
+
+--REGEXPECT--
+01. Query entities - get 8 as pageSize is set to 8 on orion-ld startup
+======================================================================
+        "id": "urn:ngsi-ld:entities:E01",
+        "id": "urn:ngsi-ld:entities:E02",
+        "id": "urn:ngsi-ld:entities:E03",
+        "id": "urn:ngsi-ld:entities:E04",
+        "id": "urn:ngsi-ld:entities:E05",
+        "id": "urn:ngsi-ld:entities:E06",
+        "id": "urn:ngsi-ld:entities:E07",
+        "id": "urn:ngsi-ld:entities:E08",
+
+
+02. Query entities with limit URL param set to 4 - see 4 entities
+=================================================================
+        "id": "urn:ngsi-ld:entities:E01",
+        "id": "urn:ngsi-ld:entities:E02",
+        "id": "urn:ngsi-ld:entities:E03",
+        "id": "urn:ngsi-ld:entities:E04",
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/unittests/main_UnitTest.cpp
+++ b/test/unittests/main_UnitTest.cpp
@@ -113,6 +113,7 @@ unsigned long long  outReqMsgMaxSize;
 bool                triggerOperation = false;
 bool                noArrayReduction = false;
 char                subordinateEndpoint[256];
+int                 pageSize         = 20;
 
 
 


### PR DESCRIPTION
Support for new CLI parameter '-pageSize' to set the default pagination limit (default is 20 if -pageSize is not used)
