### PR TITLE
Context/cache

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,6 +2,6 @@
   #XXXX: Fixed XXX
 
 ## New Features:
-  #XXXX: The context cache now ignores the protocol (http, https) in the URLs and thus avoids to store two copies of the very same @context
+  #XXXX: The context cache now ignores the protocol (http, https) in the URLs and thus avoids storing two copies of the very same @context
 
 ## Notes

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,6 +2,6 @@
   #XXXX: Fixed XXX
 
 ## New Features:
-  #XXXX: Implemented XXX
+  #XXXX: The context cache now ignores the protocol (http, https) in the URLs and thus avoids to store two copies of the very same @context
 
 ## Notes

--- a/src/lib/orionld/contextCache/orionldContextCacheLookup.cpp
+++ b/src/lib/orionld/contextCache/orionldContextCacheLookup.cpp
@@ -38,16 +38,36 @@
 //
 // orionldContextCacheLookup -
 //
-OrionldContext* orionldContextCacheLookup(const char* url)
+OrionldContext* orionldContextCacheLookup(const char* fullUrl)
 {
   OrionldContext* contextP = NULL;
+  char*           url      = (char*) fullUrl;
+
+  //
+  // Skip the protocol for the lookup
+  //
+  if (strncmp(fullUrl, "http://", 7) == 0)
+    url = (char*) &fullUrl[7];
+  else if (strncmp(fullUrl, "https://", 8) == 0)
+    url = (char*) &fullUrl[8];
 
   for (int ix = 0; ix < orionldContextCacheSlotIx; ix++)
   {
     if (orionldContextCache[ix] == NULL)
       continue;
 
-    if (strcmp(url, orionldContextCache[ix]->url) == 0)
+    //
+    // Skip the protocol for the comparison with context in cache
+    //
+    char* cacheUrlWithoutProtocol = orionldContextCache[ix]->url;
+    if (strncmp(orionldContextCache[ix]->url, "http://", 7) == 0)
+      cacheUrlWithoutProtocol = &orionldContextCache[ix]->url[7];
+    else if (strncmp(orionldContextCache[ix]->url, "https://", 8) == 0)
+      cacheUrlWithoutProtocol = &orionldContextCache[ix]->url[8];
+
+    if (strcmp(url, cacheUrlWithoutProtocol) == 0)
+      contextP = orionldContextCache[ix];
+    else if (strcmp(fullUrl, orionldContextCache[ix]->url) == 0)
       contextP = orionldContextCache[ix];
     else if ((orionldContextCache[ix]->id != NULL) && (strcmp(url, orionldContextCache[ix]->id) == 0))
       contextP = orionldContextCache[ix];

--- a/test/functionalTest/cases/0000_ngsild/ngsild_context_cache_ignores-protocol.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_context_cache_ignores-protocol.test
@@ -1,0 +1,127 @@
+# Copyright 2024 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Contexts (in cache) with different protocols are the same (https and http)
+
+--SHELL-INIT--
+dbInit CB
+dbDrop orionld  # Empty context cache
+orionldStart CB
+
+--SHELL--
+
+#
+# 01. See the contexts in the cache - only core context
+# 02. Create an entity using the context 'http://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld' - added to cache
+# 03. GET the entity using the same context as in step 2, just with protocol https instead of http
+# 04. See the contexts in the cache - see only two contexts
+#
+
+echo "01. See the contexts in the cache - only core context"
+echo "======================================================"
+orionCurl --url /ngsi-ld/v1/jsonldContexts
+echo
+echo
+
+
+echo "02. Create an entity using the context 'http://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld' - added to cache"
+echo "================================================================================================================================"
+payload='{
+  "id": "urn:E1",
+  "type": "T",
+  "@context": "http://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload" --in jsonld
+echo
+echo
+
+
+echo "03. GET the entity using the same context as in step 2, just with protocol https instead of http"
+echo "================================================================================================="
+orionCurl --url /ngsi-ld/v1/entities?type=T -H "Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>"
+echo
+echo
+
+
+echo "04. See the contexts in the cache - see only two contexts"
+echo "=========================================================="
+orionCurl --url /ngsi-ld/v1/jsonldContexts
+echo
+echo
+
+
+--REGEXPECT--
+01. See the contexts in the cache - only core context
+======================================================
+HTTP/1.1 200 OK
+Content-Length: 68
+Content-Type: application/json
+Date: REGEX(.*)
+
+[
+    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld"
+]
+
+
+02. Create an entity using the context 'http://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld' - added to cache
+================================================================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:E1
+
+
+
+03. GET the entity using the same context as in step 2, just with protocol https instead of http
+=================================================================================================
+HTTP/1.1 200 OK
+Content-Length: 28
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <http://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+[
+    {
+        "id": "urn:E1",
+        "type": "T"
+    }
+]
+
+
+04. See the contexts in the cache - see only two contexts
+==========================================================
+HTTP/1.1 200 OK
+Content-Length: REGEX(.*)
+Content-Type: application/json
+Date: REGEX(.*)
+
+[
+    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)",
+    "http://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld"
+]
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB
+

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0241_location-in-notifications.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0241_location-in-notifications.test
@@ -25,6 +25,7 @@ Notifications - correct representation of location inside notifications
 
 --SHELL-INIT--
 dbInit CB
+dbInit orionld
 orionldStart CB
 accumulatorStart --pretty-print
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_0241_notifications.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_0241_notifications.test
@@ -25,6 +25,7 @@ Notifications - response of normalized format subscription (nested JSON problem)
 
 --SHELL-INIT--
 dbInit CB
+dbInit orionld
 orionldStart CB
 accumulatorStart --pretty-print
 
@@ -153,7 +154,7 @@ Location: /ngsi-ld/v1/entities/urn:ngsi-ld:Vehicle:A4501
 ================================================
 POST http://REGEX(.*)/notify
 Fiware-Servicepath: /
-Content-Length: 878
+Content-Length: REGEX((879|878))
 User-Agent: orion/REGEX(.*)
 Ngsiv2-Attrsformat: normalized
 Host: REGEX(.*)
@@ -161,7 +162,7 @@ Accept: application/json
 Content-Type: application/ld+json
 
 {
-    "@context": "http://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+    "@context": "REGEX((http|https))://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
     "data": [
         {
             "brandName": {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_1224.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_1224.test
@@ -25,6 +25,7 @@ Issue #1224 without -experimental
 
 --SHELL-INIT--
 dbInit CB
+dbInit orionld
 orionldStart CB -experimental
 accumulatorStart --pretty-print 127.0.0.1 ${LISTENER_PORT}
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_registration_get_success.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_registration_get_success.test
@@ -26,6 +26,7 @@ Retrieval of Context Source Registrations
 --SHELL-INIT--
 # Copied from ngsild_registration_get_success.test
 dbInit CB
+dbInit orionld
 orionldStart CB -experimental
 
 --SHELL--

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_subscription_with_mqtt_issue-1178-II.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_subscription_with_mqtt_issue-1178-II.test
@@ -26,6 +26,7 @@ Notifications via MQTT - Issue 1178
 --SHELL-INIT--
 # Copied from ngsild_subscription_with_mqtt_issue.1178.test
 dbInit CB
+dbInit orionld
 orionldStart CB -experimental
 mqttTestClientStart --mqttBrokerPort $MQTT_BROKER_PORT --mqttBrokerIp $MQTT_BROKER_HOST --pretty-print --mqttTopic example_mosquitto_topic
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_testSuite-case-079.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_testSuite-case-079.test
@@ -26,6 +26,7 @@ NGSI-LD Test Suite Case 079, 080, and 081 (contextProvision/append_entity_attrs_
 --SHELL-INIT--
 # Copied from ngsild_testSuite-case-079.test
 dbInit CB
+dbInit orionld
 orionldStart CB -experimental
 
 --SHELL--

--- a/test/functionalTest/cases/0000_ngsild/ngsild_put_entity.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_put_entity.test
@@ -25,6 +25,7 @@ Update an entity using PUT
 
 --SHELL-INIT--
 dbInit CB
+dbInit orionld
 orionldStart CB -experimental
 
 --SHELL--

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_bug.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_bug.test
@@ -26,6 +26,7 @@ Subscription Creation and DB Content
 --SHELL-INIT--
 dbInit CB
 dbInit CB openiot
+dbInit orionld
 orionldStart CB -multiservice
 accumulatorStart --pretty-print
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_with_mqtt_issue.1178.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_with_mqtt_issue.1178.test
@@ -25,6 +25,7 @@ Notifications via MQTT - Issue 1178
 
 --SHELL-INIT--
 dbInit CB
+dbInit orionld
 orionldStart CB
 mqttTestClientStart --mqttBrokerPort $MQTT_BROKER_PORT --mqttBrokerIp $MQTT_BROKER_HOST --pretty-print --mqttTopic example_mosquitto_topic
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_testSuite-case-079.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_testSuite-case-079.test
@@ -25,6 +25,7 @@ NGSI-LD Test Suite Case 079, 080, and 081 (contextProvision/append_entity_attrs_
 
 --SHELL-INIT--
 dbInit CB
+dbInit orionld
 orionldStart CB
 
 --SHELL--


### PR DESCRIPTION
The context cache now ignores the protocol (http, https) in the URLs and thus avoids storing two copies of the very same @context
