### PR TITLE
Issue/1707 type discovery and local

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,5 +1,6 @@
 ## Fixed Issues:
   #XXXX: Complex @contexts of subscriptions weren't persisted in mongodb
+  #1707: Support for local=true in the type discovery endpoints (GET /ngsi-ld/v1/types[/{typeName}]
 
 ## New Features:
   * Support for ...

--- a/src/lib/orionld/db/dbEntityTypesGet.cpp
+++ b/src/lib/orionld/db/dbEntityTypesGet.cpp
@@ -311,7 +311,7 @@ KjNode* typeObjectLookup(KjNode* arrayP, const char* type)
 //
 // dbEntityTypesGet -
 //
-KjNode* dbEntityTypesGet(OrionldProblemDetails* pdP, bool details)
+KjNode* dbEntityTypesGet(OrionldProblemDetails* pdP, bool details, bool localOnly)
 {
   KjNode*  local;
   KjNode*  remote;
@@ -372,11 +372,13 @@ KjNode* dbEntityTypesGet(OrionldProblemDetails* pdP, bool details)
   //
   // GET remote types - i.e. from the "registrations" collection
   //
-  remote = entityTypesFromRegistrationsGet(details);
+  if (localOnly == false)
+  {
+    remote = entityTypesFromRegistrationsGet(details);
 
-  if ((remote != NULL) && (details == true))
-    remote = typesAndAttributesExtractFromRegistrations(remote);
-
+    if ((remote != NULL) && (details == true))
+      remote = typesAndAttributesExtractFromRegistrations(remote);
+  }
 
   //
   // Fix duplicates in 'local'
@@ -490,7 +492,6 @@ KjNode* dbEntityTypesGet(OrionldProblemDetails* pdP, bool details)
       typeP = next;
     }
   }
-
 
   if ((remote == NULL) && (local == NULL))
   {

--- a/src/lib/orionld/db/dbEntityTypesGet.cpp
+++ b/src/lib/orionld/db/dbEntityTypesGet.cpp
@@ -313,9 +313,9 @@ KjNode* typeObjectLookup(KjNode* arrayP, const char* type)
 //
 KjNode* dbEntityTypesGet(OrionldProblemDetails* pdP, bool details, bool localOnly)
 {
-  KjNode*  local;
-  KjNode*  remote;
-  KjNode*  arrayP = NULL;
+  KjNode*  local   = NULL;
+  KjNode*  remote  = NULL;
+  KjNode*  arrayP  = NULL;
 
   //
   // This is a bit ugly ...

--- a/src/lib/orionld/db/dbEntityTypesGet.h
+++ b/src/lib/orionld/db/dbEntityTypesGet.h
@@ -39,6 +39,6 @@ extern "C"
 //
 // dbEntityTypesGet -
 //
-extern KjNode* dbEntityTypesGet(OrionldProblemDetails* pdP, bool details);
+extern KjNode* dbEntityTypesGet(OrionldProblemDetails* pdP, bool details, bool localOnly);
 
 #endif  // SRC_LIB_ORIONLD_DB_DBENTITYTYPESGET_H_

--- a/src/lib/orionld/service/orionldServiceInit.cpp
+++ b/src/lib/orionld/service/orionldServiceInit.cpp
@@ -447,16 +447,22 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
     serviceP->uriParams |= ORIONLD_URIPARAM_LIMIT;
     serviceP->uriParams |= ORIONLD_URIPARAM_OFFSET;
     serviceP->uriParams |= ORIONLD_URIPARAM_DETAILS;
+    serviceP->uriParams |= ORIONLD_URIPARAM_LOCAL;
   }
   else if (serviceP->serviceRoutine == orionldGetEntityType)
   {
+    serviceP->uriParams |= ORIONLD_URIPARAM_LOCAL;
   }
   else if (serviceP->serviceRoutine == orionldGetEntityAttributes)
   {
+    serviceP->uriParams |= ORIONLD_URIPARAM_LIMIT;
+    serviceP->uriParams |= ORIONLD_URIPARAM_OFFSET;
     serviceP->uriParams |= ORIONLD_URIPARAM_DETAILS;
+    serviceP->uriParams |= ORIONLD_URIPARAM_LOCAL;
   }
   else if (serviceP->serviceRoutine == orionldGetEntityAttribute)
   {
+    serviceP->uriParams |= ORIONLD_URIPARAM_LOCAL;
   }
   else if (serviceP->serviceRoutine == orionldPostTemporalEntities)
   {

--- a/src/lib/orionld/serviceRoutines/orionldGetEntityTypes.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntityTypes.cpp
@@ -46,7 +46,7 @@ bool orionldGetEntityTypes(void)
 {
   OrionldProblemDetails  pd;
 
-  orionldState.responseTree = dbEntityTypesGet(&pd, orionldState.uriParams.details);
+  orionldState.responseTree = dbEntityTypesGet(&pd, orionldState.uriParams.details, orionldState.uriParams.local);
   if (orionldState.responseTree == NULL)
   {
     orionldError(OrionldResourceNotFound, pd.title, pd.detail, pd.status);

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_type.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_type.test
@@ -149,7 +149,7 @@ echo
 
 echo "08. GET Entity Type T1 - see T1, count 3, and attrs P1, P2, R1, and R2"
 echo "======================================================================"
-orionCurl --url /ngsi-ld/v1/types/T1
+orionCurl --url /ngsi-ld/v1/types/T1?local=true
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_types-merge-of-entities-and-registrations.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_types-merge-of-entities-and-registrations.test
@@ -36,6 +36,8 @@ orionldStart CB
 # 04. Create registration R2, entity type T1, with attributes P4 and R4
 # 05. GET Types - see T1
 # 06. GET Types with details - see T1 with P1-P4 and R1-R4
+# 07. GET Types with local=true - see T1
+# 08. GET Types with details and local=true - see T1 but attributes only from entities E1+E2
 #
 
 echo "01. Create entity E1, type T1, with attributes P1 and R1"
@@ -137,6 +139,20 @@ echo
 echo
 
 
+echo "07. GET Types with local=true - see T1"
+echo "======================================"
+orionCurl --url /ngsi-ld/v1/types?local=true
+echo
+echo
+
+
+echo "08. GET Types with details and local=true - see T1 but attributes only from entities E1+E2"
+echo "=========================================================================================="
+orionCurl --url '/ngsi-ld/v1/types?details=true&local=true'
+echo
+echo
+
+
 --REGEXPECT--
 01. Create entity E1, type T1, with attributes P1 and R1
 ========================================================
@@ -210,6 +226,46 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
             "R4",
             "P3",
             "R3"
+        ],
+        "id": "https://uri.etsi.org/ngsi-ld/default-context/T1",
+        "type": "EntityType",
+        "typeName": "T1"
+    }
+]
+
+
+07. GET Types with local=true - see T1
+======================================
+HTTP/1.1 200 OK
+Content-Length: 114
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+{
+    "id": "urn:ngsi-ld:EntityTypeList:REGEX(.*)",
+    "type": "EntityTypeList",
+    "typeList": [
+        "T1"
+    ]
+}
+
+
+08. GET Types with details and local=true - see T1 but attributes only from entities E1+E2
+==========================================================================================
+HTTP/1.1 200 OK
+Content-Length: 133
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+[
+    {
+        "attributeNames": [
+            "P2",
+            "R2",
+            "P1",
+            "R1"
         ],
         "id": "https://uri.etsi.org/ngsi-ld/default-context/T1",
         "type": "EntityType",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_types-merge-of-entities.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_types-merge-of-entities.test
@@ -34,10 +34,14 @@ orionldStart CB
 # 02. Create entity E2, type T1, with attributes P2 and R2
 # 03. GET Types - see T1
 # 04. GET Types with details - see T1 with P1, P2, R1, R2
-# 05. Create entity E3, type T2, with attributes P1 and R1
-# 06. Create entity E4, type T2, with attributes P2 and R2
-# 07. GET Types - see T1 and T2
-# 08. GET Types with details - see T1 and T2 with P1, P2, R1, R2
+# 05. GET Types with local=true - see T1
+# 06. GET Types with details and local=true - see T1 with P1, P2, R1, R2
+# 07. Create entity E3, type T2, with attributes P1 and R1
+# 08. Create entity E4, type T2, with attributes P2 and R2
+# 09. GET Types - see T1 and T2
+# 10. GET Types with details - see T1 and T2 with P1, P2, R1, R2
+# 11. GET Types with local=true - see T1 and T2
+# 12. GET Types with details and local=true - see T1 and T2 with P1, P2, R1, R2
 #
 
 echo "01. Create entity E1, type T1, with attributes P1 and R1"
@@ -92,7 +96,21 @@ echo
 echo
 
 
-echo "05. Create entity E3, type T2, with attributes P1 and R1"
+echo "05. GET Types with local=true - see T1"
+echo "======================================"
+orionCurl --url /ngsi-ld/v1/types?local=true
+echo
+echo
+
+
+echo "06. GET Types with details and local=true - see T1 with P1, P2, R1, R2"
+echo "======================================================================"
+orionCurl --url '/ngsi-ld/v1/types?details=true&local=true'
+echo
+echo
+
+
+echo "07. Create entity E3, type T2, with attributes P1 and R1"
 echo "========================================================"
 payload='{
   "id": "urn:ngsi-ld:entities:E3",
@@ -111,7 +129,7 @@ echo
 echo
 
 
-echo "06. Create entity E4, type T2, with attributes P2 and R2"
+echo "08. Create entity E4, type T2, with attributes P2 and R2"
 echo "========================================================"
 payload='{
   "id": "urn:ngsi-ld:entities:E4",
@@ -130,16 +148,30 @@ echo
 echo
 
 
-echo "07. GET Types - see T1 and T2"
+echo "09. GET Types - see T1 and T2"
 echo "============================="
 orionCurl --url /ngsi-ld/v1/types
 echo
 echo
 
 
-echo "08. GET Types with details - see T1 and T2 with P1, P2, R1, R2"
+echo "10. GET Types with details - see T1 and T2 with P1, P2, R1, R2"
 echo "=============================================================="
 orionCurl --url /ngsi-ld/v1/types?details=true
+echo
+echo
+
+
+echo "11. GET Types with local=true - see T1 and T2"
+echo "============================================="
+orionCurl --url /ngsi-ld/v1/types?local=true
+echo
+echo
+
+
+echo "12. GET Types with details and local=true - see T1 and T2 with P1, P2, R1, R2"
+echo "============================================================================="
+orionCurl --url '/ngsi-ld/v1/types?details=true&local=true'
 echo
 echo
 
@@ -203,7 +235,47 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
 ]
 
 
-05. Create entity E3, type T2, with attributes P1 and R1
+05. GET Types with local=true - see T1
+======================================
+HTTP/1.1 200 OK
+Content-Length: 114
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+{
+    "id": "urn:ngsi-ld:EntityTypeList:REGEX(.*)",
+    "type": "EntityTypeList",
+    "typeList": [
+        "T1"
+    ]
+}
+
+
+06. GET Types with details and local=true - see T1 with P1, P2, R1, R2
+======================================================================
+HTTP/1.1 200 OK
+Content-Length: 133
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+[
+    {
+        "attributeNames": [
+            "P2",
+            "R2",
+            "P1",
+            "R1"
+        ],
+        "id": "https://uri.etsi.org/ngsi-ld/default-context/T1",
+        "type": "EntityType",
+        "typeName": "T1"
+    }
+]
+
+
+07. Create entity E3, type T2, with attributes P1 and R1
 ========================================================
 HTTP/1.1 201 Created
 Content-Length: 0
@@ -212,7 +284,7 @@ Location: /ngsi-ld/v1/entities/urn:ngsi-ld:entities:E3
 
 
 
-06. Create entity E4, type T2, with attributes P2 and R2
+08. Create entity E4, type T2, with attributes P2 and R2
 ========================================================
 HTTP/1.1 201 Created
 Content-Length: 0
@@ -221,7 +293,7 @@ Location: /ngsi-ld/v1/entities/urn:ngsi-ld:entities:E4
 
 
 
-07. GET Types - see T1 and T2
+09. GET Types - see T1 and T2
 =============================
 HTTP/1.1 200 OK
 Content-Length: 119
@@ -239,8 +311,60 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
 }
 
 
-08. GET Types with details - see T1 and T2 with P1, P2, R1, R2
+10. GET Types with details - see T1 and T2 with P1, P2, R1, R2
 ==============================================================
+HTTP/1.1 200 OK
+Content-Length: 265
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+[
+    {
+        "attributeNames": [
+            "P2",
+            "R2",
+            "P1",
+            "R1"
+        ],
+        "id": "https://uri.etsi.org/ngsi-ld/default-context/T1",
+        "type": "EntityType",
+        "typeName": "T1"
+    },
+    {
+        "attributeNames": [
+            "P2",
+            "R2",
+            "P1",
+            "R1"
+        ],
+        "id": "https://uri.etsi.org/ngsi-ld/default-context/T2",
+        "type": "EntityType",
+        "typeName": "T2"
+    }
+]
+
+
+11. GET Types with local=true - see T1 and T2
+=============================================
+HTTP/1.1 200 OK
+Content-Length: 119
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+{
+    "id": "urn:ngsi-ld:EntityTypeList:REGEX(.*)",
+    "type": "EntityTypeList",
+    "typeList": [
+        "T1",
+        "T2"
+    ]
+}
+
+
+12. GET Types with details and local=true - see T1 and T2 with P1, P2, R1, R2
+=============================================================================
 HTTP/1.1 200 OK
 Content-Length: 265
 Content-Type: application/json

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_types-merge-of-registrations.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_types-merge-of-registrations.test
@@ -34,6 +34,8 @@ orionldStart CB
 # 02. Create registration with types T1 and T3, and attrs speed+isNotParked
 # 03. GET Entity Types - see three types (T1-T3)
 # 04. GET Entity Types WITH details - see three types (T1-T3)
+# 05. GET Entity Types with local=true - see empty array
+# 06. GET Entity Types WITH details and local=true - see empty array
 #
 
 echo "01. Create registration with types T1 and T2, and attrs brandName+isParked"
@@ -102,6 +104,20 @@ echo
 echo "04. GET Entity Types WITH details - see three types (T1-T3)"
 echo "==========================================================="
 orionCurl --url /ngsi-ld/v1/types?details=true
+echo
+echo
+
+
+echo "05. GET Entity Types with local=true - see empty array"
+echo "======================================================"
+orionCurl --url /ngsi-ld/v1/types?local=true
+echo
+echo
+
+
+echo "06. GET Entity Types WITH details and local=true - see empty array"
+echo "=================================================================="
+orionCurl --url '/ngsi-ld/v1/types?details=true&local=true'
 echo
 echo
 
@@ -183,6 +199,36 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
         "typeName": "T3"
     }
 ]
+
+
+05. GET Entity Types with local=true - see empty array
+======================================================
+HTTP/1.1 200 OK
+Content-Length: 110
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+{
+    "id": "urn:ngsi-ld:EntityTypeList:REGEX(.*)",
+    "type": "EntityTypeList",
+    "typeList": []
+}
+
+
+06. GET Entity Types WITH details and local=true - see empty array
+==================================================================
+HTTP/1.1 200 OK
+Content-Length: 110
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+{
+    "id": "urn:ngsi-ld:EntityTypeList:REGEX(.*)",
+    "type": "EntityTypeList",
+    "typeList": []
+}
 
 
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entity_types.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entity_types.test
@@ -39,6 +39,8 @@ orionldStart CB
 # 07. GET Entity Types - see five types (T0-T4)
 # 08. GET Entity Types WITH details - see five types (T0-T4)
 # 09. Same same, but Accept: application/ld+json
+# 10. GET Entity Types with local=true - see one type (T0)
+# 11. GET Entity Types WITH details - see one type (T0)
 #
 
 echo "01. GET Entity Types - see empty array"
@@ -150,6 +152,20 @@ echo
 echo "09. Same same, but Accept: application/ld+json"
 echo "=============================================="
 orionCurl --url /ngsi-ld/v1/types?details=true -H "Accept: application/ld+json"
+echo
+echo
+
+
+echo "10. GET Entity Types with local=true - see one type (T0)"
+echo "========================================================"
+orionCurl --url /ngsi-ld/v1/types?local=true
+echo
+echo
+
+
+echo "11. GET Entity Types WITH details and local=true - see one type (T0)"
+echo "===================================================================="
+orionCurl --url '/ngsi-ld/v1/types?details=true&local=true'
 echo
 echo
 
@@ -379,6 +395,43 @@ Date: REGEX(.*)
         "id": "https://uri.etsi.org/ngsi-ld/default-context/T4",
         "type": "EntityType",
         "typeName": "T4"
+    }
+]
+
+
+10. GET Entity Types with local=true - see one type (T0)
+========================================================
+HTTP/1.1 200 OK
+Content-Length: 114
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+{
+    "id": "urn:ngsi-ld:EntityTypeList:REGEX(.*)",
+    "type": "EntityTypeList",
+    "typeList": [
+        "T0"
+    ]
+}
+
+
+11. GET Entity Types WITH details and local=true - see one type (T0)
+====================================================================
+HTTP/1.1 200 OK
+Content-Length: 118
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+[
+    {
+        "attributeNames": [
+            "P1"
+        ],
+        "id": "https://uri.etsi.org/ngsi-ld/default-context/T0",
+        "type": "EntityType",
+        "typeName": "T0"
     }
 ]
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_entity_type.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_entity_type.test
@@ -150,7 +150,7 @@ echo
 
 echo "08. GET Entity Type T1 - see T1, count 3, and attrs P1, P2, R1, and R2"
 echo "======================================================================"
-orionCurl --url /ngsi-ld/v1/types/T1
+orionCurl --url /ngsi-ld/v1/types/T1?local=true
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_entity_types-merge-of-entities-and-registrations.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_entity_types-merge-of-entities-and-registrations.test
@@ -37,6 +37,8 @@ orionldStart CB -experimental
 # 04. Create registration R2, entity type T1, with attributes P4 and R4
 # 05. GET Types - see T1
 # 06. GET Types with details - see T1 with P1-P4 and R1-R4
+# 07. GET Types with local=true - see T1
+# 08. GET Types with details and local=true - see T1 but attributes only from entities E1+E2
 #
 
 echo "01. Create entity E1, type T1, with attributes P1 and R1"
@@ -138,6 +140,20 @@ echo
 echo
 
 
+echo "07. GET Types with local=true - see T1"
+echo "======================================"
+orionCurl --url /ngsi-ld/v1/types?local=true
+echo
+echo
+
+
+echo "08. GET Types with details and local=true - see T1 but attributes only from entities E1+E2"
+echo "=========================================================================================="
+orionCurl --url '/ngsi-ld/v1/types?details=true&local=true'
+echo
+echo
+
+
 --REGEXPECT--
 01. Create entity E1, type T1, with attributes P1 and R1
 ========================================================
@@ -211,6 +227,46 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
             "R4",
             "P3",
             "R3"
+        ],
+        "id": "https://uri.etsi.org/ngsi-ld/default-context/T1",
+        "type": "EntityType",
+        "typeName": "T1"
+    }
+]
+
+
+07. GET Types with local=true - see T1
+======================================
+HTTP/1.1 200 OK
+Content-Length: 114
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+{
+    "id": "urn:ngsi-ld:EntityTypeList:REGEX(.*)",
+    "type": "EntityTypeList",
+    "typeList": [
+        "T1"
+    ]
+}
+
+
+08. GET Types with details and local=true - see T1 but attributes only from entities E1+E2
+==========================================================================================
+HTTP/1.1 200 OK
+Content-Length: 133
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+[
+    {
+        "attributeNames": [
+            "P2",
+            "R2",
+            "P1",
+            "R1"
         ],
         "id": "https://uri.etsi.org/ngsi-ld/default-context/T1",
         "type": "EntityType",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_entity_types-merge-of-entities.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_entity_types-merge-of-entities.test
@@ -35,10 +35,14 @@ orionldStart CB -experimental
 # 02. Create entity E2, type T1, with attributes P2 and R2
 # 03. GET Types - see T1
 # 04. GET Types with details - see T1 with P1, P2, R1, R2
-# 05. Create entity E3, type T2, with attributes P1 and R1
-# 06. Create entity E4, type T2, with attributes P2 and R2
-# 07. GET Types - see T1 and T2
-# 08. GET Types with details - see T1 and T2 with P1, P2, R1, R2
+# 05. GET Types with local=true - see T1
+# 06. GET Types with details and local=true - see T1 with P1, P2, R1, R2
+# 07. Create entity E3, type T2, with attributes P1 and R1
+# 08. Create entity E4, type T2, with attributes P2 and R2
+# 09. GET Types - see T1 and T2
+# 10. GET Types with details - see T1 and T2 with P1, P2, R1, R2
+# 11. GET Types with local=true - see T1 and T2
+# 12. GET Types with details and local=true - see T1 and T2 with P1, P2, R1, R2
 #
 
 echo "01. Create entity E1, type T1, with attributes P1 and R1"
@@ -93,7 +97,21 @@ echo
 echo
 
 
-echo "05. Create entity E3, type T2, with attributes P1 and R1"
+echo "05. GET Types with local=true - see T1"
+echo "======================================"
+orionCurl --url /ngsi-ld/v1/types?local=true
+echo
+echo
+
+
+echo "06. GET Types with details and local=true - see T1 with P1, P2, R1, R2"
+echo "======================================================================"
+orionCurl --url '/ngsi-ld/v1/types?details=true&local=true'
+echo
+echo
+
+
+echo "07. Create entity E3, type T2, with attributes P1 and R1"
 echo "========================================================"
 payload='{
   "id": "urn:ngsi-ld:entities:E3",
@@ -112,7 +130,7 @@ echo
 echo
 
 
-echo "06. Create entity E4, type T2, with attributes P2 and R2"
+echo "08. Create entity E4, type T2, with attributes P2 and R2"
 echo "========================================================"
 payload='{
   "id": "urn:ngsi-ld:entities:E4",
@@ -131,16 +149,30 @@ echo
 echo
 
 
-echo "07. GET Types - see T1 and T2"
+echo "09. GET Types - see T1 and T2"
 echo "============================="
 orionCurl --url /ngsi-ld/v1/types
 echo
 echo
 
 
-echo "08. GET Types with details - see T1 and T2 with P1, P2, R1, R2"
+echo "10. GET Types with details - see T1 and T2 with P1, P2, R1, R2"
 echo "=============================================================="
 orionCurl --url /ngsi-ld/v1/types?details=true
+echo
+echo
+
+
+echo "11. GET Types with local=true - see T1 and T2"
+echo "============================================="
+orionCurl --url /ngsi-ld/v1/types?local=true
+echo
+echo
+
+
+echo "12. GET Types with details and local=true - see T1 and T2 with P1, P2, R1, R2"
+echo "============================================================================="
+orionCurl --url '/ngsi-ld/v1/types?details=true&local=true'
 echo
 echo
 
@@ -204,7 +236,47 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
 ]
 
 
-05. Create entity E3, type T2, with attributes P1 and R1
+05. GET Types with local=true - see T1
+======================================
+HTTP/1.1 200 OK
+Content-Length: 114
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+{
+    "id": "urn:ngsi-ld:EntityTypeList:REGEX(.*)",
+    "type": "EntityTypeList",
+    "typeList": [
+        "T1"
+    ]
+}
+
+
+06. GET Types with details and local=true - see T1 with P1, P2, R1, R2
+======================================================================
+HTTP/1.1 200 OK
+Content-Length: 133
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+[
+    {
+        "attributeNames": [
+            "P2",
+            "R2",
+            "P1",
+            "R1"
+        ],
+        "id": "https://uri.etsi.org/ngsi-ld/default-context/T1",
+        "type": "EntityType",
+        "typeName": "T1"
+    }
+]
+
+
+07. Create entity E3, type T2, with attributes P1 and R1
 ========================================================
 HTTP/1.1 201 Created
 Content-Length: 0
@@ -213,7 +285,7 @@ Location: /ngsi-ld/v1/entities/urn:ngsi-ld:entities:E3
 
 
 
-06. Create entity E4, type T2, with attributes P2 and R2
+08. Create entity E4, type T2, with attributes P2 and R2
 ========================================================
 HTTP/1.1 201 Created
 Content-Length: 0
@@ -222,7 +294,7 @@ Location: /ngsi-ld/v1/entities/urn:ngsi-ld:entities:E4
 
 
 
-07. GET Types - see T1 and T2
+09. GET Types - see T1 and T2
 =============================
 HTTP/1.1 200 OK
 Content-Length: 119
@@ -240,8 +312,60 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
 }
 
 
-08. GET Types with details - see T1 and T2 with P1, P2, R1, R2
+10. GET Types with details - see T1 and T2 with P1, P2, R1, R2
 ==============================================================
+HTTP/1.1 200 OK
+Content-Length: 265
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+[
+    {
+        "attributeNames": [
+            "P2",
+            "R2",
+            "P1",
+            "R1"
+        ],
+        "id": "https://uri.etsi.org/ngsi-ld/default-context/T1",
+        "type": "EntityType",
+        "typeName": "T1"
+    },
+    {
+        "attributeNames": [
+            "P2",
+            "R2",
+            "P1",
+            "R1"
+        ],
+        "id": "https://uri.etsi.org/ngsi-ld/default-context/T2",
+        "type": "EntityType",
+        "typeName": "T2"
+    }
+]
+
+
+11. GET Types with local=true - see T1 and T2
+=============================================
+HTTP/1.1 200 OK
+Content-Length: 119
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+{
+    "id": "urn:ngsi-ld:EntityTypeList:REGEX(.*)",
+    "type": "EntityTypeList",
+    "typeList": [
+        "T1",
+        "T2"
+    ]
+}
+
+
+12. GET Types with details and local=true - see T1 and T2 with P1, P2, R1, R2
+=============================================================================
 HTTP/1.1 200 OK
 Content-Length: 265
 Content-Type: application/json

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_entity_types-merge-of-registrations.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_entity_types-merge-of-registrations.test
@@ -35,6 +35,8 @@ orionldStart CB -experimental
 # 02. Create registration with types T1 and T3, and attrs speed+isNotParked
 # 03. GET Entity Types - see three types (T1-T3)
 # 04. GET Entity Types WITH details - see three types (T1-T3)
+# 05. GET Entity Types with local=true - see empty array
+# 06. GET Entity Types WITH details and local=true - see empty array
 #
 
 echo "01. Create registration with types T1 and T2, and attrs brandName+isParked"
@@ -103,6 +105,20 @@ echo
 echo "04. GET Entity Types WITH details - see three types (T1-T3)"
 echo "==========================================================="
 orionCurl --url /ngsi-ld/v1/types?details=true
+echo
+echo
+
+
+echo "05. GET Entity Types with local=true - see empty array"
+echo "======================================================"
+orionCurl --url /ngsi-ld/v1/types?local=true
+echo
+echo
+
+
+echo "06. GET Entity Types WITH details and local=true - see empty array"
+echo "=================================================================="
+orionCurl --url '/ngsi-ld/v1/types?details=true&local=true'
 echo
 echo
 
@@ -184,6 +200,36 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
         "typeName": "T3"
     }
 ]
+
+
+05. GET Entity Types with local=true - see empty array
+======================================================
+HTTP/1.1 200 OK
+Content-Length: 110
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+{
+    "id": "urn:ngsi-ld:EntityTypeList:REGEX(.*)",
+    "type": "EntityTypeList",
+    "typeList": []
+}
+
+
+06. GET Entity Types WITH details and local=true - see empty array
+==================================================================
+HTTP/1.1 200 OK
+Content-Length: 110
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+{
+    "id": "urn:ngsi-ld:EntityTypeList:REGEX(.*)",
+    "type": "EntityTypeList",
+    "typeList": []
+}
 
 
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_entity_types.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_entity_types.test
@@ -40,6 +40,8 @@ orionldStart CB -experimental
 # 07. GET Entity Types - see five types (T0-T4)
 # 08. GET Entity Types WITH details - see five types (T0-T4)
 # 09. Same same, but Accept: application/ld+json
+# 10. GET Entity Types with local=true - see one type (T0)
+# 11. GET Entity Types WITH details - see one type (T0)
 #
 
 echo "01. GET Entity Types - see empty array"
@@ -151,6 +153,20 @@ echo
 echo "09. Same same, but Accept: application/ld+json"
 echo "=============================================="
 orionCurl --url /ngsi-ld/v1/types?details=true -H "Accept: application/ld+json"
+echo
+echo
+
+
+echo "10. GET Entity Types with local=true - see one type (T0)"
+echo "========================================================"
+orionCurl --url /ngsi-ld/v1/types?local=true
+echo
+echo
+
+
+echo "11. GET Entity Types WITH details and local=true - see one type (T0)"
+echo "===================================================================="
+orionCurl --url '/ngsi-ld/v1/types?details=true&local=true'
 echo
 echo
 
@@ -380,6 +396,43 @@ Date: REGEX(.*)
         "id": "https://uri.etsi.org/ngsi-ld/default-context/T4",
         "type": "EntityType",
         "typeName": "T4"
+    }
+]
+
+
+10. GET Entity Types with local=true - see one type (T0)
+========================================================
+HTTP/1.1 200 OK
+Content-Length: 114
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+{
+    "id": "urn:ngsi-ld:EntityTypeList:REGEX(.*)",
+    "type": "EntityTypeList",
+    "typeList": [
+        "T0"
+    ]
+}
+
+
+11. GET Entity Types WITH details and local=true - see one type (T0)
+====================================================================
+HTTP/1.1 200 OK
+Content-Length: 118
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+[
+    {
+        "attributeNames": [
+            "P1"
+        ],
+        "id": "https://uri.etsi.org/ngsi-ld/default-context/T0",
+        "type": "EntityType",
+        "typeName": "T0"
     }
 ]
 


### PR DESCRIPTION
Issue #1707 : Support for local=true in the type discovery endpoints (GET /ngsi-ld/v1/types.

Note that discover of a single entity (also part of the issue #1707) is still not fully implemented (regs are not considered, hence it's like a local=true)