### PR TITLE
Better checks for the config file when DDS enabled

### DIFF
--- a/src/lib/orionld/config/configInit.cpp
+++ b/src/lib/orionld/config/configInit.cpp
@@ -55,7 +55,13 @@ void configInit(Kjson* kjP, char* configFile)
     {
       snprintf(configFile, 511, "%s/.orionld", home);
       if (access(configFile, R_OK) != 0)
-        return;  // It's OK to not have a config file
+      {
+        // It's OK to not have a config file, as lonmg as DDS is not turned on
+        if (ddsSupport == true)
+          LM_X(1, ("DDS functionality demands a configuration file"));
+
+        return;
+      }
     }
   }
 

--- a/src/lib/orionld/config/configLoad.cpp
+++ b/src/lib/orionld/config/configLoad.cpp
@@ -22,7 +22,7 @@
 *
 * Author: Ken Zangelin
 */
-#include <unistd.h>                                         // NULL
+#include <unistd.h>                                         // NULL, getcwd
 
 extern "C"
 {
@@ -54,7 +54,10 @@ int configLoad(Kjson* kjP, const char* configFile)
   int   bufLen = 0;
 
   if (kFileRead((char*) "", (char*) configFile, &buf, &bufLen) != 0)
-    KT_RE(1, "Error reading the configuration file '%s'", configFile);
+  {
+    char wd[512];
+    KT_RE(1, "Error reading the configuration file '%s/%s'", getcwd(wd, sizeof(wd) - 1), configFile);
+  }
 
   configTree = kjParse(kjP, buf);
   if (configTree == NULL)


### PR DESCRIPTION
Giving error at startup if no config file is given and DDS is turned on.