### PR TITLE
Fixed a bug in the subscription cache

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,6 +1,7 @@
 ## Fixed Issues:
   #1698: Not fixed, but making it usable. Real fix coming. Needs a complete rewrite.
-  #1704: problem when the number of tenants is bigger than the size of the mongo connection pool
+  #1704: Problem when the number of tenants is bigger than the size of the mongo connection pool
+  #1715: Bug in subscription cache: attributes in notification::attributes were not longnames after a restart with subscriptions in the DB
   #XXXX: various fixes for DDS
 
 ## New Features:

--- a/src/lib/orionld/dbModel/dbModelToApiSubscription.cpp
+++ b/src/lib/orionld/dbModel/dbModelToApiSubscription.cpp
@@ -462,9 +462,12 @@ KjNode* dbModelToApiSubscription
       kjChildAdd(notificationP, dbAttrsP);
 
       // Find alias for all attributes
-      for (KjNode* attrNameNodeP = dbAttrsP->value.firstChildP; attrNameNodeP != NULL; attrNameNodeP = attrNameNodeP->next)
+      if (forSubCache == false)
       {
-        attrNameNodeP->value.s = orionldContextItemAliasLookup(orionldState.contextP, attrNameNodeP->value.s, NULL, NULL);
+        for (KjNode* attrNameNodeP = dbAttrsP->value.firstChildP; attrNameNodeP != NULL; attrNameNodeP = attrNameNodeP->next)
+        {
+          attrNameNodeP->value.s = orionldContextItemAliasLookup(orionldState.contextP, attrNameNodeP->value.s, NULL, NULL);
+        }
       }
     }
   }

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_1715_notifications-and-troe.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_1715_notifications-and-troe.test
@@ -1,0 +1,691 @@
+# Copyright 2024 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Error in notifications when TRoE is enabled
+
+--SHELL-INIT--
+dbInit CB
+pgInit $CB_DB_NAME
+orionldStart CB -mongocOnly -troe -brokerId Domain-NCSRD -wip entityMaps,distSubs -forwarding -noArrayReduction -socketService -ssPort 1027
+accumulatorStart --pretty-print
+
+--SHELL--
+
+#
+# 01. Create a subscription for the accumulator
+# 02. Create a few registrations not matching the entity created/patched in steps 3, 5, ...
+# 03. Create an entity matching the subscription
+# 04. Dump+Reset the accumulator to see the notification
+# 05. PATCH the attribute distanceCollision, to provoke a notification
+# 06. Dump the accumulator to see the notification
+
+# 07. Restart the broker without troe
+# 08. PATCH the attribute distanceCollision, to provoke a notification
+# 09. Dump the accumulator to see the notification
+
+# 10. Restart the broker with troe
+# 11. PATCH the attribute distanceCollision, to provoke a notification
+# 12. Dump the accumulator to see the notification
+
+# 20. See the entities in the temporal database
+# 21. See the attributes in the temporal database
+# 22. See the sub-attributes in the temporal database
+#
+
+echo "01. Create a subscription for the accumulator"
+echo "============================================="
+payload='{
+  "id": "urn:aeros:subscription:car:test",
+  "type": "Subscription",
+  "description": "Subscription to Vehicle entity type for the demo",
+  "entities": [
+    {
+      "id": "urn:ngsi-ld:vehicle:5g-car:2",
+       "type": "Vehicle"
+    }
+  ],
+  "watchedAttributes": [
+    "distanceCollision"
+  ],
+  "notification": {
+    "attributes": [ "distanceCollision" ],
+    "endpoint": {
+      "uri": "http://127.0.0.1:'${LISTENER_PORT}'/notify",
+      "accept": "application/json"
+    }
+  }
+}'
+orionCurl --url /ngsi-ld/v1/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo "02a. Create an irrelevant registration"
+echo "======================================"
+payload='{
+  "id": "urn:aeros:federation:b:infrastructure",
+  "type": "ContextSourceRegistration",
+  "information": [
+    {
+      "entities": [
+        {
+          "type": "Domain"
+        },
+        {
+          "type": "LowLevelOrchestrator"
+        },
+        {
+          "type": "InfrastructureElement"
+        }
+      ]
+    }
+  ],
+  "contextSourceInfo": [
+    {
+      "key": "Authorization",
+      "value": "urn:ngsi-ld:request"
+    }
+  ],
+  "mode": "inclusive",
+  "hostAlias": "DomainB",
+  "operations": [
+    "retrieveOps"
+  ],
+  "management": {
+    "localOnly": true
+  },
+  "endpoint": "http://192.168.1.101:1026",
+  "aerosDomain": "DomainB",
+  "aerosDomainFederation": true
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload"
+echo
+echo
+
+
+echo "02b. Create an irrelevant registration"
+echo "======================================"
+payload='{
+  "id": "urn:aeros:federation:b:infrastructure2",
+  "type": "ContextSourceRegistration",
+  "information": [
+    {
+      "entities": [
+        {
+          "type": "Domain"
+        },
+        {
+          "type": "LowLevelOrchestrator"
+        },
+        {
+          "type": "InfrastructureElement"
+        }
+      ]
+    }
+  ],
+  "contextSourceInfo": [
+    {
+      "key": "Authorization",
+      "value": "urn:ngsi-ld:request"
+    }
+  ],
+  "mode": "inclusive",
+  "hostAlias": "DomainB",
+  "operations": [
+    "retrieveOps"
+  ],
+  "management": {
+    "localOnly": true
+  },
+  "endpoint": "http://192.168.1.101:1026",
+  "aerosDomain": "DomainB",
+  "aerosDomainFederation": true
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload"
+echo
+echo
+
+
+echo "02c. Create an irrelevant registration"
+echo "======================================"
+payload='{
+  "id": "urn:aeros:federation:b:infrastructure3",
+  "type": "ContextSourceRegistration",
+  "information": [
+    {
+      "entities": [
+        {
+          "type": "Domain"
+        },
+        {
+          "type": "LowLevelOrchestrator"
+        },
+        {
+          "type": "InfrastructureElement"
+        }
+      ]
+    }
+  ],
+  "contextSourceInfo": [
+    {
+      "key": "Authorization",
+      "value": "urn:ngsi-ld:request"
+    }
+  ],
+  "mode": "inclusive",
+  "hostAlias": "DomainB",
+  "operations": [
+    "retrieveOps"
+  ],
+  "management": {
+    "localOnly": true
+  },
+  "endpoint": "http://192.168.1.101:1026",
+  "aerosDomain": "DomainB",
+  "aerosDomainFederation": true
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload"
+echo
+echo
+
+
+echo "02d. Create an irrelevant registration"
+echo "======================================"
+payload='{
+  "id": "urn:aeros:federation:b:infrastructure4",
+  "type": "ContextSourceRegistration",
+  "information": [
+    {
+      "entities": [
+        {
+          "type": "Domain"
+        },
+        {
+          "type": "LowLevelOrchestrator"
+        },
+        {
+          "type": "InfrastructureElement"
+        }
+      ]
+    }
+  ],
+  "contextSourceInfo": [
+    {
+      "key": "Authorization",
+      "value": "urn:ngsi-ld:request"
+    }
+  ],
+  "mode": "inclusive",
+  "hostAlias": "DomainB",
+  "operations": [
+    "retrieveOps"
+  ],
+  "management": {
+    "localOnly": true
+  },
+  "endpoint": "http://192.168.1.101:1026",
+  "aerosDomain": "DomainB",
+  "aerosDomainFederation": true
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload"
+echo
+echo
+
+
+echo "03. Create an entity matching the subscription"
+echo "=============================================="
+payload='{
+    "id": "urn:ngsi-ld:vehicle:5g-car:2",
+    "type": "Vehicle",
+    "category": {
+        "type": "Property",
+        "value": [
+            "specialUsage",
+            "Tracked"
+        ]
+    },
+    "vehicleType": {
+        "type": "Property",
+        "value": "car"
+    },
+    "name": {
+        "type": "Property",
+        "value": "pi"
+    },
+    "vehiclePlateIdentifier": {
+        "type": "Property",
+        "value": "ncsrd"
+    },
+    "location": {
+        "type": "GeoProperty",
+        "value": {
+            "type": "Point",
+            "coordinates": [
+                94.0913,
+                38.1031
+            ]
+        }
+    },
+    "move": {
+        "type": "Property",
+        "value": true
+    },
+    "direction": {
+        "type": "Property",
+        "value": 40
+    },
+    "heading": {
+        "type": "Property",
+        "value": "188 degrees"
+    },
+    "owner": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:Organization:NCSRD"
+    },
+    "areaServed": {
+        "type": "Property",
+        "value": "NCSRD-IIT"
+    },
+    "serviceStatus": {
+        "type": "Property",
+        "value": "parked"
+    },
+    "distanceCollision": {
+        "type": "Property",
+        "value": 543333
+    },
+    "signalQuality": {
+        "type": "Property",
+        "value": "0"
+    },
+    "cargoWeight": {
+        "type": "Property",
+        "value": 0.5
+    },
+    "speed": {
+        "type": "Property",
+        "value": 89
+    }
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+
+echo "04. Dump+Reset the accumulator to see the notification"
+echo "======================================================"
+accumulatorDump
+accumulatorReset
+echo
+echo
+
+
+echo "05. PATCH the attribute distanceCollision, to provoke a notification"
+echo "===================================================================="
+payload='{
+  "distanceCollision": {
+    "type": "Property",
+    "value": 525
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:vehicle:5g-car:2 --payload "$payload" -X PATCH
+echo
+echo
+
+
+echo "06. Dump the accumulator to see the notification"
+echo "================================================"
+accumulatorDump
+accumulatorReset
+echo
+echo
+
+
+echo "07. Restart the broker without troe"
+echo "==================================="
+cp /tmp/orionld.log /tmp/orionld.log1
+brokerStop CB
+orionldStart CB -mongocOnly -brokerId Domain-NCSRD -wip entityMaps,distSubs -forwarding -noArrayReduction -socketService -ssPort 1027
+echo Broker up and running again
+echo
+echo
+
+
+echo "08. PATCH the attribute distanceCollision, to provoke a notification"
+echo "===================================================================="
+payload='{
+  "distanceCollision": {
+    "type": "Property",
+    "value": "Step 08"
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:vehicle:5g-car:2 --payload "$payload" -X PATCH
+echo
+echo
+
+
+echo "09. Dump the accumulator to see the notification"
+echo "================================================"
+accumulatorDump
+accumulatorReset
+echo
+echo
+
+
+echo "10. Restart the broker with troe"
+echo "================================"
+cp /tmp/orionld.log /tmp/orionld.log2
+brokerStop CB
+orionldStart CB -troe -mongocOnly -brokerId Domain-NCSRD -wip entityMaps,distSubs -forwarding -noArrayReduction -socketService -ssPort 1027
+echo Broker up and running again
+echo
+echo
+
+
+echo "11. PATCH the attribute distanceCollision, to provoke a notification"
+echo "===================================================================="
+payload='{
+  "distanceCollision": {
+    "type": "Property",
+    "value": "Step 11"
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:vehicle:5g-car:2 --payload "$payload" -X PATCH
+echo
+echo
+
+
+echo "12. Dump the accumulator to see the notification"
+echo "================================================"
+accumulatorDump
+accumulatorReset
+echo
+echo
+
+
+echo "20. See the entities in the temporal database"
+echo "============================================="
+postgresCmd -sql "SELECT opMode,id,type FROM entities"
+echo
+echo
+
+
+echo "21. See the attributes in the temporal database"
+echo "==============================================="
+postgresCmd -sql "SELECT opMode,id,valueType,entityId,subProperties,unitcode,datasetid,text,number,boolean,compound,observedAt FROM attributes"
+echo
+echo
+
+
+echo "22. See the sub-attributes in the temporal database"
+echo "==================================================="
+postgresCmd -sql "SELECT id,valueType,entityId,attrInstanceId,unitcode,text,number,boolean,compound,observedAt FROM subAttributes"
+echo
+echo
+
+
+cp /tmp/orionld.log /tmp/orionld.log3
+
+--REGEXPECT--
+01. Create a subscription for the accumulator
+=============================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/subscriptions/urn:aeros:subscription:car:test
+
+
+
+02a. Create an irrelevant registration
+======================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/csourceRegistrations/urn:aeros:federation:b:infrastructure
+
+
+
+02b. Create an irrelevant registration
+======================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/csourceRegistrations/urn:aeros:federation:b:infrastructure2
+
+
+
+02c. Create an irrelevant registration
+======================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/csourceRegistrations/urn:aeros:federation:b:infrastructure3
+
+
+
+02d. Create an irrelevant registration
+======================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/csourceRegistrations/urn:aeros:federation:b:infrastructure4
+
+
+
+03. Create an entity matching the subscription
+==============================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:vehicle:5g-car:2
+
+
+
+04. Dump+Reset the accumulator to see the notification
+======================================================
+POST http://REGEX(.*)/notify?subscriptionId=urn:aeros:subscription:car:test
+Content-Length: 302
+User-Agent: orionld/REGEX(.*)
+Host: REGEX(.*)
+Accept: application/json
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)"
+Ngsild-Attribute-Format: Normalized
+
+{
+    "data": [
+        {
+            "distanceCollision": {
+                "type": "Property",
+                "value": 543333
+            },
+            "id": "urn:ngsi-ld:vehicle:5g-car:2",
+            "type": "Vehicle"
+        }
+    ],
+    "id": "urn:ngsi-ld:Notification:REGEX(.*)",
+    "notifiedAt": "202REGEX(.*)Z",
+    "subscriptionId": "urn:aeros:subscription:car:test",
+    "type": "Notification"
+}
+=======================================
+
+
+05. PATCH the attribute distanceCollision, to provoke a notification
+====================================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+06. Dump the accumulator to see the notification
+================================================
+POST http://REGEX(.*)/notify?subscriptionId=urn:aeros:subscription:car:test
+Content-Length: 299
+User-Agent: orionld/REGEX(.*)
+Host: REGEX(.*)
+Accept: application/json
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+Ngsild-Attribute-Format: Normalized
+
+{
+    "data": [
+        {
+            "distanceCollision": {
+                "type": "Property",
+                "value": 525
+            },
+            "id": "urn:ngsi-ld:vehicle:5g-car:2",
+            "type": "Vehicle"
+        }
+    ],
+    "id": "urn:ngsi-ld:Notification:REGEX(.*)",
+    "notifiedAt": "202REGEX(.*)Z",
+    "subscriptionId": "urn:aeros:subscription:car:test",
+    "type": "Notification"
+}
+=======================================
+
+
+07. Restart the broker without troe
+===================================
+Broker up and running again
+
+
+08. PATCH the attribute distanceCollision, to provoke a notification
+====================================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+09. Dump the accumulator to see the notification
+================================================
+POST http://REGEX(.*)/notify?subscriptionId=urn:aeros:subscription:car:test
+Content-Length: 305
+User-Agent: orionld/REGEX(.*)
+Host: REGEX(.*)
+Accept: application/json
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+Ngsild-Attribute-Format: Normalized
+
+{
+    "data": [
+        {
+            "distanceCollision": {
+                "type": "Property",
+                "value": "Step 08"
+            },
+            "id": "urn:ngsi-ld:vehicle:5g-car:2",
+            "type": "Vehicle"
+        }
+    ],
+    "id": "urn:ngsi-ld:Notification:REGEX(.*)",
+    "notifiedAt": "202REGEX(.*)Z",
+    "subscriptionId": "urn:aeros:subscription:car:test",
+    "type": "Notification"
+}
+=======================================
+
+
+10. Restart the broker with troe
+================================
+Broker up and running again
+
+
+11. PATCH the attribute distanceCollision, to provoke a notification
+====================================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+12. Dump the accumulator to see the notification
+================================================
+POST http://REGEX(.*)/notify?subscriptionId=urn:aeros:subscription:car:test
+Content-Length: 305
+User-Agent: orionld/REGEX(.*)
+Host: REGEX(.*)
+Accept: application/json
+Content-Type: application/json
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+Ngsild-Attribute-Format: Normalized
+
+{
+    "data": [
+        {
+            "distanceCollision": {
+                "type": "Property",
+                "value": "Step 11"
+            },
+            "id": "urn:ngsi-ld:vehicle:5g-car:2",
+            "type": "Vehicle"
+        }
+    ],
+    "id": "urn:ngsi-ld:Notification:REGEX(.*)",
+    "notifiedAt": "202REGEX(.*)Z",
+    "subscriptionId": "urn:aeros:subscription:car:test",
+    "type": "Notification"
+}
+=======================================
+
+
+20. See the entities in the temporal database
+=============================================
+opmode,id,type
+Create,urn:ngsi-ld:vehicle:5g-car:2,https://uri.etsi.org/ngsi-ld/default-context/Vehicle
+
+
+21. See the attributes in the temporal database
+===============================================
+opmode,id,valuetype,entityid,subproperties,unitcode,datasetid,text,number,boolean,compound,observedat
+Create,https://uri.etsi.org/ngsi-ld/default-context/category,Compound,urn:ngsi-ld:vehicle:5g-car:2,f,,None,,,,"[""specialUsage"", ""Tracked""]",
+Create,https://uri.etsi.org/ngsi-ld/default-context/vehicleType,String,urn:ngsi-ld:vehicle:5g-car:2,f,,None,car,,,,
+Create,https://uri.etsi.org/ngsi-ld/default-context/name,String,urn:ngsi-ld:vehicle:5g-car:2,f,,None,pi,,,,
+Create,https://uri.etsi.org/ngsi-ld/default-context/vehiclePlateIdentifier,String,urn:ngsi-ld:vehicle:5g-car:2,f,,None,ncsrd,,,,
+Create,location,GeoPoint,urn:ngsi-ld:vehicle:5g-car:2,f,,None,,,,,
+Create,https://uri.etsi.org/ngsi-ld/default-context/move,Boolean,urn:ngsi-ld:vehicle:5g-car:2,f,,None,,,t,,
+Create,https://uri.etsi.org/ngsi-ld/default-context/direction,Number,urn:ngsi-ld:vehicle:5g-car:2,f,,None,,40,,,
+Create,https://uri.etsi.org/ngsi-ld/default-context/heading,String,urn:ngsi-ld:vehicle:5g-car:2,f,,None,188 degrees,,,,
+Create,https://uri.etsi.org/ngsi-ld/default-context/owner,Relationship,urn:ngsi-ld:vehicle:5g-car:2,f,,None,urn:ngsi-ld:Organization:NCSRD,,,,
+Create,https://uri.etsi.org/ngsi-ld/default-context/areaServed,String,urn:ngsi-ld:vehicle:5g-car:2,f,,None,NCSRD-IIT,,,,
+Create,https://uri.etsi.org/ngsi-ld/default-context/serviceStatus,String,urn:ngsi-ld:vehicle:5g-car:2,f,,None,parked,,,,
+Create,https://uri.etsi.org/ngsi-ld/default-context/distanceCollision,Number,urn:ngsi-ld:vehicle:5g-car:2,f,,None,,543333,,,
+Create,https://uri.etsi.org/ngsi-ld/default-context/signalQuality,String,urn:ngsi-ld:vehicle:5g-car:2,f,,None,0,,,,
+Create,https://uri.etsi.org/ngsi-ld/default-context/cargoWeight,Number,urn:ngsi-ld:vehicle:5g-car:2,f,,None,,0.5,,,
+Create,https://uri.etsi.org/ngsi-ld/default-context/speed,Number,urn:ngsi-ld:vehicle:5g-car:2,f,,None,,89,,,
+
+
+22. See the sub-attributes in the temporal database
+===================================================
+id,valuetype,entityid,attrinstanceid,unitcode,text,number,boolean,compound,observedat
+
+
+--TEARDOWN--
+brokerStop CB
+#dbDrop CB
+pgInit $CB_DB_NAME
+accumulatorStop

--- a/test/functionalTest/cases/0000_troe/troe_batch_create.test
+++ b/test/functionalTest/cases/0000_troe/troe_batch_create.test
@@ -226,3 +226,4 @@ https://uri.etsi.org/ngsi-ld/default-context/Sub-Float,Number,urn:ngsi-ld:entiti
 --TEARDOWN--
 brokerStop CB
 dbDrop CB
+pgInit $CB_DB_NAME


### PR DESCRIPTION
Partial fix for issue #1715 
The issue also talks about a crash. I've seen no such thing, unfortunately :(

When the broker starts up and there are "old" subscriptions in the database, the subscription cache needs to be populated with those subscriptions.
This issue fixes a bug for the entity projection (the field 'notification::attributes' of a subscription payload).
The attributes were compacted when added to the subscription cache.
This makes zero sense and the bug has been fixed.

Amazing how a bug *this important* has survived for so long ... 

So, when restarting the broker, as the projection attributes were erroneous (wrong names), all notifications are sent without any attributes (that is if projection attributes were part of the subscription).

