### PR TITLE
Issue/1760

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,8 +1,14 @@
 ## Fixed Issues:
-  #XXXX: ...
+  #1760: Support for multiple Link headers
 
 ## New Features:
   #XXXX: ...
 
 ## Notes
-* ...
+* Fixing the issue #1760, Orion-LD is now more strict about the syntax in the HTTP Link header for @contexts.
+  Before this fix, trhe following Link header was acepted:
+    Link: <URL to user context>
+  That's not valid HTTP so now, after the fix, the link header must have the 'rel' property set to exactly "http://www.w3.org/ns/json-ld#context":
+    Link: <URL to user context>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+  [ No check is made for the 'type' property' ]
+*

--- a/src/lib/logMsg/traceLevels.h
+++ b/src/lib/logMsg/traceLevels.h
@@ -100,6 +100,7 @@ typedef enum TraceLevels
   // Context
   //
   LmtContexts = 100,                   // Contexts
+  LmtContextInBody,                    // For Content-Type: application/ld+json
   LmtContextTree,                      // Context Tree
   LmtContextCache,                     // Context Cache
   LmtContextCacheStats,                // Context Cache Statistics
@@ -163,11 +164,12 @@ typedef enum TraceLevels
   LmtUriEncode,                        // YRL encode/decode results
   LmtBug,                              // Current bug being debugged
   LmtPick,                             // URI param 'pick'
+  LmtLinkHeader,                       // HTTP Header: Link
 
   //
   // Legacy
   //
-  LmtLegacy  = 220,                    // Old code (mongoBackend, json parsers, etc)
+  LmtLegacy  = 230,                    // Old code (mongoBackend, json parsers, etc)
   LmtLegacySubMatch,                   // Old code - update/subscription match for subs/notifs
   LmtLegacySubCacheRefresh,            // Old code - sub-cache-refresh
   LmtMongoPool,
@@ -175,7 +177,7 @@ typedef enum TraceLevels
   //
   // DDS
   //
-  LmtDds     = 230,                    // DDS
+  LmtDds     = 240,                    // DDS
 
   LmtCurl    = 250,                    // CURL library
   LmtToDo,                             // To Do list

--- a/src/lib/ngsiNotify/Notifier.cpp
+++ b/src/lib/ngsiNotify/Notifier.cpp
@@ -633,8 +633,7 @@ std::vector<SenderThreadParams*>* Notifier::buildSenderParams
     //
 
     //
-    // WARNING - Perhaps the Link should only be added if (subP->ldContext != "")   ?
-    // [ In the end, when mongoc is fully used, this function won't be used for NGSI-LD operations ]
+    // Add the Link header for the @context
     //
     if (subP != NULL)
     {

--- a/src/lib/orionld/common/responseFix.cpp
+++ b/src/lib/orionld/common/responseFix.cpp
@@ -29,10 +29,12 @@ extern "C"
 #include "kjson/kjBuilder.h"                                     // kjChildRemove
 }
 
-#include "orionld/http/httpHeaderLocationAdd.h"                  // httpHeaderLocationAdd
-#include "orionld/http/httpHeaderLinkAdd.h"                      // httpHeaderLinkAdd
+#include "logMsg/logMsg.h"                                       // Logging
+
 #include "orionld/types/DistOpType.h"                            // DistOpType
 #include "orionld/common/orionldState.h"                         // orionldState
+#include "orionld/http/httpHeaderLocationAdd.h"                  // httpHeaderLocationAdd
+#include "orionld/http/httpHeaderLinkAdd.h"                      // httpHeaderLinkAdd
 #include "orionld/kjTree/kjChildCount.h"                         // kjChildCount
 #include "orionld/kjTree/kjSort.h"                               // kjStringArraySort
 #include "orionld/common/responseFix.h"                          // Own interface

--- a/src/lib/orionld/distOp/distOpResponses.cpp
+++ b/src/lib/orionld/distOp/distOpResponses.cpp
@@ -263,6 +263,16 @@ void entityResponseAccumulate(DistOp* distOpP, KjNode* responseBody, KjNode* suc
     //
     distOpFailure(responseBody, distOpP, "Error during Distributed Operation", "Entity already exists", 409, NULL);
   }
+  else if (httpResponseCode == 404)
+  {
+    KjNode*     titleP  = (distOpP->responseBody != NULL)? kjLookup(distOpP->responseBody, "title")  : NULL;
+    KjNode*     detailP = (distOpP->responseBody != NULL)? kjLookup(distOpP->responseBody, "detail") : NULL;
+    const char* title   = (titleP  != NULL)? titleP->value.s : "Not Found";
+    const char* detail  = (detailP != NULL)? detailP->value.s : NULL;
+
+    orionldState.distOp.e404 += 1;
+    distOpFailure(responseBody, distOpP, title, detail, httpResponseCode, NULL);
+  }
   else if (httpResponseCode >= 400)
   {
     //
@@ -272,9 +282,6 @@ void entityResponseAccumulate(DistOp* distOpP, KjNode* responseBody, KjNode* suc
     KjNode*     detailP = (distOpP->responseBody != NULL)? kjLookup(distOpP->responseBody, "detail") : NULL;
     const char* title   = (titleP  != NULL)? titleP->value.s : "unspecified error from remote provider";
     const char* detail  = (detailP != NULL)? detailP->value.s : NULL;
-
-    if (httpResponseCode == 404)
-      orionldState.distOp.e404 += 1;
 
     distOpFailure(responseBody, distOpP, title, detail, httpResponseCode, NULL);
   }

--- a/src/lib/orionld/mhd/mhdConnectionInit.cpp
+++ b/src/lib/orionld/mhd/mhdConnectionInit.cpp
@@ -285,9 +285,9 @@ MimeType acceptHeaderParse(char* accept, bool textOk)
     // GET the MIME type, check for new winner
     // REMEMBER:  JSON is the default Mime Type and if equal weight, JSON wins
     //
-    LM_T(LmtMimeType, ("mimeV[%d]: '%s'", ix, mimeV[ix]));
+    // LM_T(LmtMimeType, ("mimeV[%d]: '%s'", ix, mimeV[ix]));
     mimeType                 = mimeTypeFromString(mimeV[ix], NULL, true, textOk, &orionldState.acceptMask);
-    LM_T(LmtMimeType, ("mimeType:   %d", mimeType));
+    // LM_T(LmtMimeType, ("mimeType:   %d", mimeType));
     orionldState.acceptMask |= (1 << mimeType);  // It's OK to include "NOMIMETYPE"
 
     if (mimeType > MT_NONE)
@@ -310,7 +310,7 @@ MimeType acceptHeaderParse(char* accept, bool textOk)
     }
   }
 
-  LM_T(LmtMimeType, ("winner: %d (%s)", winner, mimeType(winner)));
+  // LM_T(LmtMimeType, ("winner: %d (%s)", winner, mimeType(winner)));
   return winner;
 }
 
@@ -438,8 +438,18 @@ static MHD_Result orionldHttpHeaderReceive(void* cbDataP, MHD_ValueKind kind, co
   }
   else if (strcasecmp(key, "Link") == 0)
   {
-    orionldState.link                  = (char*) value;
-    orionldState.linkHttpHeaderPresent = true;
+    LM_T(LmtLinkHeader, ("Got a Link header: '%s'", orionldState.link));
+
+    if (strstr(value, "rel=\"http://www.w3.org/ns/json-ld#context\";") != NULL)
+    {
+      if (orionldState.link == NULL)
+      {
+        orionldState.link                  = (char*) value;
+        orionldState.linkHttpHeaderPresent = true;
+      }
+      else
+        orionldError(OrionldInternalError, "Invalid NGSI-LD request", "@context given in more than one Link header", 400);
+    }
   }
   else if ((strcasecmp(key, "Fiware-Service") == 0) || (strcasecmp(key, "NGSILD-Tenant") == 0))
   {
@@ -536,8 +546,6 @@ MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* 
     orionldError(OrionldBadRequestData, "Empty right-hand-side for a URI parameter", key, 400);
     return MHD_YES;
   }
-
-  LM_T(LmtUriParams, ("URI Param: %s=%s", key, value));
 
   //
   // Forbidden characters in URI param value - not for NGSI-LD - for now at least ...

--- a/src/lib/orionld/mhd/mhdConnectionTreat.cpp
+++ b/src/lib/orionld/mhd/mhdConnectionTreat.cpp
@@ -1325,7 +1325,7 @@ MHD_Result mhdConnectionTreat(void)
           allDone = true;
         }
       }
-      
+
       if ((orionldState.serviceP->serviceRoutine == orionldPostSubscriptions) || (orionldState.serviceP->serviceRoutine == orionldPatchSubscription))
       {
         implicitlyCreated = true;

--- a/src/lib/orionld/mhd/mhdConnectionTreat.cpp
+++ b/src/lib/orionld/mhd/mhdConnectionTreat.cpp
@@ -460,14 +460,15 @@ char* pCheckLinkHeader(char* link)
 static bool linkContextGet(char* link)
 {
   //
-  // The HTTP headers live in the thread. Once the thread dies, the memory is freed.
-  // When calling orionldContextFromUrl, the URL must be properly allocated.
-  // As it will be inserted in the Context Cache, that must survive requests, it must be
-  // allocated in the global allocation buffer 'kalloc', not the thread-local 'orionldState.kalloc'.
+  // NOTE:
+  //   The HTTP headers live in the thread. Once the thread dies, the memory is freed.
+  //   When calling orionldContextFromUrl, the URL must be properly allocated.
+  //   As it will be inserted in the Context Cache, that must survive requests, it must be
+  //   allocated in the global allocation buffer 'kalloc', not the thread-local 'orionldState.kalloc'.
+  //   This is done by the function orionldContextCreate.
   //
-  char* url = strdup(link);
 
-  orionldState.contextP = orionldContextFromUrl(url, NULL);
+  orionldState.contextP = orionldContextFromUrl(link, NULL);
   if (orionldState.contextP == NULL)
     LM_RE(false, ("orionldContextFromUrl returned NULL - no context!"));
 

--- a/src/lib/orionld/mhd/mhdConnectionTreat.cpp
+++ b/src/lib/orionld/mhd/mhdConnectionTreat.cpp
@@ -74,6 +74,7 @@ extern "C"
 #include "orionld/context/orionldContextUrlGenerate.h"             // orionldContextUrlGenerate
 #include "orionld/context/orionldContextItemExpand.h"              // orionldContextItemExpand
 #include "orionld/context/orionldAttributeExpand.h"                // orionldAttributeExpand
+#include "orionld/context/orionldContextSimplify.h"                // orionldContextSimplify
 #include "orionld/contextCache/orionldContextCachePersist.h"       // orionldContextCachePersist
 #include "orionld/serviceRoutines/orionldPatchAttribute.h"         // orionldPatchAttribute
 #include "orionld/serviceRoutines/orionldGetEntity.h"              // orionldGetEntity
@@ -311,7 +312,10 @@ static bool payloadParseAndExtractSpecialFields(bool* contextToBeCashedP)
           orionldError(OrionldBadRequestData, "Duplicated field", "@context", 400);
           return false;
         }
+
         orionldState.payloadContextNode = attrNodeP;
+        LM_T(LmtContextInBody, ("Found an @contest in the payload body - removing it and keeping it in orionldState.payloadContextNode"));
+        kjTreeLog(orionldState.payloadContextNode, "@context in body", LmtContextInBody);
 
         attrNodeP = orionldState.payloadContextNode->next;
         kjNodeDecouple(orionldState.requestTree, orionldState.payloadContextNode, prev);
@@ -417,6 +421,7 @@ static bool payloadParseAndExtractSpecialFields(bool* contextToBeCashedP)
 //
 char* pCheckLinkHeader(char* link)
 {
+  LM_T(LmtLinkHeader, ("link: '%s'", link));
   if (link[0] != '<')
   {
     orionldError(OrionldBadRequestData, "invalid Link HTTP header", "link doesn't start with '<'", 400);
@@ -440,9 +445,35 @@ char* pCheckLinkHeader(char* link)
   *cP = 0;  // End of string for the URL
 
   if (pCheckUri(linkStart, "Link", true) == false)
-    return NULL;
+    LM_RE(NULL, ("pCheckUri failed"));
 
+  LM_T(LmtLinkHeader, ("link: '%s'", linkStart));
   return linkStart;
+}
+
+
+
+// -----------------------------------------------------------------------------
+//
+// linkContext
+//
+static bool linkContextGet(char* link)
+{
+  //
+  // The HTTP headers live in the thread. Once the thread dies, the memory is freed.
+  // When calling orionldContextFromUrl, the URL must be properly allocated.
+  // As it will be inserted in the Context Cache, that must survive requests, it must be
+  // allocated in the global allocation buffer 'kalloc', not the thread-local 'orionldState.kalloc'.
+  //
+  char* url = strdup(link);
+
+  orionldState.contextP = orionldContextFromUrl(url, NULL);
+  if (orionldState.contextP == NULL)
+    LM_RE(false, ("orionldContextFromUrl returned NULL - no context!"));
+
+  orionldState.link = orionldState.contextP->url;
+
+  return true;
 }
 
 
@@ -451,21 +482,42 @@ char* pCheckLinkHeader(char* link)
 //
 // linkGet -
 //
-static bool linkGet(const char* link)
+static bool linkHeaderTreat(char* linkHeader)
 {
-  //
-  // The HTTP headers live in the thread. Once the thread dies, the mempry is freed.
-  // When calling orionldContextFromUrl, the URL must be properly allocated.
-  // As it will be inserted in the Context Cache, that must survive requests, it must be
-  // allocated in the global allocation buffer 'kalloc', not the thread-local 'orionldState.kalloc'.
-  //
-  char* url = kaStrdup(&kalloc, link);
+  LM_T(LmtLinkHeader, ("link: '%s'", linkHeader));
 
-  orionldState.contextP = orionldContextFromUrl(url, NULL);
-  if (orionldState.contextP == NULL)
-    LM_RE(false, ("orionldContextFromUrl returned NULL - no context!"));
+  char* linkV[32];
+  int   links   = kStringSplit(linkHeader, ',', linkV, K_VEC_SIZE(linkV));
+  bool  linkSet = false;
 
-  orionldState.link = orionldState.contextP->url;
+  for (int ix = 0; ix < links; ix++)
+  {
+    if (strstr(linkV[ix], "rel=\"http://www.w3.org/ns/json-ld#context\";") != NULL)
+    {
+      LM_T(LmtLinkHeader, ("Got an @context Link header: '%s'", linkV[ix]));
+
+      if (linkSet == true)
+      {
+        orionldError(OrionldInternalError, "Invalid NGSI-LD request", "@context given more than once in a Link header", 400);
+        return false;
+      }
+
+      orionldState.link = pCheckLinkHeader(linkV[ix]);
+      if (orionldState.link == NULL)
+        LM_RE(false, ("pCheckLinkHeader failed"));  // ProblemDetails set by pCheckLinkHeader
+
+      if (linkContextGet(orionldState.link) == false)  // Lookup/Download if necessary
+        LM_RE(false, ("linkContextGet failed"));
+
+      linkSet = true;
+    }
+    else if (strstr(linkV[ix], "rel=\"next\"") != NULL)
+      LM_T(LmtLinkHeader, ("Received a 'next' Link header - ignoring it"));
+    else if (strstr(linkV[ix], "rel=\"previous\"") != NULL)
+      LM_T(LmtLinkHeader, ("Received a 'previous' Link header - ignoring it"));
+    else
+      LM_W(("Unrecognized Link header: '%s'", linkV[ix]));
+  }
 
   return true;
 }
@@ -1238,14 +1290,9 @@ MHD_Result mhdConnectionTreat(void)
   {
     if (orionldState.linkHttpHeaderPresent == true)
     {
-      char* link = pCheckLinkHeader(orionldState.link);
-
-      if (link == NULL)
-        goto respond;
-
-      if (linkGet(link) == false)  // Lookup/Download if necessary
+      if (linkHeaderTreat(orionldState.link) == false)  // Lookup/Download if necessary
       {
-        LM_W(("linkGet failed, going to 'respond'"));
+        LM_W(("linkGet failed"));
         goto respond;
       }
     }
@@ -1256,13 +1303,36 @@ MHD_Result mhdConnectionTreat(void)
     if (orionldState.payloadContextNode != NULL)
     {
       bool implicitlyCreated = false;
+      bool allDone           = false;
 
       LM_T(LmtContextCacheStats, ("Got an @context in the payload body (type %s)", kjValueType(orionldState.payloadContextNode->type)));
+
+      //
+      // Simplify and if need be, flatten array
+      //
+      if (orionldState.payloadContextNode->type == KjArray)
+      {
+        int arrayItems = 0;
+        orionldContextSimplify(orionldState.payloadContextNode, &arrayItems);
+
+        if ((arrayItems == 1) && (orionldState.payloadContextNode->value.firstChildP->type == KjString))
+        {
+          LM_T(LmtContextInBody, ("@context is an array with a single URI inside - flattening"));
+          orionldState.payloadContextNode = orionldState.payloadContextNode->value.firstChildP;
+          orionldState.contextP = orionldContextFromUrl(orionldState.payloadContextNode->value.s, orionldState.payloadContextNode->value.s);
+          LM_T(LmtContextInBody, ("All done: orionldState.contextP->url: '%s'", orionldState.contextP->url));
+          allDone = true;
+        }
+      }
+      
       if ((orionldState.serviceP->serviceRoutine == orionldPostSubscriptions) || (orionldState.serviceP->serviceRoutine == orionldPatchSubscription))
       {
         implicitlyCreated = true;
         LM_T(LmtContextCacheStats, ("And the service is Subscription Creation"));
       }
+
+      if (allDone == true)
+        goto allDone;
 
       OrionldProblemDetails pd = { OrionldBadRequestData, (char*) "naught", (char*) "naught", 0 };
 
@@ -1301,6 +1371,8 @@ MHD_Result mhdConnectionTreat(void)
         orionldState.contextP->kind = OrionldContextImplicit;  // Too late - the context is already in mongo
     }
   }
+
+ allDone:
 
   LM_T(LmtUserContext, ("orionldState.contextP at %p", orionldState.contextP));
   LM_T(LmtUserContext, ("Core Context at          %p", orionldCoreContextP));

--- a/src/lib/orionld/serviceRoutines/orionldPatchEntity.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldPatchEntity.cpp
@@ -51,6 +51,7 @@ extern "C"
 #include "orionld/payloadCheck/pCheckAttribute.h"                // pCheckAttribute
 #include "orionld/dbModel/dbModelFromApiAttribute.h"             // dbModelFromApiAttribute
 #include "orionld/dbModel/dbModelToApiEntity.h"                  // dbModelToApiEntity2
+#include "orionld/context/orionldContextItemExpand.h"            // orionldContextItemExpand
 #include "orionld/context/orionldAttributeExpand.h"              // orionldAttributeExpand
 #include "orionld/mongoc/mongocEntityLookup.h"                   // mongocEntityLookup
 #include "orionld/mongoc/mongocAttributesAdd.h"                  // mongocAttributesAdd
@@ -111,15 +112,15 @@ static void attributesMerge(KjNode* finalApiEntityP, KjNode* apiAttrs)
 //
 // pCheckEntityType2 -
 //
-char* pCheckEntityType2(KjNode* payloadTypeNode, KjNode* dbEntityP, char* entityTypeFromUriParam)
+static char* pCheckEntityType2(KjNode* payloadTypeNode, KjNode* dbEntityP, char* entityTypeFromUriParam)
 {
   KjNode* dbTypeNodeP           = (dbEntityP != NULL)? dbEntityTypeExtract(dbEntityP) : NULL;
   char*   entityTypeFromDB      = (dbTypeNodeP != NULL)? dbTypeNodeP->value.s : NULL;
   char*   entityTypeFromPayload = (orionldState.payloadTypeNode != NULL)? orionldState.payloadTypeNode->value.s : NULL;
-
+  char*   entityType            = (entityTypeFromPayload != NULL)? orionldContextItemExpand(orionldState.contextP, entityTypeFromPayload, true, NULL) : NULL;
   LM_T(LmtSR, ("entityType From DB:        '%s'", entityTypeFromDB));
   LM_T(LmtSR, ("entityType From URI Param: '%s'", entityTypeFromUriParam));
-  LM_T(LmtSR, ("entityType From Payload:   '%s'", entityTypeFromPayload));
+  LM_T(LmtSR, ("entityType From Payload:   '%s'  ('%s')", entityType, entityTypeFromPayload));
 
   //
   // 3 different way to find the Entity Type:
@@ -133,13 +134,13 @@ char* pCheckEntityType2(KjNode* payloadTypeNode, KjNode* dbEntityP, char* entity
   // Question is, what to do if URI Param "type" or payload body "type" differ (from DB "type" or between the two)
   // For now (as multi type isn't supported yet), I'll give error if mismatch
   //
-  if ((entityTypeFromPayload != NULL) && (entityTypeFromDB != NULL))
+  if ((entityType != NULL) && (entityTypeFromDB != NULL))
   {
-    if (strcmp(entityTypeFromDB, entityTypeFromPayload) != 0)
+    if (strcmp(entityTypeFromDB, entityType) != 0)
     {
       orionldError(OrionldBadRequestData, "Mismatching Entity::type in payload body", "Does not coincide with the Entity::type in the database", 400);
       LM_E(("Entity type in database:       '%s'", entityTypeFromDB));
-      LM_E(("Entity type from payload body: '%s'", entityTypeFromPayload));
+      LM_E(("Entity type from payload body: '%s'", entityType));
       return NULL;
     }
   }
@@ -155,13 +156,13 @@ char* pCheckEntityType2(KjNode* payloadTypeNode, KjNode* dbEntityP, char* entity
     }
   }
 
-  if ((entityTypeFromPayload != NULL) && (entityTypeFromUriParam != NULL))
+  if ((entityType != NULL) && (entityTypeFromUriParam != NULL))
   {
-    if (strcmp(entityTypeFromPayload, entityTypeFromUriParam) != 0)
+    if (strcmp(entityType, entityTypeFromUriParam) != 0)
     {
       orionldError(OrionldBadRequestData, "Mismatching Entity type in URL parameter 'type'", "Does not coincide with the Entity::type in payload body", 400);
       LM_E(("Entity type from URI param:    '%s'", entityTypeFromUriParam));
-      LM_E(("Entity type from payload body: '%s'", entityTypeFromPayload));
+      LM_E(("Entity type from payload body: '%s'", entityType));
       return NULL;
     }
   }
@@ -271,7 +272,7 @@ bool orionldPatchEntity(void)
 
   //
   // If entity type is present in the payload body, it must be a String and identical to the entity type in the database.
-  // [ It is already extracted (by mhdConnectionTreat) and checked for String ]
+  // [ It is already extracted (by mhdConnectionTreat) and checked for String - just not yet expanded! ]
   //
   entityType = pCheckEntityType2(orionldState.payloadTypeNode, dbEntityP, entityType);
 

--- a/test/functionalTest/cases/0000_dds/dds_notifications.test
+++ b/test/functionalTest/cases/0000_dds/dds_notifications.test
@@ -142,7 +142,7 @@ echo
 
 echo "09. Dump the ftClient to see the notification"
 echo "============================================="
-sleep .5
+sleep 1
 orionCurl --url /dump --port $FT_PORT --noPayloadCheck
 echo
 echo

--- a/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert-context_in_payload_data.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert-context_in_payload_data.test
@@ -113,7 +113,7 @@ payload='[
     }
   }
 ]'
-orionCurl --url /ngsi-ld/v1/entityOperations/upsert --payload "$payload" -H "Content-Type: application/ld+json" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; ""'
+orionCurl --url /ngsi-ld/v1/entityOperations/upsert --payload "$payload" -H "Content-Type: application/ld+json" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert_and_contexts.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_batch_upsert_and_contexts.test
@@ -268,7 +268,7 @@ echo
 
 echo "03. Get the entities"
 echo "===================="
-orionCurl --url '/ngsi-ld/v1/entities?type=WeatherObserved&prettyPrint=yes' -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; ""' -H 'Fiware-Service: smartmaas001' --noPayloadCheck
+orionCurl --url '/ngsi-ld/v1/entities?type=WeatherObserved&prettyPrint=yes' -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' -H 'Fiware-Service: smartmaas001' --noPayloadCheck
 echo
 echo
 
@@ -494,7 +494,7 @@ echo
 
 echo "06. Get the entities"
 echo "===================="
-orionCurl --url '/ngsi-ld/v1/entities?type=WeatherObserved&prettyPrint=yes' -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; ""' -H 'Fiware-Service: smartmaas001' --noPayloadCheck
+orionCurl --url '/ngsi-ld/v1/entities?type=WeatherObserved&prettyPrint=yes' -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' -H 'Fiware-Service: smartmaas001' --noPayloadCheck
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_context_cache_ignores-protocol.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_context_cache_ignores-protocol.test
@@ -58,7 +58,7 @@ echo
 
 echo "03. GET the entity using the same context as in step 2, just with protocol https instead of http"
 echo "================================================================================================="
-orionCurl --url /ngsi-ld/v1/entities?type=T -H "Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>"
+orionCurl --url /ngsi-ld/v1/entities?type=T -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_context_creation.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_context_creation.test
@@ -107,7 +107,7 @@ echo
 
 echo "06. GET the entity, with the creation context, and make sure the terms are compacted accordingly"
 echo "================================================================================================"
-orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entities:E1 -H 'Link: <'http://localhost:9999$contextURL'>'
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entities:E1 -H 'Link: <'http://localhost:9999$contextURL'>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_core_context_in_response.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_core_context_in_response.test
@@ -44,7 +44,7 @@ payload='{
   "type": "ByInvoice",
   "Cash": 100 
 }'
-orionCurl --url /ngsi-ld/v1/entities --payload "$payload" -H "Link: <http://smartdatamodels.org/context.jsonld>"
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload" -H 'Link: <http://smartdatamodels.org/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -56,21 +56,21 @@ payload='{
   "type": "ByInvoice",
   "Cash": 100 
 }'
-orionCurl --url /ngsi-ld/v1/entities --payload "$payload" -H "Link: <http://smartdatamodels.org/context.jsonld>"
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload" -H 'Link: <http://smartdatamodels.org/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
 
 echo "03. Retrieve urn:E1, with @context http://smartdatamodels.org/context.jsonld and Accept ld+json - see core context in response"
 echo "=============================================================================================================================="
-orionCurl --url /ngsi-ld/v1/entities/urn:E1 --out application/ld+json -H "Link: <http://smartdatamodels.org/context.jsonld>"
+orionCurl --url /ngsi-ld/v1/entities/urn:E1 --out application/ld+json -H 'Link: <http://smartdatamodels.org/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
 
 echo "04. Query entities, with @context http://smartdatamodels.org/context.jsonld and Accept ld+json - see core context in response"
 echo "============================================================================================================================="
-orionCurl --url /ngsi-ld/v1/entities?type=ByInvoice --out application/ld+json -H "Link: <http://smartdatamodels.org/context.jsonld>"
+orionCurl --url /ngsi-ld/v1/entities?type=ByInvoice --out application/ld+json -H 'Link: <http://smartdatamodels.org/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -85,7 +85,7 @@ payload='{
     }
   ]
 }'
-orionCurl --url /ngsi-ld/v1/entityOperations/query --payload "$payload" --out application/ld+json -H "Link: <http://smartdatamodels.org/context.jsonld>"
+orionCurl --url /ngsi-ld/v1/entityOperations/query --payload "$payload" --out application/ld+json -H 'Link: <http://smartdatamodels.org/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_default_user_context.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_default_user_context.test
@@ -75,7 +75,7 @@ payload='{
   "type": "T",
   "P1": "P1 of E2"
 }'
-orionCurl --url /ngsi-ld/v1/entities --payload "$payload" -H "Link: <http://localhost:7080/jsonldContexts/urn:C2>"
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload" -H 'Link: <http://localhost:7080/jsonldContexts/urn:C2>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -89,7 +89,7 @@ echo
 
 echo "04. GET all entities, with user context urn:C2, see urn:E2 with shortnames and urn:E1 with longnames"
 echo "===================================================================================================="
-orionCurl --url /ngsi-ld/v1/entities?local=true -H "Link: <http://localhost:7080/jsonldContexts/urn:C2>"
+orionCurl --url /ngsi-ld/v1/entities?local=true -H 'Link: <http://localhost:7080/jsonldContexts/urn:C2>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_pick.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_entities_get_with_pick.test
@@ -39,6 +39,8 @@ orionldStart CP1 -experimental
 # 05. Query entities of type T and with pick=id,type,P1,P5 - see those 4 fields of the two entities
 # 06. Query entities of type T and with pick=id - see only the ids
 # 07. Retrieve urn:E1 with pick=id,type,P1,P5 - see those 4 fields of urn:E1
+# 08. Query entities of type T and with pick=P5 - see P5 only of the three entities
+# 09. Query entities of type T and with pick=P5 with local=true - see P5 only of the two local entities
 #
 
 echo "01. Create an entity urn:E1 of type T with 5 attributes P1-P5"
@@ -46,11 +48,11 @@ echo "============================================================="
 payload='{
   "id": "urn:E1",
   "type": "T",
-  "P1": 1,
-  "P2": 2,
-  "P3": 3,
-  "P4": 4,
-  "P5": 5
+  "P1": 11,
+  "P2": 12,
+  "P3": 13,
+  "P4": 14,
+  "P5": 15
 }'
 orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
 echo
@@ -62,11 +64,11 @@ echo "============================================================="
 payload='{
   "id": "urn:E2",
   "type": "T",
-  "P3": 3,
-  "P4": 4,
-  "P5": 5,
-  "P6": 6,
-  "P7": 7
+  "P3": 23,
+  "P4": 24,
+  "P5": 25,
+  "P6": 26,
+  "P7": 27
 }'
 orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
 echo
@@ -78,11 +80,11 @@ echo "====================================================================="
 payload='{
   "id": "urn:E3",
   "type": "T",
-  "P5": 5,
-  "P6": 6,
-  "P7": 7,
-  "P8": 8,
-  "P9": 9
+  "P5": 35,
+  "P6": 36,
+  "P7": 37,
+  "P8": 38,
+  "P9": 39
 }'
 orionCurl --url /ngsi-ld/v1/entities --payload "$payload" --port $CP1_PORT
 echo
@@ -111,7 +113,6 @@ echo
 echo
 
 
-
 echo "05. Query entities of type T and with pick=id,type,P1,P5 - see those 4 fields of the two entities"
 echo "================================================================================================="
 orionCurl --url '/ngsi-ld/v1/entities?type=T&pick=id,type,P1,P5&local=true'
@@ -129,6 +130,64 @@ echo
 echo "07. Retrieve urn:E1 with pick=id,type,P1,P5 - see those 4 fields of urn:E1"
 echo "=========================================================================="
 orionCurl --url '/ngsi-ld/v1/entities/urn:E1?pick=id,type,P1,P5'
+echo
+echo
+
+
+echo "08. Query entities of type T and with pick=P5 - see P5 only of the two entities"
+echo "==============================================================================="
+orionCurl --url '/ngsi-ld/v1/entities?type=T&pick=P5'
+echo
+echo
+
+
+echo "09. Query entities of type T and with pick=P5 with local=true - see P5 only of the two local entities"
+echo "====================================================================================================="
+orionCurl --url '/ngsi-ld/v1/entities?type=T&pick=P5&local=true'
+echo
+echo
+
+
+echo "10. Create an entity 'urn:ngsi-ld:Domain:Cluster' of type 'Domain' in CB"
+echo "========================================================================"
+payload='{
+  "id": "urn:ngsi-ld:Domain:Cluster",
+  "type": "Domain",
+  "description": {
+    "type": "Property",
+    "value": "UPV Domain 1"
+  },
+  "publicUrl": {
+    "type": "Property",
+    "value": "http://158.42.161.177:31552"
+  },
+  "owner": {
+    "type": "Relationship",
+    "object": [
+      "urn:ngsi-ld:Organization:UPV"
+    ]
+  },
+  "isEntrypoint": {
+    "type": "Property",
+    "value": true
+  },
+  "domainStatus": {
+    "type": "Relationship",
+    "object": "urn:ngsi-ld:DomainStatus:Functional"
+  },
+  "publicKey": {
+    "type": "Property",
+    "value": "X/4Wn7zpxxWPmLCbP6uaUFgQUDlnBLyGiPZs2C9IOlU="
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "11. Query entities of type Domain and with pick=isEntrypoint - see isEntrypoint only for urn:ngsi-ld:Domain:Cluster"
+echo "==================================================================================================================="
+orionCurl --url '/ngsi-ld/v1/entities?type=Domain&pick=isEntrypoint'
 echo
 echo
 
@@ -173,7 +232,7 @@ Location: /ngsi-ld/v1/csourceRegistrations/urn:R1
 05. Query entities of type T and with pick=id,type,P1,P5 - see those 4 fields of the two entities
 =================================================================================================
 HTTP/1.1 200 OK
-Content-Length: 160
+Content-Length: 163
 Content-Type: application/json
 Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
@@ -182,11 +241,11 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
     {
         "P1": {
             "type": "Property",
-            "value": 1
+            "value": 11
         },
         "P5": {
             "type": "Property",
-            "value": 5
+            "value": 15
         },
         "id": "urn:E1",
         "type": "T"
@@ -194,7 +253,7 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
     {
         "P5": {
             "type": "Property",
-            "value": 5
+            "value": 25
         },
         "id": "urn:E2",
         "type": "T"
@@ -226,7 +285,7 @@ NGSILD-EntityMap: urn:ngsi-ld:entity-map:REGEX(.*)
 07. Retrieve urn:E1 with pick=id,type,P1,P5 - see those 4 fields of urn:E1
 ==========================================================================
 HTTP/1.1 200 OK
-Content-Length: 96
+Content-Length: 98
 Content-Type: application/json
 Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
@@ -234,15 +293,97 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
 {
     "P1": {
         "type": "Property",
-        "value": 1
+        "value": 11
     },
     "P5": {
         "type": "Property",
-        "value": 5
+        "value": 15
     },
     "id": "urn:E1",
     "type": "T"
 }
+
+
+08. Query entities of type T and with pick=P5 - see P5 only of the two entities
+===============================================================================
+HTTP/1.1 200 OK
+Content-Length: 115
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+NGSILD-EntityMap: urn:ngsi-ld:entity-map:REGEX(.*)
+
+[
+    {
+        "P5": {
+            "type": "Property",
+            "value": 15
+        }
+    },
+    {
+        "P5": {
+            "type": "Property",
+            "value": 25
+        }
+    },
+    {
+        "P5": {
+            "type": "Property",
+            "value": 35
+        }
+    }
+]
+
+
+09. Query entities of type T and with pick=P5 with local=true - see P5 only of the two local entities
+=====================================================================================================
+HTTP/1.1 200 OK
+Content-Length: 77
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+[
+    {
+        "P5": {
+            "type": "Property",
+            "value": 15
+        }
+    },
+    {
+        "P5": {
+            "type": "Property",
+            "value": 25
+        }
+    }
+]
+
+
+10. Create an entity 'urn:ngsi-ld:Domain:Cluster' of type 'Domain' in CB
+========================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:Domain:Cluster
+
+
+
+11. Query entities of type Domain and with pick=isEntrypoint - see isEntrypoint only for urn:ngsi-ld:Domain:Cluster
+===================================================================================================================
+HTTP/1.1 200 OK
+Content-Length: 51
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+[
+    {
+        "isEntrypoint": {
+            "type": "Property",
+            "value": true
+        }
+    }
+]
 
 
 --TEARDOWN--
@@ -250,4 +391,3 @@ brokerStop CB
 brokerStop CP1
 dbDrop CB
 dbDrop CP1
-

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_1615-empty-url-for-notification.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_1615-empty-url-for-notification.test
@@ -71,7 +71,7 @@ payload='{
   "type": "WasteContainer",
   "name": "abc"
 }'
-orionCurl --url /ngsi-ld/v1/entities --payload "$payload"  -H "NGSILD-Tenant: X" -H 'Link: <https://raw.githubusercontent.com/smart-data-models/dataModel.WasteManagement/master/context.jsonld>'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"  -H "NGSILD-Tenant: X" -H 'Link: <https://raw.githubusercontent.com/smart-data-models/dataModel.WasteManagement/master/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -82,7 +82,7 @@ payload='{
   "type": "Property",
   "value": "def"
 }'
-orionCurl --url /ngsi-ld/v1/entities/urn:E1/attrs/name --payload "$payload" -X PATCH -H "NGSILD-Tenant: X" -H 'Link: <https://raw.githubusercontent.com/smart-data-models/dataModel.WasteManagement/master/context.jsonld>'
+orionCurl --url /ngsi-ld/v1/entities/urn:E1/attrs/name --payload "$payload" -X PATCH -H "NGSILD-Tenant: X" -H 'Link: <https://raw.githubusercontent.com/smart-data-models/dataModel.WasteManagement/master/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_1615.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_1615.test
@@ -67,7 +67,7 @@ payload='{
   "type": "WasteContainer",
   "name": "abc"
 }'
-orionCurl --url /ngsi-ld/v1/entities --payload "$payload"  -H "NGSILD-Tenant: X" -H 'Link: <https://raw.githubusercontent.com/smart-data-models/dataModel.WasteManagement/master/context.jsonld>'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"  -H "NGSILD-Tenant: X" -H 'Link: <https://raw.githubusercontent.com/smart-data-models/dataModel.WasteManagement/master/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -78,7 +78,7 @@ payload='{
   "type": "Property",
   "value": "def"
 }'
-orionCurl --url /ngsi-ld/v1/entities/urn:E1/attrs/name --payload "$payload" -X PATCH -H "NGSILD-Tenant: X" -H 'Link: <https://raw.githubusercontent.com/smart-data-models/dataModel.WasteManagement/master/context.jsonld>'
+orionCurl --url /ngsi-ld/v1/entities/urn:E1/attrs/name --payload "$payload" -X PATCH -H "NGSILD-Tenant: X" -H 'Link: <https://raw.githubusercontent.com/smart-data-models/dataModel.WasteManagement/master/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_1652-csf.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_1652-csf.test
@@ -62,7 +62,7 @@ payload='{
   "endpoint": "http://my.csource.org:1026",
   "Type2": "urn:aeros:federation:r1"
 }'
-orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload" -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload" -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -85,7 +85,7 @@ payload='{
   "endpoint": "http://my.csource.org:1026",
   "Type2": "urn:aeros:federation:r2"
 }'
-orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload" -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload" -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -108,14 +108,14 @@ payload='{
   "endpoint": "http://my.csource.org:1026",
   "Type2": "urn:aeros:other:r3"
 }'
-orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload" -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload" -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
 
 echo "04. GET R1 with same @context - see Type2 as shortname"
 echo "======================================================"
-orionCurl --url /ngsi-ld/v1/csourceRegistrations/urn:ngsi-ld:R1 -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations/urn:ngsi-ld:R1 -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -129,21 +129,21 @@ echo
 
 echo "06. Query registrations with csf=Type2~=urn:aeros:federation:.* - see R1 and R2"
 echo "==============================================================================="
-orionCurl --url /ngsi-ld/v1/csourceRegistrations?csf=Type2~=urn:aeros:federation:.* -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations?csf=Type2~=urn:aeros:federation:.* -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
 
 echo "07. Query registrations with csf=Type2~=urn:aeros:o.* - see R3"
 echo "=============================================================="
-orionCurl --url /ngsi-ld/v1/csourceRegistrations?csf=Type2~=urn:aeros:o.* -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations?csf=Type2~=urn:aeros:o.* -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
 
 echo "08. Query registrations with csf=Type2~=urn:hairos:.* - see []"
 echo "=============================================================="
-orionCurl --url /ngsi-ld/v1/csourceRegistrations?csf=Type2~=urn:hairos.* -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations?csf=Type2~=urn:hairos.* -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -153,14 +153,14 @@ echo "==========================================="
 payload='{
   "Type2": "urn:hairos:09"
 }'
-orionCurl --url /ngsi-ld/v1/csourceRegistrations/urn:ngsi-ld:R1 --payload "$payload" -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>' -X PATCH
+orionCurl --url /ngsi-ld/v1/csourceRegistrations/urn:ngsi-ld:R1 --payload "$payload" -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' -X PATCH
 echo
 echo
 
 
 echo "10. Query registrations with csf=Type2~=urn:hairos:.* - see R1"
 echo "=============================================================="
-orionCurl --url /ngsi-ld/v1/csourceRegistrations?csf=Type2~=urn:hairos.* -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations?csf=Type2~=urn:hairos.* -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -170,14 +170,14 @@ echo "=================================================================="
 payload='{
   "Type3": "urn:aeros:federation2:R2"
 }'
-orionCurl --url /ngsi-ld/v1/csourceRegistrations/urn:ngsi-ld:R2 --payload "$payload" -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>' -X PATCH
+orionCurl --url /ngsi-ld/v1/csourceRegistrations/urn:ngsi-ld:R2 --payload "$payload" -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' -X PATCH
 echo
 echo
 
 
 echo "12. Query registrations with csf=Type3~=urn:aeros:federation2.* - see R2"
 echo "========================================================================"
-orionCurl --url /ngsi-ld/v1/csourceRegistrations?csf=Type3~=urn:aeros:federation2.* -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations?csf=Type3~=urn:aeros:federation2.* -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_issue_823.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_issue_823.test
@@ -53,7 +53,7 @@ payload='{
     }
   }
 }'
-orionCurl --url /ngsi-ld/v1/subscriptions --payload "$payload" -H "Link: <https://smartdatamodels.org/context.jsonld>"
+orionCurl --url /ngsi-ld/v1/subscriptions --payload "$payload" -H 'Link: <https://smartdatamodels.org/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -67,7 +67,7 @@ payload='{
   "occupationRate": {"type": "Property", "value": "low"},
   "peopleOccupancy": {"type": "Property", "value": 4}
 }'
-orionCurl --url /ngsi-ld/v1/entities -X POST --payload "$payload" -H "Link: <https://smartdatamodels.org/context.jsonld>"
+orionCurl --url /ngsi-ld/v1/entities -X POST --payload "$payload" -H 'Link: <https://smartdatamodels.org/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_link_header.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_link_header.test
@@ -1,0 +1,214 @@
+# Copyright 2025 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Link headers
+
+--SHELL-INIT--
+dbInit CB
+orionldStart CB -experimental
+
+--SHELL--
+
+#
+# 01. Create an entity with a specific @context, expanding 'P1' to 'http://example.org/P1'
+# 02. Query entities request with two Link headers, both with a context - see error
+# 03. Query entities request with one Link header that contains two contexts (comma-separated) - see error
+# 04. Query entities request with a correct Link header with the @context from step 01 - see P1 as shortname
+# 05. Query entities request with a correct Link header with some other @context from step 01 - see P1 as longname
+# 06. Query entities request with 3 Link headers: @context, next, and previous
+# 07. Query entities request with a Link header with 3 items: @context, next, and previous
+#
+
+
+echo "01. Create an entity with a specific @context, expanding 'P1' to 'http://example.org/P1'"
+echo "========================================================================================"
+payload='{
+  "id": "urn:E1",
+  "type": "T",
+  "P1": 1
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+echo
+echo
+
+
+echo "02. Query entities request with two Link headers, both with a context - see error"
+echo "================================================================================="
+orionCurl --url /ngsi-ld/v1/entities?local=true -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json", <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+echo
+echo
+
+
+echo "03. Query entities request with one Link header that contains two contexts (comma-separated) - see error"
+echo "========================================================================================="
+curl localhost:$CB_PORT/ngsi-ld/v1/entities?local=true -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' --dump-header /tmp/headers 2> /dev/null > /tmp/body
+cat /tmp/headers
+cat /tmp/body
+rm -f /tmp/body
+rm -f /tmp/headers
+echo
+echo
+
+
+echo "04. Query entities request with a correct Link header with the @context from step 01 - see P1 as shortname"
+echo "=========================================================================================================="
+orionCurl --url /ngsi-ld/v1/entities?local=true -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+echo
+echo
+
+
+echo "05. Query entities request with a correct Link header with some other @context from step 01 - see P1 as longname"
+echo "================================================================================================================"
+orionCurl --url /ngsi-ld/v1/entities?local=true -H 'Link: <https://fiware.github.io/data-models/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+echo
+echo
+
+
+echo "06. Query entities request with 3 Link headers: @context, next, and previous"
+echo "============================================================================"
+curl localhost:$CB_PORT/ngsi-ld/v1/entities?local=true \
+  -H 'Link: </entities/?type=TemperatureSensor&limit=1&offset=2>; rel="next"' \
+  -H 'Link: </entities/?type=TemperatureSensor&limit=1&offset=0>; rel="previous"' \
+  -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' --dump-header /tmp/headers 2> /dev/null > /tmp/body
+
+cat /tmp/headers
+cat /tmp/body
+rm -f /tmp/body
+rm -f /tmp/headers
+echo
+echo
+
+
+echo "07. Query entities request with a Link header with 3 items: @context, next, and previous"
+echo "========================================================================================"
+orionCurl --url /ngsi-ld/v1/entities?local=true -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json", </entities/?type=TemperatureSensor&limit=1&offset=2>; rel="next", </entities/?type=TemperatureSensor&limit=1&offset=0>; rel="previous"'
+echo
+echo
+
+
+--REGEXPECT--
+01. Create an entity with a specific @context, expanding 'P1' to 'http://example.org/P1'
+========================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:E1
+
+
+
+02. Query entities request with two Link headers, both with a context - see error
+=================================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 152
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "@context given more than once in a Link header",
+    "title": "Invalid NGSI-LD request",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/InternalError"
+}
+
+
+03. Query entities request with one Link header that contains two contexts (comma-separated) - see error
+=========================================================================================
+HTTP/1.1 400 Bad Request
+Date: REGEX(.*)
+Content-Type: application/json
+Content-Length: 149
+
+{"type":"https://uri.etsi.org/ngsi-ld/errors/InternalError","title":"Invalid NGSI-LD request","detail":"@context given in more than one Link header"}
+
+04. Query entities request with a correct Link header with the @context from step 01 - see P1 as shortname
+==========================================================================================================
+HTTP/1.1 200 OK
+Content-Length: 63
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+[
+    {
+        "P1": {
+            "type": "Property",
+            "value": 1
+        },
+        "id": "urn:E1",
+        "type": "T"
+    }
+]
+
+
+05. Query entities request with a correct Link header with some other @context from step 01 - see P1 as longname
+================================================================================================================
+HTTP/1.1 200 OK
+Content-Length: 101
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://fiware.github.io/data-models/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+[
+    {
+        "http://example.org/P1": {
+            "type": "Property",
+            "value": 1
+        },
+        "id": "urn:E1",
+        "type": "http://example.org/T"
+    }
+]
+
+
+06. Query entities request with 3 Link headers: @context, next, and previous
+============================================================================
+HTTP/1.1 200 OK
+Date: REGEX(.*)
+Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Content-Type: application/json
+Content-Length: 63
+
+[{"id":"urn:E1","type":"T","P1":{"type":"Property","value":1}}]
+
+07. Query entities request with a Link header with 3 items: @context, next, and previous
+========================================================================================
+HTTP/1.1 200 OK
+Content-Length: 63
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+[
+    {
+        "P1": {
+            "type": "Property",
+            "value": 1
+        },
+        "id": "urn:E1",
+        "type": "T"
+    }
+]
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_batch_upsert-context_in_payload_data.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_batch_upsert-context_in_payload_data.test
@@ -114,7 +114,7 @@ payload='[
     }
   }
 ]'
-orionCurl --url /ngsi-ld/v1/entityOperations/upsert --payload "$payload" -H "Content-Type: application/ld+json" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; ""'
+orionCurl --url /ngsi-ld/v1/entityOperations/upsert --payload "$payload" -H "Content-Type: application/ld+json" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_batch_upsert_and_contexts.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_batch_upsert_and_contexts.test
@@ -277,7 +277,7 @@ echo
 
 echo "03. Get the entities"
 echo "===================="
-orionCurl --url '/ngsi-ld/v1/entities?type=WeatherObserved&prettyPrint=yes' -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; ""' -H 'Fiware-Service: smartmaas001' --noPayloadCheck
+orionCurl --url '/ngsi-ld/v1/entities?type=WeatherObserved&prettyPrint=yes' -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' -H 'Fiware-Service: smartmaas001' --noPayloadCheck
 echo
 echo
 
@@ -501,7 +501,7 @@ echo
 
 echo "06. Get the entities"
 echo "===================="
-orionCurl --url '/ngsi-ld/v1/entities?type=WeatherObserved&prettyPrint=yes' -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; ""' -H 'Fiware-Service: smartmaas001' --noPayloadCheck
+orionCurl --url '/ngsi-ld/v1/entities?type=WeatherObserved&prettyPrint=yes' -H 'Link: <http://localhost:7080/jsonldContexts/schema_lab_fiware_org_ld_context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' -H 'Fiware-Service: smartmaas001' --noPayloadCheck
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_context_inline_array_with_one_string_that_is_not_the_core_context.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_context_inline_array_with_one_string_that_is_not_the_core_context.test
@@ -75,7 +75,7 @@ Location: /ngsi-ld/v1/entities/http://a.b.c/entity/E1
 02. Ask for the entire list of contexts in the context cache
 ============================================================
 HTTP/1.1 200 OK
-Content-Length: 1339
+Content-Length: 1374
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -101,7 +101,7 @@ Date: REGEX(.*)
   },
   {
     "URL": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld",
-    "localId": "REGEX(.*)",
+    "localId": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld",
     "kind": "Cached",
     "createdAt": "202REGEX(.*)",
     "extraInfo": {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_context_inline_array_with_two_items_of_which_one_is_the_core_context.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_context_inline_array_with_two_items_of_which_one_is_the_core_context.test
@@ -76,7 +76,7 @@ Location: /ngsi-ld/v1/entities/http://a.b.c/entity/E1
 02. Ask for the entire list of contexts in the context cache
 ============================================================
 HTTP/1.1 200 OK
-Content-Length: 1339
+Content-Length: 1374
 Content-Type: application/json
 Date: REGEX(.*)
 
@@ -102,7 +102,7 @@ Date: REGEX(.*)
   },
   {
     "URL": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld",
-    "localId": "REGEX(.*)",
+    "localId": "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld",
     "kind": "Cached",
     "createdAt": "202REGEX(.*)",
     "extraInfo": {

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_forward_get_entity-attrs-only-uriAttrs.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_forward_get_entity-attrs-only-uriAttrs.test
@@ -1,4 +1,4 @@
-# Copyright 2019 FIWARE Foundation e.V.
+# Copyright 2025 FIWARE Foundation e.V.
 #
 # This file is part of Orion-LD Context Broker.
 #
@@ -26,8 +26,8 @@ NGSI-LD Forward of GET /entities/{entityId}?attrs=<Only URI Parameter Attributes
 --SHELL-INIT--
 dbInit CB
 dbInit CP1
-orionldStart CB -forwarding
-orionldStart CP1
+orionldStart CB -forwarding -experimental
+orionldStart CP1 -experimental
 
 --SHELL--
 
@@ -44,7 +44,7 @@ orionldStart CP1
 # 11. See the registration in mongo
 # 21. Create entity urn:ngsi-ld:entities:E1 in CP1, with attributes P1, P2, R1, and R1
 # 03. Ask CB to GET entity urn:ngsi-ld:entities:E1?attrs=P1,R2 - provoke a forward request of GET urn:ngsi-ld:entities:E1?attrs=P1,R2 to CP1
-# 04. Do the same GET, but with a Link HTTP header, with a @context that redefines P1 and R2 => no hits and no attrs are returned
+# 04. Do the same GET, but with a Link HTTP header, with a @context that redefines P1 and R2 => no hits and 404
 # 05. Like step 03 but with options=keyValues
 #
 
@@ -122,8 +122,8 @@ echo
 echo
 
 
-echo "04. Do the same GET, but with a Link HTTP header, with a @context that redefines P1 and R2 => no hits and no attrs are returned"
-echo "==============================================================================================================================="
+echo "04. Do the same GET, but with a Link HTTP header, with a @context that redefines P1 and R2 => no hits and 404"
+echo "============================================================================================================="
 orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:entities:E1?attrs=P1,R2 -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
@@ -162,7 +162,8 @@ connecting to: REGEX(.*)
 MongoDB server version: REGEX(.*)
 {
 	"_id" : "urn:ngsi-ld:ContextSourceRegistration:csr01",
-	"servicePath" : "/",
+	"createdAt" : REGEX(.*),
+	"modifiedAt" : REGEX(.*),
 	"contextRegistration" : [
 		{
 			"entities" : [
@@ -175,9 +176,10 @@ MongoDB server version: REGEX(.*)
 			"providingApplication" : "http://REGEX(.*)"
 		}
 	],
-	"format" : "JSON",
-	"createdAt" : REGEX(.*),
-	"modifiedAt" : REGEX(.*)
+	"properties" : {
+		
+	},
+	"status" : "active"
 }
 bye
 
@@ -213,17 +215,17 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
 }
 
 
-04. Do the same GET, but with a Link HTTP header, with a @context that redefines P1 and R2 => no hits and no attrs are returned
-===============================================================================================================================
-HTTP/1.1 200 OK
-Content-Length: 43
+04. Do the same GET, but with a Link HTTP header, with a @context that redefines P1 and R2 => no hits and 404
+=============================================================================================================
+HTTP/1.1 404 Not Found
+Content-Length: 125
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
-    "id": "urn:ngsi-ld:entities:E1",
-    "type": "T"
+    "detail": "urn:ngsi-ld:entities:E1",
+    "title": "Entity not found",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/ResourceNotFound"
 }
 
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_notifications_after_restarting_broker.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_notifications_after_restarting_broker.test
@@ -56,7 +56,7 @@ payload='{
     "value": "ok"
   }
 }'
-orionCurl --url /ngsi-ld/v1/entities -X POST --payload "$payload" -H "Content-Type: application/json" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>'
+orionCurl --url /ngsi-ld/v1/entities -X POST --payload "$payload" -H "Content-Type: application/json" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -83,7 +83,7 @@ payload='{
   },
   "expires": "2028-12-31T10:00:00"
 }'
-orionCurl --url /ngsi-ld/v1/subscriptions --payload "$payload" -H "Content-Type: application/json" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>'
+orionCurl --url /ngsi-ld/v1/subscriptions --payload "$payload" -H "Content-Type: application/json" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -103,7 +103,7 @@ payload='{
     "value": 3
   }
 }'
-orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:E01/attrs?options=noOverwrite' --payload "$payload" -H "Content-Type: application/json" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>'
+orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:E01/attrs?options=noOverwrite' --payload "$payload" -H "Content-Type: application/json" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -133,7 +133,7 @@ payload='{
     "value": 4
   }
 }'
-orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:E01/attrs?options=noOverwrite' --payload "$payload" -H "Content-Type: application/json" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>'
+orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:E01/attrs?options=noOverwrite' --payload "$payload" -H "Content-Type: application/json" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_notifications_issue-1244.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_notifications_issue-1244.test
@@ -59,7 +59,7 @@ payload='{
     }
   }
 }'
-orionCurl --url /ngsi-ld/v1/subscriptions --payload "$payload" -H "Link: <https://fiware.github.io/data-models/full-context.jsonld>"
+orionCurl --url /ngsi-ld/v1/subscriptions --payload "$payload" -H 'Link: <https://fiware.github.io/data-models/full-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -79,7 +79,7 @@ payload='{
     }
   }
 }'
-orionCurl --url /ngsi-ld/v1/subscriptions --payload "$payload" -H "Link: <https://fiware.github.io/data-models/full-context.jsonld>"
+orionCurl --url /ngsi-ld/v1/subscriptions --payload "$payload" -H 'Link: <https://fiware.github.io/data-models/full-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -104,7 +104,7 @@ payload='[
     }
   }
 ]'
-orionCurl --url /ngsi-ld/v1/entityOperations/create -X POST --payload "$payload" -H "Link: <https://fiware.github.io/data-models/full-context.jsonld>"
+orionCurl --url /ngsi-ld/v1/entityOperations/create -X POST --payload "$payload" -H 'Link: <https://fiware.github.io/data-models/full-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -123,7 +123,7 @@ payload='{
   "type": "Property",
   "value": 80
 }'
-orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:Vehicle:A100/attrs/speed -X PATCH --payload "$payload" -H "Link: <https://fiware.github.io/data-models/full-context.jsonld>"
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:Vehicle:A100/attrs/speed -X PATCH --payload "$payload" -H 'Link: <https://fiware.github.io/data-models/full-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -148,7 +148,7 @@ payload='[
     }
   }
 ]'
-orionCurl --url /ngsi-ld/v1/entityOperations/upsert -X POST --payload "$payload" -H "Link: <https://fiware.github.io/data-models/full-context.jsonld>"
+orionCurl --url /ngsi-ld/v1/entityOperations/upsert -X POST --payload "$payload" -H 'Link: <https://fiware.github.io/data-models/full-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_subscription-with-mqtt-notification.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_subscription-with-mqtt-notification.test
@@ -151,7 +151,7 @@ echo
 
 echo "07. GET the subscription, with context => AirQualityObserved as shortname"
 echo "========================================================================="
-orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:mqttNotification  -H 'Link: <https://fiware.github.io/data-models/context.jsonld>'
+orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:mqttNotification  -H 'Link: <https://fiware.github.io/data-models/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -275,7 +275,7 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
     ],
     "id": "urn:ngsi-ld:Subscription:mqttNotification",
     "isActive": true,
-    "jsonldContext": "http://REGEX(.*)",
+    "jsonldContext": "https://REGEX(.*)",
     "notification": {
         "endpoint": {
             "accept": "application/json",

--- a/test/functionalTest/cases/0000_ngsild/ngsild_new_subscription_with_mqtt_issue-1178-II.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_new_subscription_with_mqtt_issue-1178-II.test
@@ -86,7 +86,7 @@ echo
 
 echo "03. GET the subscription"
 echo "========================"
-orionCurl --url $subLocation -H 'Link: <https://fiware.github.io/data-models/context.jsonld>'
+orionCurl --url $subLocation -H 'Link: <https://fiware.github.io/data-models/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_notifications_after_restarting_broker.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_notifications_after_restarting_broker.test
@@ -55,7 +55,7 @@ payload='{
     "value": "ok"
   }
 }'
-orionCurl --url /ngsi-ld/v1/entities -X POST --payload "$payload" -H "Content-Type: application/json" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>'
+orionCurl --url /ngsi-ld/v1/entities -X POST --payload "$payload" -H "Content-Type: application/json" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -83,7 +83,7 @@ payload='{
   },
   "expires": "2028-12-31T10:00:00"
 }'
-orionCurl --url /ngsi-ld/v1/subscriptions --payload "$payload" -H "Content-Type: application/json" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>'
+orionCurl --url /ngsi-ld/v1/subscriptions --payload "$payload" -H "Content-Type: application/json" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -103,7 +103,7 @@ payload='{
     "value": 3
   }
 }'
-orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:E01/attrs?options=noOverwrite' --payload "$payload" -H "Content-Type: application/json" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>'
+orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:E01/attrs?options=noOverwrite' --payload "$payload" -H "Content-Type: application/json" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -133,7 +133,7 @@ payload='{
     "value": 4
   }
 }'
-orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:E01/attrs?options=noOverwrite' --payload "$payload" -H "Content-Type: application/json" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>'
+orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:E01/attrs?options=noOverwrite' --payload "$payload" -H "Content-Type: application/json" -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_poort8.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_poort8.test
@@ -46,7 +46,7 @@ payload='{
   "type": "T",
   "eans": 12
 }'
-orionCurl --url /ngsi-ld/v1/entities --payload "$payload" -H "Link: <https://raw.githubusercontent.com/POORT8/poort8.dvu.datamodels/main/datamodels.context-ngsi.jsonl>"
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload" -H 'Link: <https://raw.githubusercontent.com/POORT8/poort8.dvu.datamodels/main/datamodels.context-ngsi.jsonl>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -58,7 +58,7 @@ payload='{
   "type": "T",
   "eans": 12
 }'
-orionCurl --url /ngsi-ld/v1/entities --payload "$payload" -H "Link: <https://raw.githubusercontent.com/POORT8/poort8.dvu.datamodels/main/datamodels.context-ngsi.jsonld>"
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload" -H 'Link: <https://raw.githubusercontent.com/POORT8/poort8.dvu.datamodels/main/datamodels.context-ngsi.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -72,7 +72,7 @@ echo
 
 echo "04. GET the entity - with POORT8's context"
 echo "=========================================="
-orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:T:E1 -H "Link: <https://raw.githubusercontent.com/POORT8/poort8.dvu.datamodels/main/datamodels.context-ngsi.jsonld>"
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:T:E1 -H 'Link: <https://raw.githubusercontent.com/POORT8/poort8.dvu.datamodels/main/datamodels.context-ngsi.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_pre-expanded-attr-name.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_pre-expanded-attr-name.test
@@ -47,7 +47,7 @@ payload='{
     "value": true
   }
 }'
-orionCurl --url /ngsi-ld/v1/entities --payload "$payload" -H "Link: <https://smartdatamodels.org/context.jsonld>"
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload" -H 'Link: <https://smartdatamodels.org/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -67,7 +67,7 @@ echo
 
 echo "03. GET the entity and see the update"
 echo "====================================="
-orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:Entity:001 -H "Link: <https://smartdatamodels.org/context.jsonld>"
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:Entity:001 -H 'Link: <https://smartdatamodels.org/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
@@ -87,7 +87,7 @@ echo
 
 echo "05. GET the entity and see the update"
 echo "====================================="
-orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:Entity:001 -H "Link: <https://smartdatamodels.org/context.jsonld>"
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:Entity:001 -H 'Link: <https://smartdatamodels.org/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subCache-with-mongoc-on-startup.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subCache-with-mongoc-on-startup.test
@@ -123,14 +123,14 @@ echo
 
 echo "05. GET the subscription from cache, with testFullContext - see short names"
 echo "==========================================================================="
-orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:subs:S1 -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld>'
+orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:subs:S1 -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 
 
 echo "06. GET the subscription from DB, with testFullContext - see short names"
 echo "========================================================================"
-orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:subs:S1?options=fromDb -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld>'
+orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:subs:S1?options=fromDb -H 'Link: <https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_with_mqtt_issue.1178.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_with_mqtt_issue.1178.test
@@ -85,7 +85,7 @@ echo
 
 echo "03. GET the subscription"
 echo "========================"
-orionCurl --url $subLocation -H 'Link: <https://fiware.github.io/data-models/context.jsonld>'
+orionCurl --url $subLocation -H 'Link: <https://fiware.github.io/data-models/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_with_mqtt_notification-with-qos-and-version.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_with_mqtt_notification-with-qos-and-version.test
@@ -78,7 +78,7 @@ echo
 
 echo "02. GET the subscripion to see the MQTT info"
 echo "============================================"
-orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:mqttNotification -H 'Link: <https://fiware.github.io/data-models/context.jsonld>'
+orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:mqttNotification -H 'Link: <https://fiware.github.io/data-models/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_with_mqtt_notification-with-qos-version-user-and-password.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_with_mqtt_notification-with-qos-version-user-and-password.test
@@ -77,7 +77,7 @@ echo
 
 echo "02. GET the subscripion to see the MQTT info"
 echo "============================================"
-orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:mqttNotification -H 'Link: <https://fiware.github.io/data-models/context.jsonld>'
+orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:mqttNotification -H 'Link: <https://fiware.github.io/data-models/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_with_mqtt_notification-with-qos.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_with_mqtt_notification-with-qos.test
@@ -75,7 +75,7 @@ echo
 
 echo "02. GET the subscripion to see the MQTT info"
 echo "============================================"
-orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:mqttNotification -H 'Link: <https://fiware.github.io/data-models/context.jsonld>'
+orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:mqttNotification -H 'Link: <https://fiware.github.io/data-models/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_with_mqtt_notification-with-user-and-password.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_with_mqtt_notification-with-user-and-password.test
@@ -68,7 +68,7 @@ echo
 
 echo "02. GET the subscripion to see the MQTT info"
 echo "============================================"
-orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:mqttNotification -H 'Link: <https://fiware.github.io/data-models/context.jsonld>'
+orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:mqttNotification -H 'Link: <https://fiware.github.io/data-models/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_with_mqtt_notification-with-version.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_with_mqtt_notification-with-version.test
@@ -74,7 +74,7 @@ echo
 
 echo "02. GET the subscripion to see the MQTT info"
 echo "============================================"
-orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:mqttNotification -H 'Link: <https://fiware.github.io/data-models/context.jsonld>'
+orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:mqttNotification -H 'Link: <https://fiware.github.io/data-models/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ngsild/ngsild_subscription_with_mqtt_notifications.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_subscription_with_mqtt_notifications.test
@@ -88,7 +88,7 @@ echo
 
 echo "03. GET the subscription"
 echo "========================"
-orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:mqttNotification -H 'Link: <https://fiware.github.io/data-models/context.jsonld>'
+orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:mqttNotification -H 'Link: <https://fiware.github.io/data-models/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 echo
 echo
 

--- a/test/functionalTest/cases/0000_troe/troe_new_exhaustive_patch_attributes.test
+++ b/test/functionalTest/cases/0000_troe/troe_new_exhaustive_patch_attributes.test
@@ -30,7 +30,7 @@ dbInit CB
 dbInit CB t1
 pgInit $CB_DB_NAME
 pgInit ${CB_DB_NAME}_t1
-brokerStart CB 100 IPv4 -troe -multiservice -experimental
+orionldStart CB -troe -multiservice -experimental
 
 --SHELL--
 
@@ -435,7 +435,7 @@ echo
 echo "13. Patch E2, all 7 attributes, on T1 tenant and with user context in payload body - make sure createdAt+modifiedAt+weight+owner are ignored and that the other three are REPLACED"
 echo "=================================================================================================================================================================================="
 payload='{
-  "@context": "https://raw.githubusercontent.com/FIWARE/tutorials.NGSI-LD/master/app/public/data-models/ngsi-context.jsonld",
+  "@context": [ "https://raw.githubusercontent.com/FIWARE/tutorials.NGSI-LD/master/app/public/data-models/ngsi-context.jsonld" ],
   "id": "urn:ngsi-ld:entity:E2",
   "type": "Device",
   "location": {

--- a/test/functionalTest/harnessFunctions.sh
+++ b/test/functionalTest/harnessFunctions.sh
@@ -1473,9 +1473,9 @@ function orionCurl()
     elif [ "$1" == "--tenant2" ]; then         _tenant='--header "NGSILD-Tenant: '${2}'"'; shift;
     elif [ "$1" == "--origin" ]; then          _origin='--header "Origin: '${2}'"'; shift;
     elif [ "$1" == "--correlator" ]; then      _correlator='--header "Fiware-Correlator: '${2}'"'; shift;
-    elif [ "$1" == "-H" ]; then                _headers=${_headers}" --header \"$2\""; shift;
-    elif [ "$1" == "--header" ]; then          _headers=${_headers}" --header \"$2\""; shift;
-    elif [ "$1" == "-Link" ]; then             _Link="$2"; shift;
+    elif [ "$1" == "-H" ]; then                _headers=${_headers}" --header '"$2"'"; shift;
+    elif [ "$1" == "--header" ]; then          _headers=${_headers}" --header '"$2"'"; shift;
+    elif [ "$1" == "-Link" ]; then             _Link=\'$2\'; shift;
     elif [ "$1" == "--in" ]; then              _in="$2"; shift;
     elif [ "$1" == "--out" ]; then             _out="$2"; shift;
     elif [ "$1" == "--xauthToken" ]; then      _xauthToken='--header "X-Auth-Token: '${2}'"'; shift;
@@ -1602,7 +1602,6 @@ function orionCurl()
   command=${command}' --header "Expect:"'
   command=${command}' -k -s -S --dump-header /tmp/httpHeaders.out'
   logMsg command: $command
-
 
   #
   # Execute the command


### PR DESCRIPTION
## Fixed issue #1760 

## Note
Fixing the issue #1760, Orion-LD is now more strict about the syntax in the HTTP Link header for @contexts.  

Before this fix, the following Link header was accepted:
`    Link: <URL to user context>`

  That's not valid HTTP so now, after the fix, the link header must have the 'rel' property set to exactly:  
"http://www.w3.org/ns/json-ld#context":
`    Link: <URL to user context>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"`

  [ No check is made for the 'type' property' ]
