### PR TITLE
no-array-reduction (for aerOS) in Simplified format

### DIFF
--- a/src/lib/orionld/payloadCheck/pCheckAttribute.cpp
+++ b/src/lib/orionld/payloadCheck/pCheckAttribute.cpp
@@ -158,6 +158,9 @@ static void arrayReduceForLangProp(KjNode* languageMapP)
   if (languageMapP->type != KjObject)
     return;
 
+  if (noArrayReduction == true)  // Global variable, from CLI
+    return;
+
   for (KjNode* lmapValueP = languageMapP->value.firstChildP; lmapValueP != NULL; lmapValueP = lmapValueP->next)
   {
     if (lmapValueP->type == KjArray)
@@ -173,7 +176,7 @@ static void arrayReduceForLangProp(KjNode* languageMapP)
 //
 static bool pCheckTypeFromContext(KjNode* attrP, OrionldContextItem* attrContextInfoP)
 {
-  bool arrayReduction = true;
+  bool arrayReduction = (noArrayReduction == true)? false : true;
 
   if ((attrContextInfoP != NULL) && (attrContextInfoP->type != NULL))
   {
@@ -411,7 +414,10 @@ inline bool pCheckAttributeArray
   valueP->lastChild         = attrP->lastChild;
 
   pCheckAttributeTransform(attrP, "Property", valueP);
-  arrayReduce(valueP);
+
+  if (noArrayReduction == false)  // Global variable, from CLI
+    arrayReduce(valueP);
+
   return true;
 }
 
@@ -880,9 +886,9 @@ bool multiAttributeArray(KjNode* attrArrayP, bool* errorP)
 
   if (objects - datasets > 1)  // More than one object without datasetId field
   {
-      orionldError(OrionldBadRequestData, "More than one default attribute in dataset array", attrArrayP->name, 400);
-      *errorP = true;
-      return false;
+    orionldError(OrionldBadRequestData, "More than one default attribute in dataset array", attrArrayP->name, 400);
+    *errorP = true;
+    return false;
   }
 
   return true;

--- a/test/functionalTest/cases/0000_ngsild/ngsild_no-array-reduction-and-concise-format.test
+++ b/test/functionalTest/cases/0000_ngsild/ngsild_no-array-reduction-and-concise-format.test
@@ -68,7 +68,7 @@ Location: /ngsi-ld/v1/entities/urn:E1
 02. GET E1 - see the arrays reduced
 ===================================
 HTTP/1.1 200 OK
-Content-Length: 98
+Content-Length: 100
 Content-Type: application/json
 Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
@@ -76,7 +76,9 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
 {
     "A1": {
         "type": "Property",
-        "value": 1
+        "value": [
+            1
+        ]
     },
     "A2": {
         "type": "Property",


### PR DESCRIPTION
The aerOS option (non-NGSI-LD) -noArrayReduction didn't take effect if creating entities with attributes in Simplified format.
Now it works.
