### PR TITLE
Concatenation of arrays in the new PATCH Entity, only if a specific HTTP header is set

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -5,5 +5,5 @@
 
 ## New Features:
   #XXXX: The context cache now ignores the protocol (http, https) in the URLs and thus avoids storing two copies of the very same @context
-
+  #XXXX: Special treatment for aerOS: PATCH /entities/* can now concatenate arrays instead of replacing (HTTP header aerOS-Array-Concat: TRUE)
 ## Notes

--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -252,6 +252,7 @@ typedef struct OrionldStateIn
   char*     legacy;          // Use legacy mongodb driver / mongoBackend
   bool      performance;
   bool      aerOS;           // Special treatment for aerOS specific features
+  bool      arrayConcat;     // Concatenate arrays in PATCH Entity2
   char*     wip;
 
   // Incoming payload

--- a/src/lib/orionld/mhd/mhdConnectionInit.cpp
+++ b/src/lib/orionld/mhd/mhdConnectionInit.cpp
@@ -378,6 +378,11 @@ static MHD_Result orionldHttpHeaderReceive(void* cbDataP, MHD_ValueKind kind, co
     if (strcasecmp(value, "true") == 0)
       orionldState.in.aerOS = true;
   }
+  else if (strcasecmp(key, "aerOS-Array-Concat") == 0)
+  {
+    if (strcasecmp(value, "true") == 0)
+      orionldState.in.arrayConcat = true;
+  }
   else if (strcasecmp(key, "NGSILD-Scope") == 0)
   {
     orionldState.scopes = strSplit((char*) value, ',', orionldState.scopeV, K_VEC_SIZE(orionldState.scopeV));

--- a/src/lib/orionld/serviceRoutines/orionldPatchEntity2.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchEntity2.cpp
@@ -255,6 +255,15 @@ static void orionldEntityPatchTree(KjNode* oldP, KjNode* newP, char* path, KjNod
   else if (newP->type == KjFloat)    { if (newP->value.f != oldP->value.f)             change = true; nonCompound = true; }
   else if (newP->type == KjBoolean)  { if (newP->value.b != oldP->value.b)             change = true; nonCompound = true; }
 
+  //
+  // Special case for aerOS
+  //
+  if ((orionldState.in.arrayConcat == true) && (oldP->type == KjArray) && (newP->type == KjArray))
+  {
+    oldP->lastChild->next   = newP->value.firstChildP;
+    newP->value.firstChildP = oldP->value.firstChildP;
+  }
+    
   if (change == true)
     patchTreeItemAdd(patchTree, path, newP, NULL);
 

--- a/src/lib/orionld/serviceRoutines/orionldPatchEntity2.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchEntity2.cpp
@@ -263,7 +263,7 @@ static void orionldEntityPatchTree(KjNode* oldP, KjNode* newP, char* path, KjNod
     oldP->lastChild->next   = newP->value.firstChildP;
     newP->value.firstChildP = oldP->value.firstChildP;
   }
-    
+
   if (change == true)
     patchTreeItemAdd(patchTree, path, newP, NULL);
 


### PR DESCRIPTION
Special request from the aerOS project (not NGSI-LD compliant).

They ask for a feature change in `PATCH /ngsi-ld/v1/entities/{entityId}`, making it concatenate arrays instead of replacing them (which is what the RFC says).

So, I invented a HTTP header to turn this "weird" feature on:
```
aerOS-Array-Concat: TRUE
```
