### PR TITLE
Distop/use pick not only ids

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -15,3 +15,4 @@
 
 ## Notes
 * Updated to the newest libraries of FastDDS, with a number of changes in the source code, to prepare for pushing to DDS via the broker.
+* Internal entity map creation is now done using 'pick=id', and not the outdated (never made it into the spec) 'onlyIds=true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,10 +246,10 @@ SET (ORION_LIBS
     orionld_mqtt
     orionld_q
     orionld_mongoc       # subCache needs mongoc
+    orionld_entityMaps
     orionld_dbModel
     orionld_apiModel
     orionld_common
-    orionld_entityMaps
     orionld_types
     parse
     apiTypesV2

--- a/src/lib/orionld/common/orionldState.h
+++ b/src/lib/orionld/common/orionldState.h
@@ -168,7 +168,6 @@ typedef struct OrionldUriParams
   char*     observedAt;
   char*     lang;
   bool      local;
-  bool      onlyIds;
   bool      entityMap;
   char*     format;
   char*     csf;

--- a/src/lib/orionld/dbModel/dbModelToEntityIdAndTypeObject.cpp
+++ b/src/lib/orionld/dbModel/dbModelToEntityIdAndTypeObject.cpp
@@ -40,9 +40,13 @@ extern "C"
 // dbModelToEntityIdAndTypeObject - FIXME: rename to dbModelToEntityMap
 //
 // INPUT:  [ { "_id": { "id": "urn:E1", "type": "urn:...:T1" } }, { "_id": { "id": "urn:E2", "type": "urn:...:T2" } }, ... ]
-// OUTPUT: ["urn:E1", "urn:E2", ...]
+// OUTPUT: [ "urn:E1", "urn:E2", ...]
 //
-KjNode* dbModelToEntityIdAndTypeObject(KjNode* localDbMatches)
+//   OR, if objects==true:
+//
+// OUTPUT: [ { "id": "urn:E1" }, { "id": "urn:E2" }, ... ]
+//
+KjNode* dbModelToEntityIdAndTypeObject(KjNode* localDbMatches, bool objects)
 {
   KjNode* matchIds = kjArray(orionldState.kjsonP, NULL);
 
@@ -58,9 +62,19 @@ KjNode* dbModelToEntityIdAndTypeObject(KjNode* localDbMatches)
     if (idP == NULL)
       continue;   // DB Error !!!
 
-    KjNode* idNodeP = kjString(orionldState.kjsonP, NULL, idP->value.s);
+    if (objects == false)
+    {
+      KjNode* idNodeP = kjString(orionldState.kjsonP, NULL, idP->value.s);
+      kjChildAdd(matchIds, idNodeP);
+    }
+    else
+    {
+      KjNode* idObjectNodeP = kjObject(orionldState.kjsonP, NULL);
+      KjNode* idNodeP       = kjString(orionldState.kjsonP, "id", idP->value.s);
 
-    kjChildAdd(matchIds, idNodeP);
+      kjChildAdd(idObjectNodeP, idNodeP);
+      kjChildAdd(matchIds, idObjectNodeP);
+    }
   }
 
   return matchIds;

--- a/src/lib/orionld/dbModel/dbModelToEntityIdAndTypeObject.h
+++ b/src/lib/orionld/dbModel/dbModelToEntityIdAndTypeObject.h
@@ -39,6 +39,6 @@ extern "C"
 // INPUT:  [ { "_id": { "id": "urn:E1", "type": "urn:...:T1" } }, { "_id": { "id": "urn:E2", "type": "urn:...:T2" } }, ... ]
 // OUTPUT: { "urn:E1": "urn:...:T1", "urn:E2", "urn:...:T2" }
 //
-extern KjNode* dbModelToEntityIdAndTypeObject(KjNode* localDbMatches);
+extern KjNode* dbModelToEntityIdAndTypeObject(KjNode* localDbMatches, bool objects);
 
 #endif  // SRC_LIB_ORIONLD_DBMODEL_DBMODELTOENTITYIDANDTYPEOBJECT_H_

--- a/src/lib/orionld/distOp/distOpSend.cpp
+++ b/src/lib/orionld/distOp/distOpSend.cpp
@@ -484,8 +484,13 @@ bool distOpSend(DistOp* distOpP, const char* dateHeader, const char* xForwardedF
     //
     if (orionldState.verb == HTTP_GET)
     {
-      if (distOpP->onlyIds == true)
-        uriParamAdd(&urlParts, "onlyIds=true", NULL, 12);
+      LM_T(LmtEntityMap, ("distOpP->entityMap == %s", (distOpP->entityMap == true)? "true" : "false"));
+
+      if (distOpP->entityMap == true)
+      {
+        LM_W(("********************************************** Adding pick=id as URL param"));
+        uriParamAdd(&urlParts, "pick=id", NULL, 7);
+      }
       else
         uriParamAdd(&urlParts, "options=sysAttrs", NULL, 16);
     }

--- a/src/lib/orionld/distOp/distOpsSend.cpp
+++ b/src/lib/orionld/distOp/distOpsSend.cpp
@@ -27,7 +27,7 @@
 
 #include "orionld/types/DistOp.h"                                   // DistOp
 #include "orionld/common/orionldState.h"                            // orionldState
-#include "orionld/distOp/distOpSend.h"                              // distOpSend
+#include "orionld/distOp/distOpSend.h"                              // istOpSend
 #include "orionld/distOp/xForwardedForCompose.h"                    // xForwardedForCompose
 #include "orionld/distOp/viaCompose.h"                              // viaCompose
 #include "orionld/distOp/distOpsSend.h"                             // Own interface
@@ -52,7 +52,7 @@ int distOpsSend(DistOp* distOpList, bool local)
     // Send the forwarded request and await all responses
     if ((distOpP->regP != NULL) && (distOpP->error == false))
     {
-      distOpP->onlyIds = true;
+      distOpP->entityMap = true;
 
       if (distOpSend(distOpP, dateHeader, xff, via, local, NULL) == 0)
         distOpP->error = false;
@@ -120,7 +120,8 @@ int distOpsSend2(DistOpListItem* distOpList)
     // Send the forwarded request and await all responses
     if ((distOpP->regP != NULL) && (distOpP->error == false))
     {
-      distOpP->onlyIds = false;
+      distOpP->entityMap = false;
+      LM_T(LmtEntityMap, ("Setting distOpP->entityMap to '%s'", (distOpP->entityMap == true)? "true" : "false"));
 
       if (distOpSend(distOpP, dateHeader, xff, via, false, doItemP->entityIds) == 0)
         distOpP->error = false;

--- a/src/lib/orionld/entityMaps/entityMapCreate.cpp
+++ b/src/lib/orionld/entityMaps/entityMapCreate.cpp
@@ -118,7 +118,7 @@ static int idListResponse(DistOp* distOpP, void* callbackParam)
 
   if ((distOpP->httpResponseCode == 200) && (distOpP->responseBody != NULL))
   {
-    kjTreeLog(distOpP->responseBody, "DistOp RESPONSE", LmtCount);
+    kjTreeLog(distOpP->responseBody, "DistOp RESPONSE", LmtEntityMap);
     for (KjNode* eIdNodeP = distOpP->responseBody->value.firstChildP; eIdNodeP != NULL; eIdNodeP = eIdNodeP->next)
     {
       // FIXME: The response is supposed to be an array of entity ids
@@ -127,7 +127,7 @@ static int idListResponse(DistOp* distOpP, void* callbackParam)
       //        This is an UGLY attempt to "make it work"
       //
       KjNode* eP = (eIdNodeP->type == KjObject)? kjLookup(eIdNodeP, "id") : eIdNodeP;
-      LM_T(LmtCount, ("JSON Type of array item: %s", kjValueType(eIdNodeP->type)));
+      LM_T(LmtEntityMap, ("JSON Type of array item: %s", kjValueType(eIdNodeP->type)));
 
       char* entityId = eP->value.s;
 
@@ -167,6 +167,8 @@ static void distOpMatchIdsRequest(DistOp* distOpList, EntityMap* entityMap)
 //
 EntityMap* entityMapCreate(DistOp* distOpList, char* idPattern, QNode* qNode, OrionldGeoInfo* geoInfoP)
 {
+  LM_T(LmtEntityMap, ("Creating an entity map"));
+
   EntityMap* entityMap = (EntityMap*) malloc(sizeof(EntityMap));
   if (entityMap == NULL)
     LM_X(1, ("Out of memory allocating a memory map"));
@@ -177,7 +179,7 @@ EntityMap* entityMapCreate(DistOp* distOpList, char* idPattern, QNode* qNode, Or
 
   uuidGenerate(entityMap->id, sizeof(entityMap->id), "urn:ngsi-ld:entity-map:");
 
-  LM_T(LmtDistOpList, ("Created an entity map at %p (%s)", entityMap, entityMap->id));
+  LM_T(LmtEntityMap, ("Created an entity map at %p (%s)", entityMap, entityMap->id));
 
   //
   // Send requests to all matching registration-endpoints, to fill in the entity map
@@ -205,24 +207,31 @@ EntityMap* entityMapCreate(DistOp* distOpList, char* idPattern, QNode* qNode, Or
   orionldState.uriParams.offset = 0;
   orionldState.uriParams.limit  = 1000;
 
+  StringArray pickList;
+  char*       pickListArray[2];
+
+  pickList.items = 1;
+  pickListArray[0] = (char*) "id";
+  pickListArray[1] = NULL;
+  pickList.array   = pickListArray;
+
   KjNode* localDbMatches = mongocEntitiesQuery(&orionldState.in.typeList,
                                                &orionldState.in.idList,
                                                idPattern,
                                                &orionldState.in.attrList,
+                                               &pickList,
                                                qNode,
                                                geoInfoP,
                                                NULL,
                                                geojsonGeometryLongName,
-                                               orionldState.uriParams.orderBy,
-                                               true,
-                                               false);
+                                               orionldState.uriParams.orderBy);
 
   orionldState.uriParams.offset = offset;
   orionldState.uriParams.limit  = limit;
 
   if (localDbMatches != NULL)
   {
-    localEntityV = dbModelToEntityIdAndTypeObject(localDbMatches);
+    localEntityV = dbModelToEntityIdAndTypeObject(localDbMatches, false);
     LM_T(LmtEntityMap, ("Adding local entities to the entityMap"));
 
     for (KjNode* eidNodeP = localEntityV->value.firstChildP; eidNodeP != NULL; eidNodeP = eidNodeP->next)

--- a/src/lib/orionld/mhd/mhdConnectionInit.cpp
+++ b/src/lib/orionld/mhd/mhdConnectionInit.cpp
@@ -979,21 +979,6 @@ MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* 
 
     orionldState.uriParams.mask |= ORIONLD_URIPARAM_ENTITYMAP;
   }
-  else if (strcmp(key, "onlyIds") == 0)
-  {
-    if (strcmp(value, "true") == 0)
-    {
-      orionldState.uriParams.onlyIds = true;
-      LM_T(LmtCount, ("onlyIds is ON"));
-    }
-    else if (strcmp(key, "false") != 0)
-    {
-      orionldError(OrionldBadRequestData, "Invalid value for uri parameter /onlyIds/", value, 400);
-      return MHD_YES;
-    }
-
-    orionldState.uriParams.mask |= ORIONLD_URIPARAM_ONLYIDS;
-  }
   else if (strcmp(key, "entity::type") == 0)  // Is NGSIv1 ?entity::type=X the same as NGSIv2 ?type=X ?
   {
     orionldState.uriParams.type = (char*) value;

--- a/src/lib/orionld/mongoc/mongocAuxAttributesFilter.cpp
+++ b/src/lib/orionld/mongoc/mongocAuxAttributesFilter.cpp
@@ -40,13 +40,13 @@ extern "C"
 //
 // mongocAuxAttributesFilter -
 //
-bool mongocAuxAttributesFilter(bson_t* mongoFilterP, StringArray* attrList, bson_t* projectionP, const char* geojsonGeometry, bool onlyIds)
+bool mongocAuxAttributesFilter(bson_t* mongoFilterP, StringArray* attrList, bson_t* projectionP, const char* geojsonGeometry, bool entityIdsOnly)
 {
   char    path[512];  // Assuming 512 is always enough ...
   bson_t  exists;
   bool    geojsonGeometryToProjection = (geojsonGeometry == NULL)? false : true;  // if GEOJSON, the "geometry" must be present
 
-  if (onlyIds == true)
+  if (entityIdsOnly == true)
     geojsonGeometryToProjection = false;
 
   bson_init(&exists);
@@ -77,7 +77,7 @@ bool mongocAuxAttributesFilter(bson_t* mongoFilterP, StringArray* attrList, bson
 
     bson_append_document(&attrExists, path, len, &exists);
 
-    if (onlyIds == false)
+    if (entityIdsOnly == false)
       bson_append_bool(projectionP, path, len, true);
 
     bson_append_document(&array, &num[2-numLen], numLen, &attrExists);
@@ -101,7 +101,7 @@ bool mongocAuxAttributesFilter(bson_t* mongoFilterP, StringArray* attrList, bson
   //
   // Then "@datasets.X" - geojsonGeometryToProjection is already taken care of by "attrs" loop
   //
-  if (onlyIds == false)
+  if (entityIdsOnly == false)
   {
     int offset = attrList->items;
     for (int ix = 0; ix < attrList->items; ix++)

--- a/src/lib/orionld/mongoc/mongocAuxAttributesFilter.h
+++ b/src/lib/orionld/mongoc/mongocAuxAttributesFilter.h
@@ -40,6 +40,6 @@ extern "C"
 //
 // mongocAuxAttributesFilter -
 //
-extern bool mongocAuxAttributesFilter(bson_t* mongoFilterP, StringArray* attrList, bson_t* projectionP, const char* geojsonGeometry, bool onlyIds);
+extern bool mongocAuxAttributesFilter(bson_t* mongoFilterP, StringArray* attrList, bson_t* projectionP, const char* geojsonGeometry, bool entityIdsOnly);
 
 #endif  // SRC_LIB_ORIONLD_MONGOC_MONGOCAUXATTRIBUTESFILTER_H_

--- a/src/lib/orionld/mongoc/mongocEntitiesQuery.cpp
+++ b/src/lib/orionld/mongoc/mongocEntitiesQuery.cpp
@@ -658,19 +658,35 @@ KjNode* mongocEntitiesQuery
   StringArray*     entityIdList,
   const char*      entityIdPattern,
   StringArray*     attrList,
+  StringArray*     pickList,
   QNode*           qNode,
   OrionldGeoInfo*  geoInfoP,
   int64_t*         countP,
   const char*      geojsonGeometry,
-  const char*      orderBy,
-  bool             onlyIds,
-  bool             onlyIdAndType
+  const char*      orderBy
 )
 {
   if ((attrList != NULL) && (attrList->items > 99))
   {
     orionldError(OrionldBadRequestData, "Too many attributes", "maximum is 99", 400);
     return NULL;
+  }
+
+  //
+  // Just asking for entity id?
+  //
+  bool entityIdsOnly = false;
+  bool onlyIdAndType = false;
+
+  if (pickList != NULL)
+  {
+    if ((pickList->items == 1) && (strcmp(pickList->array[0], "id") == 0))
+      entityIdsOnly = true;
+    else if (pickList->items == 2)
+    {
+      if ((stringArrayLookup(pickList, "id") == true) && (stringArrayLookup(pickList, "type") == true))
+        onlyIdAndType = true;
+    }
   }
 
   bson_t                mongoFilter;
@@ -690,7 +706,7 @@ KjNode* mongocEntitiesQuery
   bson_init(&options);
   bson_init(&projection);
 
-  if (onlyIds == false)
+  if (entityIdsOnly == false)
   {
     bson_t sortDoc;
     int    limit       = orionldState.uriParams.limit;
@@ -790,12 +806,12 @@ KjNode* mongocEntitiesQuery
   // Attribute List
   if ((attrList != NULL) && (attrList->items > 0))
   {
-    if (mongocAuxAttributesFilter(&mongoFilter, attrList, &projection, geojsonGeometry, onlyIds) == false)
+    if (mongocAuxAttributesFilter(&mongoFilter, attrList, &projection, geojsonGeometry, entityIdsOnly) == false)
       return NULL;
   }
   else
   {
-    if (onlyIds == false)
+    if (entityIdsOnly == false)
     {
       bson_append_bool(&projection, "attrs",     5, true);
       bson_append_bool(&projection, "@datasets", 9, true);

--- a/src/lib/orionld/mongoc/mongocEntitiesQuery.h
+++ b/src/lib/orionld/mongoc/mongocEntitiesQuery.h
@@ -46,13 +46,12 @@ extern KjNode* mongocEntitiesQuery
   StringArray*     entityIdList,
   const char*      entityIdPattern,
   StringArray*     attrList,
+  StringArray*     pickList,
   QNode*           qNode,
   OrionldGeoInfo*  geoInfoP,
   int64_t*         countP,
   const char*      geojsonGeometry,
-  const char*      orderBy,
-  bool             onlyIds,
-  bool             onlyIdAndType
+  const char*      orderBy
 );
 
 #endif  // SRC_LIB_ORIONLD_MONGOC_MONGOCENTITIESQUERY_H_

--- a/src/lib/orionld/payloadCheck/pcheckInformationItem.cpp
+++ b/src/lib/orionld/payloadCheck/pcheckInformationItem.cpp
@@ -307,7 +307,7 @@ bool pCheckOverlappingEntities(KjNode* entitiesP, KjNode* propertiesP, KjNode* r
 
   if (entitiesP == NULL)
   {
-    KjNode* entityArray = mongocEntitiesQuery(NULL, NULL, NULL, &attrsV, NULL, NULL, NULL, NULL, orionldState.uriParams.orderBy, false, false);
+    KjNode* entityArray = mongocEntitiesQuery(NULL, NULL, NULL, &attrsV, NULL, NULL, NULL, NULL, NULL, orionldState.uriParams.orderBy);
     if ((entityArray != NULL) && (entityArray->value.firstChildP != NULL))
     {
       KjNode*      _idP = kjLookup(entityArray->value.firstChildP, "_id");
@@ -350,7 +350,7 @@ bool pCheckOverlappingEntities(KjNode* entitiesP, KjNode* propertiesP, KjNode* r
         entityTypeList.array = entityTypeArray;
         entityTypeArray[0]   = entityType;
 
-        KjNode* entityArray = mongocEntitiesQuery(&entityTypeList, NULL, entityIdPattern, &attrsV, NULL, NULL, NULL, NULL, NULL, false, false);
+        KjNode* entityArray = mongocEntitiesQuery(&entityTypeList, NULL, entityIdPattern, &attrsV, NULL, NULL, NULL, NULL, NULL, NULL);
         if ((entityArray != NULL) && (entityArray->value.firstChildP != NULL))
         {
           KjNode*      _idP = kjLookup(entityArray->value.firstChildP, "_id");

--- a/src/lib/orionld/service/orionldServiceInit.cpp
+++ b/src/lib/orionld/service/orionldServiceInit.cpp
@@ -244,7 +244,6 @@ static void restServicePrepare(OrionLdRestService* serviceP, OrionLdRestServiceS
     serviceP->uriParams |= ORIONLD_URIPARAM_GEOMETRYPROPERTY;
     serviceP->uriParams |= ORIONLD_URIPARAM_LANG;
     serviceP->uriParams |= ORIONLD_URIPARAM_LOCAL;
-    serviceP->uriParams |= ORIONLD_URIPARAM_ONLYIDS;
     serviceP->uriParams |= ORIONLD_URIPARAM_ENTITYMAP;
     serviceP->uriParams |= ORIONLD_URIPARAM_ORDERBY;
     serviceP->uriParams |= ORIONLD_URIPARAM_REVERSE;

--- a/src/lib/orionld/serviceRoutines/orionldDeleteEntities.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldDeleteEntities.cpp
@@ -162,13 +162,12 @@ bool orionldDeleteEntities(void)
                                                          &orionldState.in.idList,
                                                          idPattern,
                                                          &orionldState.in.attrList,
+                                                         NULL,
                                                          qNode,
                                                          &geoInfo,
                                                          &count,
                                                          geojsonGeometryLongName,
-                                                         NULL,
-                                                         false,
-                                                         true);
+                                                         NULL);
   //
   // Create the alterations
   //

--- a/src/lib/orionld/serviceRoutines/orionldGetEntities.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntities.cpp
@@ -104,8 +104,6 @@ bool orionldGetEntities(void)
   bool    local     = orionldState.uriParams.local;
   QNode*  qNode     = NULL;
 
-  LM_T(LmtEntityMap, ("onlyIds: %s", (orionldState.uriParams.onlyIds == true)? "TRUE" : "FALSE"));
-
   // According to the spec, id takes precedence over idPattern, so, if both are present, idPattern is NULLed out
   if ((orionldState.in.idList.items > 0) && (orionldState.uriParams.idPattern != NULL))
     idPattern = NULL;
@@ -148,13 +146,13 @@ bool orionldGetEntities(void)
     return orionldGetEntitiesLocal(&orionldState.in.typeList,
                                    &orionldState.in.idList,
                                    &orionldState.in.attrList,
+                                   &orionldState.in.pickList,
                                    idPattern,
                                    qNode,
                                    &geoInfo,
                                    orionldState.uriParams.lang,
                                    orionldState.uriParamOptions.sysAttrs,
                                    orionldState.uriParams.geometryProperty,
-                                   orionldState.uriParams.onlyIds,
                                    false);
 
   if (orionldState.in.entityMap == NULL)  // No prior entity map is requested - must create a new one
@@ -171,13 +169,13 @@ bool orionldGetEntities(void)
       return orionldGetEntitiesLocal(&orionldState.in.typeList,
                                      &orionldState.in.idList,
                                      &orionldState.in.attrList,
+                                     &orionldState.in.pickList,
                                      idPattern,
                                      qNode,
                                      &geoInfo,
                                      orionldState.uriParams.lang,
                                      orionldState.uriParamOptions.sysAttrs,
                                      orionldState.uriParams.geometryProperty,
-                                     orionldState.uriParams.onlyIds,
                                      true);
 
     // Create the "@none" DistOp

--- a/src/lib/orionld/serviceRoutines/orionldGetEntitiesDistributed.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntitiesDistributed.cpp
@@ -151,10 +151,11 @@ extern "C"
 //
 bool orionldGetEntitiesDistributed(DistOp* distOpList, char* idPattern, QNode* qNode, OrionldGeoInfo* geoInfoP)
 {
+  LM_T(LmtEntityMap, ("orionldState.in.entityMap at %p", orionldState.in.entityMap));
   if (orionldState.in.entityMap != NULL)
     return orionldGetEntitiesPage();
 
-  LM_T(LmtCount, ("--------------------------- Creating entity map"));
+  LM_T(LmtEntityMap, ("--------------------------- Creating entity map"));
   orionldState.in.entityMap = entityMapCreate(distOpList, idPattern, qNode, geoInfoP);
   distOpListRelease(distOpList);
 
@@ -190,13 +191,13 @@ bool orionldGetEntitiesDistributed(DistOp* distOpList, char* idPattern, QNode* q
     return orionldGetEntitiesLocal(&orionldState.in.typeList,
                                    &orionldState.in.idList,
                                    &orionldState.in.attrList,
+                                   &orionldState.in.pickList,
                                    idPattern,
                                    qNode,
                                    geoInfoP,
                                    orionldState.uriParams.lang,
                                    orionldState.uriParamOptions.sysAttrs,
                                    orionldState.uriParams.geometryProperty,
-                                   orionldState.uriParams.onlyIds,
                                    true);
 
   return orionldGetEntitiesPage();

--- a/src/lib/orionld/serviceRoutines/orionldGetEntitiesLocal.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntitiesLocal.cpp
@@ -162,13 +162,13 @@ bool orionldGetEntitiesLocal
   StringArray*     typeList,
   StringArray*     idList,
   StringArray*     attrList,
+  StringArray*     pickList,
   char*            idPattern,
   QNode*           qNode,
   OrionldGeoInfo*  geoInfoP,
   const char*      lang,
   bool             sysAttrs,
   const char*      geometryProperty,
-  bool             onlyIds,
   bool             countHeaderAlreadyAdded
 )
 {
@@ -187,20 +187,19 @@ bool orionldGetEntitiesLocal
                                                     idList,
                                                     idPattern,
                                                     attrList,
+                                                    pickList,
                                                     qNode,
                                                     geoInfoP,
                                                     &count,
                                                     geojsonGeometryLongName,
-                                                    orionldState.uriParams.orderBy,
-                                                    onlyIds,
-                                                    false);
+                                                    orionldState.uriParams.orderBy);
 
   if (dbEntityArray == NULL)
     return false;
 
-  if (onlyIds == true)
+  if ((pickList->items == 1) && (strcmp(pickList->array[0], "id") == 0))
   {
-    orionldState.responseTree = dbModelToEntityIdAndTypeObject(dbEntityArray);
+    orionldState.responseTree = dbModelToEntityIdAndTypeObject(dbEntityArray, true);
     orionldState.noLinkHeader = true;
   }
   else
@@ -258,6 +257,7 @@ bool orionldGetEntitiesLocal
   if (orionldState.responseTree->value.firstChildP == NULL)
     orionldState.noLinkHeader = true;
 
+  kjTreeLog(orionldState.responseTree, "Response Tree", LmtPick);
   if (orionldState.in.pickList.items > 0)
     pickForEntityArray();
 

--- a/src/lib/orionld/serviceRoutines/orionldGetEntitiesLocal.h
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntitiesLocal.h
@@ -39,13 +39,13 @@ extern bool orionldGetEntitiesLocal
   StringArray*     typeList,
   StringArray*     idList,
   StringArray*     attrList,
+  StringArray*     pickList,
   char*            idPattern,
   QNode*           qNode,
   OrionldGeoInfo*  geoInfoP,
   const char*      lang,
   bool             sysAttrs,
   const char*      geometryProperty,
-  bool             onlyIds,
   bool             countHeaderAlreadyAdded
 );
 

--- a/src/lib/orionld/serviceRoutines/orionldGetEntitiesPage.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldGetEntitiesPage.cpp
@@ -259,17 +259,17 @@ bool orionldGetEntitiesPage(void)
   }
 
   DistOpListItem* distOpListItem = NULL;
+  LM_T(LmtEntityMap, ("Sending the distOp requests for the entity map"));
   for (KjNode* sourceP = sources->value.firstChildP; sourceP != NULL; sourceP = sourceP->next)
   {
     if (strcmp(sourceP->name, "@none") == 0)
     {
-      LM_T(LmtDistOpList, ("orionldState.distOpList at %p", orionldState.distOpList));
       DistOp* distOpP = distOpLookupByRegId(orionldState.distOpList, "@none");
+      LM_T(LmtEntityMap, ("distOpP->entityMap == %s", (distOpP->entityMap == true)? "true" : "false"));
 
       // Local query - set input params for orionldGetEntitiesLocal
 
       // We want the entire entity this time, not only the entity id
-      orionldState.uriParams.onlyIds = false;
 
       // The type doesn't matter, we have a list of entity ids
       orionldState.in.typeList.items = 0;
@@ -311,13 +311,13 @@ bool orionldGetEntitiesPage(void)
       orionldGetEntitiesLocal(distOpP->typeList,
                               distOpP->idList,
                               &orionldState.in.attrList,
+                              &orionldState.in.pickList,
                               NULL,
                               distOpP->qNode,
                               &distOpP->geoInfo,
                               distOpP->lang,
                               true,                        // sysAttrs needed, to help pick attributes in case more than one of the same
                               distOpP->geometryProperty,
-                              false,
                               true);
 
       // Response comes in orionldState.responseTree - move those to entityArray

--- a/src/lib/orionld/serviceRoutines/orionldPostBatchCreate.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostBatchCreate.cpp
@@ -118,7 +118,7 @@ bool orionldPostBatchCreate(void)
   //
   // FIXME: Use simpler mongoc function - we only need to know whether the entities exist or not
   //
-  KjNode* dbEntityArray = mongocEntitiesQuery(NULL, &eIdArray, NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false);
+  KjNode* dbEntityArray = mongocEntitiesQuery(NULL, &eIdArray, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
   if (dbEntityArray == NULL)
   {
     orionldError(OrionldInternalError, "Database Error", "error querying the database for entities", 500);

--- a/src/lib/orionld/serviceRoutines/orionldPostBatchUpdate.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostBatchUpdate.cpp
@@ -108,7 +108,7 @@ bool orionldPostBatchUpdate(void)
   //
   // The entity id array is ready - time to query mongo
   //
-  KjNode* dbEntityArray = mongocEntitiesQuery(NULL, &eIdArray, NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false);
+  KjNode* dbEntityArray = mongocEntitiesQuery(NULL, &eIdArray, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
   if (dbEntityArray == NULL)
   {
     orionldError(OrionldInternalError, "Database Error", "error querying the database for entities", 500);

--- a/src/lib/orionld/serviceRoutines/orionldPostBatchUpsert.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPostBatchUpsert.cpp
@@ -173,7 +173,7 @@ bool orionldPostBatchUpsert(void)
   //
   orionldState.uriParams.limit  = noOfEntities;
   orionldState.uriParams.offset = 0;
-  KjNode* dbEntityArray = mongocEntitiesQuery(NULL, &eIdArray, NULL, NULL, NULL, NULL, NULL, NULL, orionldState.uriParams.orderBy, false, false);
+  KjNode* dbEntityArray = mongocEntitiesQuery(NULL, &eIdArray, NULL, NULL, NULL, NULL, NULL, NULL, NULL, orionldState.uriParams.orderBy);
   if (dbEntityArray == NULL)
   {
     orionldError(OrionldInternalError, "Database Error", "error querying the database for entities", 500);

--- a/src/lib/orionld/types/DistOp.h
+++ b/src/lib/orionld/types/DistOp.h
@@ -65,7 +65,7 @@ typedef struct DistOp
 
   StringArray*        idList;            // Used by GET /entities (unless entityId is used)
   StringArray*        typeList;          // Used by GET /entities (unless entityType is used)
-  bool                onlyIds;           // Used to compile the list of entity ids in the preparation for GET /entities
+  bool                entityMap;         // Used to compile the list of entity ids in the preparation for GET /entities
 
   OrionldGeoInfo      geoInfo;
   QNode*              qNode;

--- a/src/lib/orionld/types/OrionLdRestService.h
+++ b/src/lib/orionld/types/OrionLdRestService.h
@@ -152,7 +152,7 @@ typedef struct OrionLdRestServiceSimplifiedVector
 #define ORIONLD_URIPARAM_LOCAL                (UINT64_C(1) << 35)
 #define ORIONLD_URIPARAM_RESET                (UINT64_C(1) << 36)
 #define ORIONLD_URIPARAM_LEVEL                (UINT64_C(1) << 37)
-#define ORIONLD_URIPARAM_ONLYIDS              (UINT64_C(1) << 38)
+
 #define ORIONLD_URIPARAM_ENTITYMAP            (UINT64_C(1) << 39)
 #define ORIONLD_URIPARAM_FORMAT               (UINT64_C(1) << 40)
 #define ORIONLD_URIPARAM_EXPAND_VALUES        (UINT64_C(1) << 41)

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_pick.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_pick.test
@@ -208,7 +208,6 @@ HTTP/1.1 200 OK
 Content-Length: 49
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
 NGSILD-EntityMap: urn:ngsi-ld:entity-map:REGEX(.*)
 
 [

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entityMap_simple.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entityMap_simple.test
@@ -1,0 +1,249 @@
+# Copyright 2025 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Simple entityMap
+
+--SHELL-INIT--
+dbInit CB
+dbInit CP1
+dbInit CP2
+orionldStart CB  -experimental -forwarding -wip entityMaps
+orionldStart CP1 -experimental
+orionldStart CP2 -experimental
+
+--SHELL--
+#
+# 01. In CB,  create an entity urn:E1 with attribute  P0
+# 02. In CP1, create an entity urn:E1 with attributes P1-P3+R1
+# 03. In CP2, Create an entity urn:E1 with attributes P1-P3+R1
+# 03. Create an exclusive registration R1 on urn:E1/P1 for CP1  (on urn:E1 only)
+# 07. Create a  redirect  registration R2 on urn:E1/P2 for CP2  (on urn:E1 only)
+# 04. GET /entities - see urn:E1 with 3 attributes
+# 05. GET /entityMaps/* - see the entityMap with urn:E1 and its registration + URLs
+#
+
+echo "01. In CB,  create an entity urn:E1 with attribute P0"
+echo "====================================================="
+payload='{
+  "id": "urn:E1",
+  "type": "T",
+  "P0": "In CB"
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "02. In CP1, create an entity urn:E1 with attributes P1-P3+R1"
+echo "============================================================"
+payload='{
+  "id": "urn:E1",
+  "type": "T",
+  "P1": "P1 in CP1",
+  "P2": "P2 in CP1",
+  "P3": "P3 in CP1",
+  "R1": { "object": "urn:in:cp1" }
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload" --port $CP1_PORT
+echo
+echo
+
+
+echo "03. In CP2, Create an entity urn:E1 with attributes P1-P3+R1"
+echo "============================================================"
+payload='{
+  "id": "urn:E1",
+  "type": "T",
+  "P1": "P1 in CP2",
+  "P2": "P2 in CP2",
+  "P3": "P3 in CP2",
+  "R1": { "object": "urn:in:cp2" }
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload" --port $CP2_PORT
+echo
+echo
+
+
+echo "03. Create an exclusive registration R1 on urn:E1/P1 for CP1"
+echo "============================================================"
+payload='{
+  "id": "urn:Reg1",
+  "type": "ContextSourceRegistration",
+  "information": [
+    {
+      "entities": [
+        {
+          "id": "urn:E1",
+          "type": "T"
+        }
+      ],
+      "propertyNames": [ "P1" ]
+    }
+  ],
+  "mode": "exclusive",
+  "operations": [ "queryEntity" ],
+  "endpoint": "http://localhost:'$CP1_PORT'"
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload"
+echo
+echo
+
+
+echo "07. Create a  redirect  registration R2 on urn:E1/P2 for CP2"
+echo "============================================================"
+payload='{
+  "id": "urn:Reg2",
+  "type": "ContextSourceRegistration",
+  "information": [
+    {
+      "entities": [
+        {
+          "id": "urn:E1",
+          "type": "T"
+        }
+      ],
+      "propertyNames": [ "P2" ]
+    }
+  ],
+  "mode": "redirect",
+  "operations": [ "queryEntity" ],
+  "endpoint": "http://localhost:'$CP2_PORT'"
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload"
+echo
+echo
+
+
+echo "04. GET /entities - see urn:E1 with 3 attributes"
+echo "================================================"
+orionCurl --url "/ngsi-ld/v1/entities?type=T"
+entityMap=$(echo "$_responseHeaders" | grep NGSILD-EntityMap: | awk -F ': ' '{ print $2 }' | tr -d "\r\n")
+echo
+echo
+
+
+echo "05. GET /entityMaps/* - see the entityMap with urn:E1 and its registration + URLs"
+echo "================================================================================="
+orionCurl --url /ngsi-ld/v1/entityMaps/$entityMap
+echo
+echo
+
+
+--REGEXPECT--
+01. In CB,  create an entity urn:E1 with attribute P0
+=====================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:E1
+
+
+
+02. In CP1, create an entity urn:E1 with attributes P1-P3+R1
+============================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:E1
+
+
+
+03. In CP2, Create an entity urn:E1 with attributes P1-P3+R1
+============================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:E1
+
+
+
+03. Create an exclusive registration R1 on urn:E1/P1 for CP1
+============================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/csourceRegistrations/urn:Reg1
+
+
+
+07. Create a  redirect  registration R2 on urn:E1/P2 for CP2
+============================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/csourceRegistrations/urn:Reg2
+
+
+
+04. GET /entities - see urn:E1 with 3 attributes
+================================================
+HTTP/1.1 200 OK
+Content-Length: 159
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+NGSILD-EntityMap: urn:ngsi-ld:entity-map:REGEX(.*)
+
+[
+    {
+        "P0": {
+            "type": "Property",
+            "value": "In CB"
+        },
+        "P1": {
+            "type": "Property",
+            "value": "P1 in CP1"
+        },
+        "P2": {
+            "type": "Property",
+            "value": "P2 in CP2"
+        },
+        "id": "urn:E1",
+        "type": "T"
+    }
+]
+
+
+05. GET /entityMaps/* - see the entityMap with urn:E1 and its registration + URLs
+=================================================================================
+HTTP/1.1 200 OK
+Content-Length: 42
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "urn:E1": [
+        "@none",
+        "urn:Reg1",
+        "urn:Reg2"
+    ]
+}
+
+
+--TEARDOWN---
+brokerStop CB
+brokerStop CP1
+brokerStop CP2
+dbDrop CB
+dbDrop CP1
+dbDrop CP2

--- a/test/functionalTest/cases/0000_ngsild/ngsild_forward_get_entities.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_forward_get_entities.test
@@ -46,7 +46,7 @@ orionldStart CP3 -experimental
 # 07. Create a registration for all CP2 entities in CB
 # 08. Create a registration for all CP3 entities in CB
 # 09. Create a registration for E1 and E2 in CP3, using 2 information array items
-# 10. Local query on CB for all entities of type T, with onlyIds=true set
+# 10. Local query on CB for all entities of type T, with pick=id
 # 11. Query CB for all entities (they're all type 'T')
 # 12. See the entity map
 # 13. Query using the entity map I got from step 11
@@ -252,9 +252,9 @@ echo
 echo
 
 
-echo "10. Local query on CB for all entities of type T, with onlyIds=true set"
-echo "======================================================================="
-orionCurl --url '/ngsi-ld/v1/entities?type=T&onlyIds=true&local=true'
+echo "10. Local query on CB for all entities of type T, with pick=id"
+echo "=============================================================="
+orionCurl --url '/ngsi-ld/v1/entities?type=T&pick=id&local=true'
 echo
 echo
 
@@ -390,8 +390,8 @@ Location: /ngsi-ld/v1/csourceRegistrations/urn:Reg4
 
 
 
-10. Local query on CB for all entities of type T, with onlyIds=true set
-=======================================================================
+10. Local query on CB for all entities of type T, with pick=id
+==============================================================
 HTTP/1.1 200 OK
 Content-Length: 221
 Content-Type: application/json

--- a/test/functionalTest/cases/0000_ngsild/ngsild_forward_get_entities.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_forward_get_entities.test
@@ -393,21 +393,41 @@ Location: /ngsi-ld/v1/csourceRegistrations/urn:Reg4
 10. Local query on CB for all entities of type T, with pick=id
 ==============================================================
 HTTP/1.1 200 OK
-Content-Length: 221
+Content-Length: 291
 Content-Type: application/json
 Date: REGEX(.*)
 
 [
-    "urn:cb:entities:E00",
-    "urn:cb:entities:E01",
-    "urn:cb:entities:E02",
-    "urn:cb:entities:E03",
-    "urn:cb:entities:E04",
-    "urn:cb:entities:E05",
-    "urn:cb:entities:E06",
-    "urn:cb:entities:E07",
-    "urn:cb:entities:E08",
-    "urn:cb:entities:E09"
+    {
+        "id": "urn:cb:entities:E00"
+    },
+    {
+        "id": "urn:cb:entities:E01"
+    },
+    {
+        "id": "urn:cb:entities:E02"
+    },
+    {
+        "id": "urn:cb:entities:E03"
+    },
+    {
+        "id": "urn:cb:entities:E04"
+    },
+    {
+        "id": "urn:cb:entities:E05"
+    },
+    {
+        "id": "urn:cb:entities:E06"
+    },
+    {
+        "id": "urn:cb:entities:E07"
+    },
+    {
+        "id": "urn:cb:entities:E08"
+    },
+    {
+        "id": "urn:cb:entities:E09"
+    }
 ]
 
 


### PR DESCRIPTION
To create entity maps, needed for distributed entity query (and pagination) was implemented using a URL parameter "idsOnly",
This was agreed upon in ETSI ISG CIM and put in the draft for v1.8.1.
Then we invented the "pick" URL parameter to replace "attrs", and we saw that "pick=id" can actually replace "idsOnly" as well.
So, "idsOnly" never got into the spec. However, Orion-LD had already implemented that, long before "pick" was invented.

This PR is about stopping the use of "idsOnly" and use "pick=id" instead.

As other brokers (Scorpio, Stellio, ...) don't support idsOnly, this is needed for Orion-LD to interoperate with other brokers.
Especially needed for the ETSI NGSI-LD plugtest coming up in the end of February 2025 (a little over a week from now).
