### PR TITLE
Added a CLI option '-kToScreen' to see K-Traces on stdout

### DIFF
--- a/src/app/orionld/orionld.cpp
+++ b/src/app/orionld/orionld.cpp
@@ -256,6 +256,7 @@ char            defaultUserContextUrl[256];
 bool            ddsSupport       = false;
 char            configFile[512];
 bool            extras;
+bool            kToScreen        = false;
 char            kTraceLevels[256];
 
 
@@ -357,6 +358,7 @@ char            kTraceLevels[256];
 #define DUC_URL_DESC           "URL to default user context"
 #define EXTRAS_DESC            "Extra stuff, non-NGSI-LD, like 'origin' in subs/regs"
 #define KTRACE_LEVELS_DESC     "K-Trace levels"
+#define KTOSCREEN_DESC         "K-Trace to stdout"
 
 
 
@@ -467,6 +469,7 @@ PaArgument paArgs[] =
   { "-configFile",            configFile,               "CONFIG_FILE",               PaString,  PaOpt,  _i "",             PaNL,  PaNL,             CONFIG_FILE_DESC          },
   { "-duc",                   defaultUserContextUrl,    "DUC_URL",                   PaString,  PaOpt,  _i "",             PaNL,  PaNL,             DUC_URL_DESC              },
   { "-kt",                    kTraceLevels,             "KTRACE_LEVELS",             PaString,  PaOpt,  _i "",             PaNL,  PaNL,             KTRACE_LEVELS_DESC        },
+  { "-kToScreen",             &kToScreen,               "KTOSCREEN",                 PaBool,    PaOpt,  false,            false,  true,             KTOSCREEN_DESC            },
 
   PA_END_OF_ARGS
 };
@@ -1250,6 +1253,8 @@ int main(int argC, char* argV[])
   // This call redirects all log messages from the K-libs to the brokers log file.
   //
   kInit(libLogFunction);
+  if (kToScreen == true)
+    ktToScreen = KTRUE;
 
 
   //

--- a/test/functionalTest/cases/0000_cli/bool_option_with_value.test
+++ b/test/functionalTest/cases/0000_cli/bool_option_with_value.test
@@ -119,5 +119,6 @@ Usage: orionld  [option '-U' (extended usage)]
                 [option '-configFile' <Path to configuration file>]
                 [option '-duc' <URL to default user context>]
                 [option '-kt' <K-Trace levels>]
+                [option '-kToScreen' (K-Trace to stdout)]
 
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_cli/command_line_options.test
+++ b/test/functionalTest/cases/0000_cli/command_line_options.test
@@ -108,5 +108,6 @@ Usage: orionld  [option '-U' (extended usage)]
                 [option '-configFile' <Path to configuration file>]
                 [option '-duc' <URL to default user context>]
                 [option '-kt' <K-Trace levels>]
+                [option '-kToScreen' (K-Trace to stdout)]
 
 --TEARDOWN--


### PR DESCRIPTION
Added a CLI option `-kToScreen` to make the broker print K-Trace logs on stdout