### PR TITLE
Fixed issue #1748

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,6 +2,7 @@
   #1706: Fixed a bug in the logic merging attributes from the URL parameter (attrs) with attributes from registrations
   #1733: URL-encoding entity type in forwarded requests
   #1677: More than 6 decimals in floating point numbers (supporting 9 decimals)
+  #1748: Orion-LD automatically adds a few HTTP headers to notifications. BUT, no check was done for already included in receiverInfo. Got duplicated headers.
   #XXXX: Fixed a bug for system attributes (timestamps) which were sometimes included in sub-attributes without being requested
   #XXXX: Fixed a bug for registration matching of subscriptions (for entity types)
   #XXXX: Fixed a bug in the matching of subs/regs of subsequent subs

--- a/src/lib/orionld/notifications/notificationSend.cpp
+++ b/src/lib/orionld/notifications/notificationSend.cpp
@@ -843,37 +843,12 @@ int notificationSend(OrionldAlterationMatch* mAltP, double timestamp, CURL** cur
     ++headerIx;
   }
 
-
-  //
-  // X-Auth-Token
-  //
-  if (orionldState.in.xAuthToken != NULL)
-  {
-    int   len = strlen(orionldState.in.xAuthToken) + 20;  // X-Auth-Token: xxx\r\n0
-    char* buf = kaAlloc(&orionldState.kalloc, len);
-
-    ioVec[headerIx].iov_len  = snprintf(buf, len, "X-Auth-Token: %s\r\n", orionldState.in.xAuthToken);
-    ioVec[headerIx].iov_base = buf;
-    ++headerIx;
-  }
-
-
-  //
-  // Authorization
-  //
-  if (orionldState.in.authorization != NULL)
-  {
-    int   len = strlen(orionldState.in.authorization) + 20;  // Authorization: xxx\r\n0
-    char* buf = kaAlloc(&orionldState.kalloc, len);
-
-    ioVec[headerIx].iov_len  = snprintf(buf, len, "Authorization: %s\r\n", orionldState.in.authorization);
-    ioVec[headerIx].iov_base = buf;
-    ++headerIx;
-  }
-
   //
   // FIXME: Store headers in a better way - see issue #1095
   //
+  bool authorizationHeaderPresent = false;
+  bool xAuthTokenPresent          = false;
+
   for (std::map<std::string, std::string>::const_iterator it = mAltP->subP->httpInfo.headers.begin(); it != mAltP->subP->httpInfo.headers.end(); ++it)
   {
     const char* key    = it->first.c_str();
@@ -896,7 +871,40 @@ int notificationSend(OrionldAlterationMatch* mAltP, double timestamp, CURL** cur
     int   len = strlen(key) + strlen(value) + 10;
     char* buf = kaAlloc(&orionldState.kalloc, len);
 
+    if (strcasecmp(key, "Authorization") == 0)
+      authorizationHeaderPresent = true;
+    if (strcasecmp(key, "X-Auth-Token") == 0)
+      xAuthTokenPresent = true;
+
     ioVec[headerIx].iov_len  = snprintf(buf, len, "%s: %s\r\n", key, value);
+    ioVec[headerIx].iov_base = buf;
+    ++headerIx;
+  }
+
+  //
+  // Automatic inclusion of the X-Auth-Token header
+  // But, only if it NOT part of "receiverInfo" of the subscription
+  //
+  if ((xAuthTokenPresent == false) && (orionldState.in.xAuthToken != NULL))
+  {
+    int   len = strlen(orionldState.in.xAuthToken) + 20;  // X-Auth-Token: xxx\r\n0
+    char* buf = kaAlloc(&orionldState.kalloc, len);
+
+    ioVec[headerIx].iov_len  = snprintf(buf, len, "X-Auth-Token: %s\r\n", orionldState.in.xAuthToken);
+    ioVec[headerIx].iov_base = buf;
+    ++headerIx;
+  }
+
+  //
+  // Automatic inclusion of the Authorization header
+  // But, only if it NOT part of "receiverInfo" of the subscription
+  //
+  if ((authorizationHeaderPresent == false) && (orionldState.in.authorization != NULL))
+  {
+    int   len = strlen(orionldState.in.authorization) + 20;  // Authorization: xxx\r\n0
+    char* buf = kaAlloc(&orionldState.kalloc, len);
+
+    ioVec[headerIx].iov_len  = snprintf(buf, len, "Authorization: %s\r\n", orionldState.in.authorization);
     ioVec[headerIx].iov_base = buf;
     ++headerIx;
   }


### PR DESCRIPTION
Fixed issue #1748
Avoiding duplicate HTTP headers for automatic headers in notifications:
* Authorization
* X-Auth-Token

The duplication occurs when those headers are also present in "receiverInfo" of a subscription.
