### PR TITLE
Dds/functestfix

### DIFF
--- a/src/lib/orionld/dds/ddsPublishAttribute.cpp
+++ b/src/lib/orionld/dds/ddsPublishAttribute.cpp
@@ -218,7 +218,7 @@ void ddsPublishAttribute(const char* entityId, const char* attrName, KjNode* att
   char* serialized = kjDdsType(valueP, serializedV, sizeof(serializedV));
 
   if (strcmp(serialized, typeP->type) != 0)
-    KT_RVE("Not publishing attribute '%s' of entity '%s' on DDS as types differ: expected from DDS: '%s', got via HTTP: '%s'", attrName, entityId, typeP->type, serialized);
+    KT_W("Publishing attribute '%s' of entity '%s' on DDS even though types differ: expected from DDS: '%s', got via HTTP: '%s'", attrName, entityId, typeP->type, serialized);
 
   //
   // All good, lets serialize and send to the DDS Enabler

--- a/src/lib/orionld/mhd/mhdRequest.cpp
+++ b/src/lib/orionld/mhd/mhdRequest.cpp
@@ -39,7 +39,7 @@ extern "C"
 #include "orionld/mhd/mhdRequest.h"                              // Own interface
 
 
-__thread int mhdCalls = 0;
+static int mhdCalls = 0;
 
 
 
@@ -62,14 +62,14 @@ MHD_Result mhdRequest
   void**           con_cls
 )
 {
-  ++mhdCalls;
   if (mhdCalls > 50)
     KT_X(1, "More than 50 MHD calls");
 
   if (*con_cls == NULL)
   {
+    ++mhdCalls;
     KT_T(StRequest, "=======================================================================================");
-    KT_T(StRequest, "Incoming request: %s %s, type I (*con_cls == %p)", method, url, *con_cls);
+    KT_T(StRequest, "KZ: Incoming request %d: %s %s, type I (*con_cls == %p)", mhdCalls, method, url, *con_cls);
     KT_T(StRequest, "=======================================================================================");
     KT_T(StRequest, "");
     *con_cls = &cls;  // to "acknowledge" the first call
@@ -78,13 +78,13 @@ MHD_Result mhdRequest
   }
   else if (*upload_data_size != 0)
   {
-    KT_T(StRequest, "Incoming request: %s %s, type II - body (*con_cls == %p)", method, url, *con_cls);
+    KT_T(StRequest, "Request: %s %s, type II - body (*con_cls == %p)", method, url, *con_cls);
     return mhdRequestBodyF(upload_data_size, upload_data);
   }
   else
   {
-    KT_T(StRequest, "Incoming request: %s %s, type III - last call (*con_cls == %p)", method, url, *con_cls);
-    KT_T(StRequest, "Incoming request: %s %s", method, url);
+    KT_T(StRequest, "Request: %s %s, type III - last call (*con_cls == %p)", method, url, *con_cls);
+    KT_T(StRequest, "Request: %s %s", method, url);
     *upload_data_size = 0;  // Mark the request as "finished"
 
     int            statusCode;
@@ -97,10 +97,13 @@ MHD_Result mhdRequest
     else
       responseLen = strlen(response);
 
-    KT_T(StRequest, "Response(%d bytes): '%s'", responseLen, response);
+    KT_T(StRequest, "Response (%d bytes): '%s'", responseLen, response);
     r = MHD_create_response_from_buffer(responseLen, response, MHD_RESPMEM_MUST_COPY);
     MHD_queue_response(connection, statusCode, r);
     MHD_destroy_response(r);
+
+    if (responseLen > 0)
+      bzero(response, responseLen);
   }
 
   return MHD_YES;

--- a/test/functionalTest/cases/0000_ld/dds/dds_notifications.test
+++ b/test/functionalTest/cases/0000_ld/dds/dds_notifications.test
@@ -38,9 +38,9 @@ ftClientStart -t 0-5000
 # 02. Ask FT to publish an entity urn:E2 on topic 'P2'
 # 03. Ask FT to publish an entity urn:E3 on topic 'P3'
 # 04. Ask FT to publish an entity urn:E4 on topic 'P4'
-# 05. Query the broker for all its entities, see all three (urn:ngsi-ld:camera:cam1, urn:ngsi-ld:arm:arm1, and the default entity))
+# 05. Query the broker for all its entities, see three (urn:ngsi-ld:camera:cam1, urn:ngsi-ld:arm:arm1, and the default entity)
 #
-# 06. Create a subscription for entity type 'Camera'
+# 06. Create a subscription for entity type 'Camera', to be received by the ftClient
 # 07. Ask FT to publish an entity urn:E1 on topic 'P1' - to provoke a notification to ftClient
 # 08. Ping broker to make sure it's still OK (issue XXX says it dies)
 # 09. Dump the ftClient to see the notification
@@ -56,7 +56,7 @@ ftClientStart -t 0-5000
 echo "01. Ask FT to publish an entity urn:E1 on topic 'P1'"
 echo "===================================================="
 payload='{
-  "s": "abc"
+  "s": "step 01"
 }'
 orionCurl --url '/dds/pub?ddsTopicType=xyz&entityId=urn:E1&entityType=T&ddsTopicName=P1' --port $FT_PORT --payload "$payload"
 echo
@@ -66,7 +66,8 @@ echo
 echo "02. Ask FT to publish an entity urn:E2 on topic 'P2'"
 echo "===================================================="
 payload='{
-  "i": 2
+  "i": 2,
+  "s": "step 02"
 }'
 orionCurl --url '/dds/pub?ddsTopicType=xyz&entityId=urn:E2&entityType=T&ddsTopicName=P2' --port $FT_PORT --payload "$payload"
 echo
@@ -76,7 +77,8 @@ echo
 echo "03. Ask FT to publish an entity urn:E3 on topic 'P3'"
 echo "===================================================="
 payload='{
-  "f": 3.14
+  "f": 3.14,
+  "s": "step 03"
 }'
 orionCurl --url '/dds/pub?ddsTopicType=xyz&entityId=urn:E3&entityType=T&ddsTopicName=P3' --port $FT_PORT --payload "$payload"
 echo
@@ -86,7 +88,7 @@ echo
 echo "04. Ask FT to publish an entity urn:E4 on topic 'P4'"
 echo "===================================================="
 payload='{
-  "s": "p4",
+  "s": "step 04",
   "i": 4,
   "f": 4.14
 }'
@@ -95,15 +97,16 @@ echo
 echo
 
 
-echo "05. Query the broker for all its entities, see all four"
-echo "======================================================="
+echo "05. Query the broker for all its entities, see three (urn:ngsi-ld:camera:cam1, urn:ngsi-ld:arm:arm1, and the default entity)"
+echo "============================================================================================================================"
+sleep 2
 orionCurl --url /ngsi-ld/v1/entities?local=true
 echo
 echo
 
 
-echo "06. Create a subscription for entity type 'Camera'"
-echo "=================================================="
+echo "06. Create a subscription for entity type 'Camera', to be received by the ftClient"
+echo "=================================================================================="
 payload='{
   "id": "urn:s1",
   "type": "Subscription",
@@ -126,7 +129,7 @@ echo
 echo "07. Ask FT to publish an entity urn:E1 on topic 'P1' - to provoke a notification to ftClient"
 echo "============================================================================================"
 payload='{
-  "s": "def"
+  "s": "step 07"
 }'
 orionCurl --url '/dds/pub?ddsTopicType=xyz&entityId=urn:E1&entityType=T&ddsTopicName=P1' --port $FT_PORT --payload "$payload"
 echo
@@ -207,9 +210,8 @@ HTTP/1.1 204 No Content
 Date: REGEX(.*)
 
 
-
-05. Query the broker for all its entities, see all four
-=======================================================
+05. Query the broker for all its entities, see three (urn:ngsi-ld:camera:cam1, urn:ngsi-ld:arm:arm1, and the default entity)
+============================================================================================================================
 HTTP/1.1 200 OK
 Content-Length: REGEX(.*)
 Content-Type: application/json
@@ -245,7 +247,7 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
                     1,
                     2
                 ],
-                "s": "abc"
+                "s": "step 01"
             },
             "xId": {
                 "type": "Property",
@@ -277,7 +279,7 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
                     0,
                     0
                 ],
-                "s": ""
+                "s": "step 02"
             },
             "xId": {
                 "type": "Property",
@@ -314,7 +316,7 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
                     0,
                     0
                 ],
-                "s": ""
+                "s": "step 03"
             },
             "xId": {
                 "type": "Property",
@@ -343,7 +345,7 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
                     0,
                     0
                 ],
-                "s": "p4"
+                "s": "step 04"
             },
             "xId": {
                 "type": "Property",
@@ -360,8 +362,8 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
 ]
 
 
-06. Create a subscription for entity type 'Camera'
-==================================================
+06. Create a subscription for entity type 'Camera', to be received by the ftClient
+==================================================================================
 HTTP/1.1 201 Created
 Content-Length: 0
 Date: REGEX(.*)
@@ -416,7 +418,7 @@ Content-Length: REGEX(.*)
 Date: REGEX(.*)
 
 POST /notify?subscriptionId=urn:s1
-Content-Length: 617
+Content-Length: REGEX(.*)
 Content-Type: application/json
 User-Agent: orionld/REGEX(.*)
 Host: REGEX(.*)
@@ -446,7 +448,7 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
             1,
             2
           ],
-          "s": "def"
+          "s": "step 07"
         },
         "xId": {
           "type": "Property",

--- a/test/functionalTest/cases/0000_ld/dds/dds_publish_patch_attribute-with-invalid-value.test
+++ b/test/functionalTest/cases/0000_ld/dds/dds_publish_patch_attribute-with-invalid-value.test
@@ -46,8 +46,9 @@ payload='{
   "s": "111"
 }'
 orionCurl --url '/dds/pub?ddsTopicType=xyz&entityId=urn:ngsi-ld:camera:cam1&entityType=T&ddsTopicName=P1' --port $FT_PORT --payload "$payload"
-echo
-echo
+
+# The ftClient gets a callback on the topic for its own request - deleting it
+orionCurl --url /dds/dump --port $FT_PORT --noPayloadCheck -X DELETE
 
 
 echo "02. GET urn:ngsi-ld:camera:cam1 from CB"
@@ -90,6 +91,9 @@ echo
 HTTP/1.1 204 No Content
 Date: REGEX(.*)
 
+HTTP/1.1 200 OK
+Content-Length: 0
+Date: REGEX(.*)
 
 
 02. GET urn:ngsi-ld:camera:cam1 from CB
@@ -189,30 +193,9 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
 05. Dump the ftClient for DDS notifications - see no PATCH in DDS
 =================================================================
 HTTP/1.1 200 OK
-Content-Length: REGEX(.*)
+Content-Length: 0
 Date: REGEX(.*)
 
-[
-  {
-    "P1": {
-      "data": {
-        "REGEX(.*)": {
-          "b": false,
-          "f": 0,
-          "i": 0,
-          "ia": [
-            1,
-            2
-          ],
-          "s": "111"
-        }
-      },
-      "type": "NgsildSample"
-    },
-    "id": "REGEX(.*)",
-    "type": "fastdds"
-  }
-]
 
 
 

--- a/test/functionalTest/cases/0000_ld/dds/dds_publish_patch_attribute.test
+++ b/test/functionalTest/cases/0000_ld/dds/dds_publish_patch_attribute.test
@@ -47,8 +47,9 @@ payload='{
   "s": "111"
 }'
 orionCurl --url '/dds/pub?ddsTopicType=xyz&entityId=urn:ngsi-ld:camera:cam1&entityType=T&ddsTopicName=P1' --port $FT_PORT --payload "$payload"
-echo
-echo
+
+# The ftClient gets a callback on the topic for its own request - deleting it
+orionCurl --url /dds/dump --port $FT_PORT --noPayloadCheck -X DELETE
 
 
 echo "02. GET urn:ngsi-ld:camera:cam1 from CB"
@@ -98,6 +99,9 @@ echo
 HTTP/1.1 204 No Content
 Date: REGEX(.*)
 
+HTTP/1.1 200 OK
+Content-Length: 0
+Date: REGEX(.*)
 
 
 02. GET urn:ngsi-ld:camera:cam1 from CB
@@ -208,25 +212,6 @@ Content-Length: REGEX(.*)
 Date: REGEX(.*)
 
 [
-  {
-    "P1": {
-      "data": {
-        "REGEX(.*)": {
-          "b": false,
-          "f": 0,
-          "i": 0,
-          "ia": [
-            1,
-            2
-          ],
-          "s": "111"
-        }
-      },
-      "type": "NgsildSample"
-    },
-    "id": "REGEX(.*)",
-    "type": "fastdds"
-  },
   {
     "P1": {
       "data": {

--- a/test/functionalTest/cases/0000_ld/dds/dds_publish_patch_entity.test
+++ b/test/functionalTest/cases/0000_ld/dds/dds_publish_patch_entity.test
@@ -52,8 +52,8 @@ payload='{
   "s": "step 01"
 }'
 orionCurl --url '/dds/pub?ddsTopicType=xyz&entityId=urn:ngsi-ld:camera:cam1&entityType=T&ddsTopicName=P1' --port $FT_PORT --payload "$payload"
-echo
-echo
+# The ftClient gets a callback on the topic for its own request - deleting it
+orionCurl --url /dds/dump --port $FT_PORT --noPayloadCheck -X DELETE
 
 
 echo "02. GET urn:ngsi-ld:camera:cam1 from CB"
@@ -92,6 +92,7 @@ echo "05. Dump/Reset the ftClient for DDS notifications - see the PATCH in DDS"
 echo "========================================================================"
 sleep 1
 orionCurl --url /dds/dump --port $FT_PORT --noPayloadCheck
+sleep .1
 orionCurl --url /dds/dump --port $FT_PORT --noPayloadCheck -X DELETE
 echo
 echo
@@ -127,6 +128,7 @@ echo "08. Dump/Reset the ftClient for DDS notifications - see the PATCH in DDS"
 echo "========================================================================"
 sleep 1
 orionCurl --url /dds/dump --port $FT_PORT --noPayloadCheck
+sleep .1
 orionCurl --url /dds/dump --port $FT_PORT --noPayloadCheck -X DELETE
 echo
 echo
@@ -160,6 +162,7 @@ echo "11. Dump/Reset the ftClient for DDS notifications - see no update in DDS"
 echo "========================================================================"
 sleep 1
 orionCurl --url /dds/dump --port $FT_PORT --noPayloadCheck
+sleep .1
 orionCurl --url /dds/dump --port $FT_PORT --noPayloadCheck -X DELETE
 echo
 echo
@@ -171,6 +174,9 @@ echo
 HTTP/1.1 204 No Content
 Date: REGEX(.*)
 
+HTTP/1.1 200 OK
+Content-Length: REGEX(.*)
+Date: REGEX(.*)
 
 
 02. GET urn:ngsi-ld:camera:cam1 from CB
@@ -265,25 +271,6 @@ Content-Length: REGEX(.*)
 Date: REGEX(.*)
 
 [
-  {
-    "P1": {
-      "data": {
-        "REGEX(.*)": {
-          "b": false,
-          "f": 0,
-          "i": 0,
-          "ia": [
-            1,
-            2
-          ],
-          "s": "step 01"
-        }
-      },
-      "type": "NgsildSample"
-    },
-    "id": "REGEX(.*)",
-    "type": "fastdds"
-  },
   {
     "P1": {
       "data": {

--- a/test/functionalTest/cases/0000_ld/dds/dds_publish_patch_entity2.test
+++ b/test/functionalTest/cases/0000_ld/dds/dds_publish_patch_entity2.test
@@ -47,8 +47,9 @@ payload='{
   "s": "abc"
 }'
 orionCurl --url '/dds/pub?ddsTopicType=xyz&entityId=urn:ngsi-ld:camera:cam1&entityType=T&ddsTopicName=P1' --port $FT_PORT --payload "$payload"
-echo
-echo
+
+# The ftClient gets a callback on the topic for its own request - deleting it
+orionCurl --url /dds/dump --port $FT_PORT --noPayloadCheck -X DELETE
 
 
 echo "02. GET urn:ngsi-ld:camera:cam1 from CB"
@@ -93,6 +94,9 @@ echo
 HTTP/1.1 204 No Content
 Date: REGEX(.*)
 
+HTTP/1.1 200 OK
+Content-Length: 0
+Date: REGEX(.*)
 
 
 02. GET urn:ngsi-ld:camera:cam1 from CB
@@ -203,25 +207,6 @@ Content-Length: REGEX(.*)
 Date: REGEX(.*)
 
 [
-  {
-    "P1": {
-      "data": {
-        "REGEX(.*)": {
-          "b": false,
-          "f": 0,
-          "i": 0,
-          "ia": [
-            1,
-            2
-          ],
-          "s": "abc"
-        }
-      },
-      "type": "NgsildSample"
-    },
-    "id": "REGEX(.*)",
-    "type": "fastdds"
-  },
   {
     "P1": {
       "data": {

--- a/test/functionalTest/cases/0000_ld/dds/dds_publish_post_batch_update.test
+++ b/test/functionalTest/cases/0000_ld/dds/dds_publish_post_batch_update.test
@@ -52,8 +52,9 @@ payload='{
   "s": "step 01"
 }'
 orionCurl --url '/dds/pub?ddsTopicType=xyz&entityId=urn:ngsi-ld:camera:cam1&entityType=T&ddsTopicName=P1' --port $FT_PORT --payload "$payload"
-echo
-echo
+
+# The ftClient gets a callback on the topic for its own request - deleting it
+orionCurl --url /dds/dump --port $FT_PORT --noPayloadCheck -X DELETE
 
 
 echo "02. GET urn:ngsi-ld:camera:cam1 from CB"
@@ -180,6 +181,9 @@ echo
 HTTP/1.1 204 No Content
 Date: REGEX(.*)
 
+HTTP/1.1 200 OK
+Content-Length: 0
+Date: REGEX(.*)
 
 
 02. GET urn:ngsi-ld:camera:cam1 from CB
@@ -274,25 +278,6 @@ Content-Length: REGEX(.*)
 Date: REGEX(.*)
 
 [
-  {
-    "P1": {
-      "data": {
-        "REGEX(.*)": {
-          "b": false,
-          "f": 0,
-          "i": 0,
-          "ia": [
-            1,
-            2
-          ],
-          "s": "step 01"
-        }
-      },
-      "type": "NgsildSample"
-    },
-    "id": "REGEX(.*)",
-    "type": "fastdds"
-  },
   {
     "P1": {
       "data": {

--- a/test/functionalTest/cases/0000_ld/dds/dds_publish_post_entity.test
+++ b/test/functionalTest/cases/0000_ld/dds/dds_publish_post_entity.test
@@ -52,8 +52,9 @@ payload='{
   "s": "step 01"
 }'
 orionCurl --url '/dds/pub?ddsTopicType=xyz&entityId=urn:ngsi-ld:camera:cam1&entityType=T&ddsTopicName=P1' --port $FT_PORT --payload "$payload"
-echo
-echo
+
+# The ftClient gets a callback on the topic for its own request - deleting it
+orionCurl --url /dds/dump --port $FT_PORT --noPayloadCheck -X DELETE
 
 
 echo "02. GET urn:ngsi-ld:camera:cam1 from CB"
@@ -171,6 +172,9 @@ echo
 HTTP/1.1 204 No Content
 Date: REGEX(.*)
 
+HTTP/1.1 200 OK
+Content-Length: 0
+Date: REGEX(.*)
 
 
 02. GET urn:ngsi-ld:camera:cam1 from CB
@@ -265,25 +269,6 @@ Content-Length: REGEX(.*)
 Date: REGEX(.*)
 
 [
-  {
-    "P1": {
-      "data": {
-        "REGEX(.*)": {
-          "b": false,
-          "f": 0,
-          "i": 0,
-          "ia": [
-            1,
-            2
-          ],
-          "s": "step 01"
-        }
-      },
-      "type": "NgsildSample"
-    },
-    "id": "REGEX(.*)",
-    "type": "fastdds"
-  },
   {
     "P1": {
       "data": {

--- a/test/functionalTest/cases/0000_ld/dds/dds_publish_put_attribute.test
+++ b/test/functionalTest/cases/0000_ld/dds/dds_publish_put_attribute.test
@@ -47,8 +47,9 @@ payload='{
   "s": "111"
 }'
 orionCurl --url '/dds/pub?ddsTopicType=xyz&entityId=urn:ngsi-ld:camera:cam1&entityType=T&ddsTopicName=P1' --port $FT_PORT --payload "$payload"
-echo
-echo
+
+# The ftClient gets a callback on the topic for its own request - deleting it
+orionCurl --url /dds/dump --port $FT_PORT --noPayloadCheck -X DELETE
 
 
 echo "02. GET urn:ngsi-ld:camera:cam1 from CB"
@@ -98,6 +99,9 @@ echo
 HTTP/1.1 204 No Content
 Date: REGEX(.*)
 
+HTTP/1.1 200 OK
+Content-Length: 0
+Date: REGEX(.*)
 
 
 02. GET urn:ngsi-ld:camera:cam1 from CB
@@ -192,25 +196,6 @@ Content-Length: REGEX(.*)
 Date: REGEX(.*)
 
 [
-  {
-    "P1": {
-      "data": {
-        "REGEX(.*)": {
-          "b": false,
-          "f": 0,
-          "i": 0,
-          "ia": [
-            1,
-            2
-          ],
-          "s": "111"
-        }
-      },
-      "type": "NgsildSample"
-    },
-    "id": "REGEX(.*)",
-    "type": "fastdds"
-  },
   {
     "P1": {
       "data": {

--- a/test/functionalTest/cases/0000_ld/dds/dds_publish_put_entity.test
+++ b/test/functionalTest/cases/0000_ld/dds/dds_publish_put_entity.test
@@ -52,8 +52,9 @@ payload='{
   "s": "step 01"
 }'
 orionCurl --url '/dds/pub?ddsTopicType=xyz&entityId=urn:ngsi-ld:camera:cam1&entityType=T&ddsTopicName=P1' --port $FT_PORT --payload "$payload"
-echo
-echo
+
+# The ftClient gets a callback on the topic for its own request - deleting it
+orionCurl --url /dds/dump --port $FT_PORT --noPayloadCheck -X DELETE
 
 
 echo "02. GET urn:ngsi-ld:camera:cam1 from CB"
@@ -174,6 +175,9 @@ echo
 HTTP/1.1 204 No Content
 Date: REGEX(.*)
 
+HTTP/1.1 200 OK
+Content-Length: 0
+Date: REGEX(.*)
 
 
 02. GET urn:ngsi-ld:camera:cam1 from CB
@@ -264,25 +268,6 @@ Content-Length: REGEX(.*)
 Date: REGEX(.*)
 
 [
-  {
-    "P1": {
-      "data": {
-        "REGEX(.*)": {
-          "b": false,
-          "f": 0,
-          "i": 0,
-          "ia": [
-            1,
-            2
-          ],
-          "s": "step 01"
-        }
-      },
-      "type": "NgsildSample"
-    },
-    "id": "REGEX(.*)",
-    "type": "fastdds"
-  },
   {
     "P1": {
       "data": {

--- a/test/functionalTest/ftClient/NgsildPublisher.cpp
+++ b/test/functionalTest/ftClient/NgsildPublisher.cpp
@@ -50,7 +50,7 @@ extern "C"
 
 #include "orionld/common/traceLevels.h"                     // Trace Levels
 #include "orionld/common/orionldState.h"                    // orionldState
-#include "ftClient/NgsildPublisher.h"                    // NgsildPublisher
+#include "ftClient/NgsildPublisher.h"                       // NgsildPublisher
 #include "orionld/dds/kjTreeLog.h"                          // kjTreeLog2
 
 
@@ -217,6 +217,12 @@ bool NgsildPublisher::publish(const char* entityType, const char* entityId, cons
       }
       else if  (r == eprosima::fastdds::dds::RETCODE_TIMEOUT)
         KT_W("KZ: wait_for_acknowledgments timed out (1 second!)");
+      else if (r == 1)
+      {
+        KT_W("KZ: wait_for_acknowledgments reports error 1 but that's OK according to eProsima");
+        ret = true;
+        break;
+      }
       else
         KT_E("KZ: wait_for_acknowledgments failed with error %d", r);
     }

--- a/test/functionalTest/ftClient/deleteDdsDump.cpp
+++ b/test/functionalTest/ftClient/deleteDdsDump.cpp
@@ -49,9 +49,7 @@ KjNode* deleteDdsDump(int* statusCodeP)
   if (ddsDumpArray != NULL)
     kjFree(ddsDumpArray);  // Crash!
 
-  KT_T(StRequest, "Resetting DDS Dump");
   ddsDumpArray = NULL;
-  KT_T(StRequest, "Resetting DDS Dump");
 
   *statusCodeP = 200;
   return NULL;

--- a/test/functionalTest/ftClient/mhdRequestTreat.cpp
+++ b/test/functionalTest/ftClient/mhdRequestTreat.cpp
@@ -127,6 +127,7 @@ char* mhdRequestTreat(int* statusCodeP)
       int     bufSize      = kjRenderSize(orionldState.kjsonP, responseTree) + 1024;
       char*   buf          = kaAlloc(&orionldState.kalloc, bufSize);
 
+      bzero(buf, bufSize);
       kjRender(orionldState.kjsonP, responseTree, buf, bufSize);
       return buf;
     }


### PR DESCRIPTION
1. Made the DDS functests work (it was an error in ftClient) - except one (dds_notifications.test) that is still failing.
2. Temporarily (I think) removed the check for exact match of types before publishing in DDS.
     We need this for tests in a Pilot of ARISE.
     The change make another 4 functests fail (as they do error handling on the "don't publish on DDS if not exact same type")
