### PR TITLE
Bug/subsequent subs matching

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -3,6 +3,7 @@
   #1733: URL-encoding entity type in forwarded requests
   #1677: More than 6 decimals in floating point numbers (supporting 9 decimals - 12 is just not possible)
   #XXXX: Fixed a bug for system attributes (timestamps) which were sometimes included in sub-attributes without being requested
+  #XXXX: Fixed a bug for registration matching of subscriptions (for entity types)
 
 ## New Features:
   #XXXX: The context cache now ignores the protocol (http, https) in the URLs and thus avoids storing two copies of the very same @context

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -4,6 +4,7 @@
   #1677: More than 6 decimals in floating point numbers (supporting 9 decimals)
   #XXXX: Fixed a bug for system attributes (timestamps) which were sometimes included in sub-attributes without being requested
   #XXXX: Fixed a bug for registration matching of subscriptions (for entity types)
+  #XXXX: Fixed a bug in the matching of subs/regs of subsequent subs
 
 ## New Features:
   #XXXX: The context cache now ignores the protocol (http, https) in the URLs and thus avoids storing two copies of the very same @context
@@ -11,4 +12,4 @@
   #DDS:  Pushing to DDS via PATCH /ngsi-ld/v1/entities/{entityId} 
 
 ## Notes
-  Updated to the latest libraries of FastDDS, with a number of changes in the souirce code, to prepare for pushing to DDS via the broker.
+* Updated to the newest libraries of FastDDS, with a number of changes in the source code, to prepare for pushing to DDS via the broker.

--- a/src/lib/orionld/regMatch/regMatchSubscription.cpp
+++ b/src/lib/orionld/regMatch/regMatchSubscription.cpp
@@ -80,18 +80,24 @@ bool regMatchSubscription
 
           for (KjNode* entityInfoP = entitiesP->value.firstChildP; entityInfoP != NULL; entityInfoP = entityInfoP->next)
           {
-            // Only supported if only an entity type is given
+            // Only supported if only entity type is given
             KjNode* typeP = entityInfoP->value.firstChildP;
 
-            if (strcmp(typeP->name, "type") != 0)
-              continue;
+            //
+            // If the first child is NOT "type", OR there's another child => NOT only entity type is given => no support
+            //
+            if ((strcmp(typeP->name, "type") != 0) || (typeP->next != NULL))
+            {
+              LM_W(("For now, distributed subscriptions only work for type based registrations"));
+              break;
+            }
 
-            if (typeP->next != NULL)
-              continue;
-
-            LM_T(LmtSR, ("Found a matching registration for entity type '%s': %s", entityType, rciP->regId));
-            *entityTypeP = (char*) entityType;
-            return true;
+            if (strcmp(entityType, typeP->value.s) == 0)
+            {
+              LM_T(LmtSR, ("Found a matching registration for entity type '%s': %s", entityType, rciP->regId));
+              *entityTypeP = (char*) entityType;
+              return true;
+            }
           }
         }
       }

--- a/src/lib/orionld/serviceRoutines/orionldPostSubscriptions.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostSubscriptions.cpp
@@ -101,7 +101,7 @@ SubordinateSubscription* subordinateCreate(CachedSubscription* cSubP, RegCacheIt
 
   for (SubordinateSubscription* subordinateP = cSubP->subordinateP; subordinateP != NULL; subordinateP = subordinateP->next)
   {
-    runNo = MAX(runNo, subordinateP->runNo);
+    runNo = MAX(runNo, subordinateP->runNo) + 1;
   }
 
   char subSubId[128];
@@ -109,12 +109,14 @@ SubordinateSubscription* subordinateCreate(CachedSubscription* cSubP, RegCacheIt
 
   char notificationUrl[512];
 
+  LM_T(LmtSubordinate, ("subordinateEndpoint; '%s'", subordinateEndpoint));
+
   if (subordinateEndpoint[0] != 0)
     snprintf(notificationUrl, sizeof(notificationUrl), "%s/notifications/%s", subordinateEndpoint, cSubP->subscriptionId);
   else
     snprintf(notificationUrl, sizeof(notificationUrl), "http://%s/ngsi-ld/ex/v1/notifications/%s", localIpAndPort, cSubP->subscriptionId);
 
-  LM_T(LmtSubordinate, ("URL for subordinate subscription: '%s'", notificationUrl));
+  LM_T(LmtSubordinate, ("Notification URL for subordinate subscription: '%s'", notificationUrl));
 
   KjNode* bodyP         = kjObject(orionldState.kjsonP, NULL);
   KjNode* idP           = kjString(orionldState.kjsonP, "id", subSubId);
@@ -200,6 +202,7 @@ SubordinateSubscription* subordinateCreate(CachedSubscription* cSubP, RegCacheIt
 
   LM_T(LmtSR, ("IP of registration: '%s'", rciIp));
   snprintf(rciUrl, sizeof(rciUrl) - 1, "http://%s/ngsi-ld/v1/subscriptions", rciP->ipAndPort);
+  LM_T(LmtSR, ("URL for creation of subordinate subscription '%s'", rciUrl));
 
   httpRequestHeaderAdd(&headers[headerIx++], "Content-Type", "application/json", 0);
   int httpStatus = httpRequest(rciIp, "POST", rciUrl, bodyP, NULL, headers, tmo, &responseBody, &pd);

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_distributed_subscription_creation.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_distributed_subscription_creation.test
@@ -556,7 +556,7 @@ Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:S3
 16. List subs in CP1 - see the CB::S2 subordinate subscription
 ==============================================================
 HTTP/1.1 200 OK
-Content-Length: 793
+Content-Length: REGEX(.*)
 Content-Type: application/json
 Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
@@ -574,7 +574,7 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
         "notification": {
             "endpoint": {
                 "accept": "application/json",
-                "uri": "http://tux:9999/ngsi-ld/ex/v1/notifications/urn:ngsi-ld:Subscription:S3"
+                "uri": "http://REGEX(.*)/ngsi-ld/ex/v1/notifications/urn:ngsi-ld:Subscription:S3"
             },
             "format": "normalized",
             "status": "ok"
@@ -595,7 +595,7 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
         "notification": {
             "endpoint": {
                 "accept": "application/json",
-                "uri": "http://tux:9999/ngsi-ld/ex/v1/notifications/urn:ngsi-ld:Subscription:S3"
+                "uri": "http://REGEX(.*)/ngsi-ld/ex/v1/notifications/urn:ngsi-ld:Subscription:S3"
             },
             "format": "normalized",
             "status": "ok"

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_distributed_subscription_creation.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_distributed_subscription_creation.test
@@ -45,6 +45,13 @@ accumulatorStart --pretty-print 127.0.0.1 ${LISTENER_PORT}
 # 10. List subs in CB - see empty array
 # 11. List subs in CP1 - see empty array
 #
+# 12. Create a registration R2 on CB, on entity type T2, with endpoint CP1
+# 13. Create a subscription S2 on CB, on entity type T3 - forwarded to CP1
+# 14. List subs in CP1 - see empty array (non-matching entity types)
+#
+# 15. Create a subscription S3 on CB, on entity type T2 - forwarded to CP1
+# 16. List subs in CP1 - see the CB::S2 subordinate subscription
+#
 
 echo "01. Create a registration R1 on CB, on entity type T, with endpoint CP1"
 echo "======================================================================="
@@ -165,6 +172,84 @@ echo
 
 echo "11. List subs in CP1 - see empty array"
 echo "======================================"
+orionCurl --url /ngsi-ld/v1/subscriptions --port $CP1_PORT
+echo
+echo
+
+
+echo "12. Create a registration R2 on CB, on entity type T2, with endpoint CP1"
+echo "========================================================================"
+payload='{
+  "id": "urn:R2",
+  "type": "ContextSourceRegistration",
+  "information": [
+    {
+      "entities": [
+        {
+          "type": "T2"
+        }
+      ]
+    }
+  ],
+  "endpoint": "localhost:'$CP1_PORT'",
+  "operations": [ "createEntity", "retrieveEntity", "mergeEntity", "createSubscription" ]
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload"
+echo
+echo
+
+
+echo "13. Create a subscription S2 on CB, on entity type T3 - forwarded to CP1"
+echo "========================================================================"
+payload='{
+  "id": "urn:ngsi-ld:Subscription:S2",
+  "type": "Subscription",
+  "entities": [
+    {
+      "type": "T3"
+    }
+  ],
+  "notification": {
+    "endpoint": {
+      "uri": "http://localhost:'$LISTENER_PORT'/notify",
+    }
+  }
+}'
+orionCurl --url /ngsi-ld/v1/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo "14. List subs in CP1 - see empty array (non-matching entity types)"
+echo "=================================================================="
+orionCurl --url /ngsi-ld/v1/subscriptions --port $CP1_PORT
+echo
+echo
+
+
+echo "15. Create a subscription S3 on CB, on entity type T2 - forwarded to CP1"
+echo "========================================================================"
+payload='{
+  "id": "urn:ngsi-ld:Subscription:S3",
+  "type": "Subscription",
+  "entities": [
+    {
+      "type": "T2"
+    }
+  ],
+  "notification": {
+    "endpoint": {
+      "uri": "http://localhost:'$LISTENER_PORT'/notify",
+    }
+  }
+}'
+orionCurl --url /ngsi-ld/v1/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo "16. List subs in CP1 - see the CB::S2 subordinate subscription"
+echo "=============================================================="
 orionCurl --url /ngsi-ld/v1/subscriptions --port $CP1_PORT
 echo
 echo

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_distributed_subscription_creation.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_distributed_subscription_creation.test
@@ -211,7 +211,7 @@ payload='{
   ],
   "notification": {
     "endpoint": {
-      "uri": "http://localhost:'$LISTENER_PORT'/notify",
+      "uri": "http://localhost:'$LISTENER_PORT'/notify"
     }
   }
 }'
@@ -239,7 +239,7 @@ payload='{
   ],
   "notification": {
     "endpoint": {
-      "uri": "http://localhost:'$LISTENER_PORT'/notify",
+      "uri": "http://localhost:'$LISTENER_PORT'/notify"
     }
   }
 }'
@@ -513,6 +513,98 @@ Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
 
 []
+
+
+12. Create a registration R2 on CB, on entity type T2, with endpoint CP1
+========================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/csourceRegistrations/urn:R2
+
+
+
+13. Create a subscription S2 on CB, on entity type T3 - forwarded to CP1
+========================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:S2
+
+
+
+14. List subs in CP1 - see empty array (non-matching entity types)
+==================================================================
+HTTP/1.1 200 OK
+Content-Length: 2
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+[]
+
+
+15. Create a subscription S3 on CB, on entity type T2 - forwarded to CP1
+========================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:S3
+
+
+
+16. List subs in CP1 - see the CB::S2 subordinate subscription
+==============================================================
+HTTP/1.1 200 OK
+Content-Length: 793
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+[
+    {
+        "entities": [
+            {
+                "type": "T2"
+            }
+        ],
+        "id": "urn:ngsi-ld:Subscription:S3:1",
+        "isActive": true,
+        "jsonldContext": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+        "notification": {
+            "endpoint": {
+                "accept": "application/json",
+                "uri": "http://tux:9999/ngsi-ld/ex/v1/notifications/urn:ngsi-ld:Subscription:S3"
+            },
+            "format": "normalized",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "status": "active",
+        "type": "Subscription"
+    },
+    {
+        "entities": [
+            {
+                "type": "T2"
+            }
+        ],
+        "id": "urn:ngsi-ld:Subscription:S3:2",
+        "isActive": true,
+        "jsonldContext": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+        "notification": {
+            "endpoint": {
+                "accept": "application/json",
+                "uri": "http://tux:9999/ngsi-ld/ex/v1/notifications/urn:ngsi-ld:Subscription:S3"
+            },
+            "format": "normalized",
+            "status": "ok"
+        },
+        "origin": "cache",
+        "status": "active",
+        "type": "Subscription"
+    }
+]
 
 
 --TEARDOWN--


### PR DESCRIPTION
Fixed two bugs concerning subsequent subscriptions÷
* The registration matching on entity type was erroneous
* The id of the subsequent subs for a sub had all the same id ! (a `runNo++` was missing)