### PR TITLE
New base image for a new version of kjson

### DIFF
--- a/.github/workflows/mintaka-compatibility.yml
+++ b/.github/workflows/mintaka-compatibility.yml
@@ -58,7 +58,6 @@ jobs:
         run: |
           # Mintaka uses Testcontainers 1.15.1 (Docker API v1.30) which is too old
           # for the runner's Docker engine (Docker 29+ requires API v1.44+)
-          # Testcontainers 1.21.3+ defaults to API v1.44
           sed -i 's|<version.org.testcontainers>[^<]*</version.org.testcontainers>|<version.org.testcontainers>1.21.3</version.org.testcontainers>|' pom.xml
           grep testcontainers pom.xml | head -2
 
@@ -83,21 +82,11 @@ jobs:
           echo "=== Patched docker-compose ==="
           find . -name "docker-compose*.yml" -exec cat {} \;
 
-      - name: Configure testcontainers
+      - name: Pre-pull images
         run: |
-          # Tell Testcontainers to use host's docker compose CLI (v2) instead of
-          # the containerized docker/compose:1.29.2 image which uses Docker API v1.32
-          # and is incompatible with Docker 29+ (requires API v1.44+)
-          printf '%s\n' \
-            'docker.client.strategy=org.testcontainers.dockerclient.UnixSocketClientProviderStrategy' \
-            'testcontainers.environmentprovider.local.enabled=true' \
-            > ~/.testcontainers.properties
-          # Also set TESTCONTAINERS_DOCKER_COMPOSE_LOCAL=true to force local compose
-          echo "TESTCONTAINERS_DOCKER_COMPOSE_LOCAL=true" >> $GITHUB_ENV
-          # Pre-pull the image so testcontainers doesn't need to parse the variable
+          # Pre-pull the orion-ld image so testcontainers doesn't timeout pulling it
           docker pull localhost:5000/orion-ld:latest
           docker images | grep orion
-          # Verify docker compose v2 is available
           docker compose version
 
       - name: Verify orion-ld image
@@ -110,26 +99,6 @@ jobs:
           mkdir -p src/test/resources
           echo "api.version=1.44" > src/test/resources/docker-java.properties
           cat src/test/resources/docker-java.properties
-
-      - name: Smoke-test docker-compose stack
-        run: |
-          # Run the compose stack independently to verify orion-ld starts
-          cd src/test/resources/docker-compose
-          docker compose -f docker-compose-it.yml up -d
-          echo "=== Waiting 30s for containers to start ==="
-          sleep 30
-          echo "=== Container status ==="
-          docker compose -f docker-compose-it.yml ps
-          echo "=== orion-ld logs ==="
-          docker compose -f docker-compose-it.yml logs orion-ld 2>&1 | tail -80
-          echo "=== mongo-db logs ==="
-          docker compose -f docker-compose-it.yml logs mongo-db 2>&1 | tail -30
-          echo "=== timescale logs ==="
-          docker compose -f docker-compose-it.yml logs timescale 2>&1 | tail -30
-          # Check if orion-ld is responding
-          docker compose -f docker-compose-it.yml exec -T orion-ld curl -s http://localhost:1026/version || echo "orion-ld not responding yet"
-          # Clean up
-          docker compose -f docker-compose-it.yml down -v
 
       - name: Run tests
         run: mvn clean test -B -ntp
@@ -147,3 +116,5 @@ jobs:
             echo "--- Container $c ($(docker inspect --format '{{.Name}} {{.Config.Image}}' $c)) ---"
             docker logs $c 2>&1 | tail -100 || true
           done
+          echo "=== Docker events (last 2 minutes) ==="
+          docker events --since 2m --until 0s 2>&1 | head -50 || true

--- a/.github/workflows/mintaka-compatibility.yml
+++ b/.github/workflows/mintaka-compatibility.yml
@@ -111,6 +111,26 @@ jobs:
           echo "api.version=1.44" > src/test/resources/docker-java.properties
           cat src/test/resources/docker-java.properties
 
+      - name: Smoke-test docker-compose stack
+        run: |
+          # Run the compose stack independently to verify orion-ld starts
+          cd src/test/resources/docker-compose
+          docker compose -f docker-compose-it.yml up -d
+          echo "=== Waiting 30s for containers to start ==="
+          sleep 30
+          echo "=== Container status ==="
+          docker compose -f docker-compose-it.yml ps
+          echo "=== orion-ld logs ==="
+          docker compose -f docker-compose-it.yml logs orion-ld 2>&1 | tail -80
+          echo "=== mongo-db logs ==="
+          docker compose -f docker-compose-it.yml logs mongo-db 2>&1 | tail -30
+          echo "=== timescale logs ==="
+          docker compose -f docker-compose-it.yml logs timescale 2>&1 | tail -30
+          # Check if orion-ld is responding
+          docker compose -f docker-compose-it.yml exec -T orion-ld curl -s http://localhost:1026/version || echo "orion-ld not responding yet"
+          # Clean up
+          docker compose -f docker-compose-it.yml down -v
+
       - name: Run tests
         run: mvn clean test -B -ntp
         env:
@@ -120,10 +140,10 @@ jobs:
       - name: Show container logs on failure
         if: failure()
         run: |
-          echo "=== Docker containers ==="
+          echo "=== Docker containers (all) ==="
           docker ps -a
           echo "=== Recent container logs ==="
-          for c in $(docker ps -aq | head -5); do
-            echo "--- Container $c ---"
+          for c in $(docker ps -aq | head -10); do
+            echo "--- Container $c ($(docker inspect --format '{{.Name}} {{.Config.Image}}' $c)) ---"
             docker logs $c 2>&1 | tail -100 || true
           done

--- a/.github/workflows/mintaka-compatibility.yml
+++ b/.github/workflows/mintaka-compatibility.yml
@@ -54,11 +54,12 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - name: Upgrade Testcontainers version
+      - name: Upgrade Testcontainers for Docker 29+ compatibility
         run: |
           # Mintaka uses Testcontainers 1.15.1 (Docker API v1.30) which is too old
-          # for the runner's Docker engine (requires API v1.44+)
-          sed -i 's|<version.org.testcontainers>1.15.1</version.org.testcontainers>|<version.org.testcontainers>1.19.3</version.org.testcontainers>|' pom.xml
+          # for the runner's Docker engine (Docker 29+ requires API v1.44+)
+          # Testcontainers 1.21.3+ defaults to API v1.44
+          sed -i 's|<version.org.testcontainers>[^<]*</version.org.testcontainers>|<version.org.testcontainers>1.21.3</version.org.testcontainers>|' pom.xml
           grep testcontainers pom.xml | head -2
 
       - name: Patch Mintaka docker-compose

--- a/.github/workflows/mintaka-compatibility.yml
+++ b/.github/workflows/mintaka-compatibility.yml
@@ -62,6 +62,18 @@ jobs:
           sed -i 's|<version.org.testcontainers>[^<]*</version.org.testcontainers>|<version.org.testcontainers>1.21.3</version.org.testcontainers>|' pom.xml
           grep testcontainers pom.xml | head -2
 
+      - name: Patch Mintaka startup timeout
+        run: |
+          # DockerComposeContainer.start() has a default 60s startup timeout which is
+          # too short for Orion-LD + MongoDB + TimescaleDB on GitHub Actions runners.
+          # Add withStartupTimeout to give containers 5 minutes to start.
+          # Add required imports for Duration and ChronoUnit
+          sed -i '1,/^import/{s/^import/import java.time.Duration;\nimport java.time.temporal.ChronoUnit;\nimport/}' src/test/java/org/fiware/mintaka/ComposeTest.java
+          # Add withStartupTimeout call
+          sed -i 's|.withExposedService("timescale", TIMESCALE_PORT);|.withExposedService("timescale", TIMESCALE_PORT)\n\t\t\t.withStartupTimeout(Duration.of(5, ChronoUnit.MINUTES));|' src/test/java/org/fiware/mintaka/ComposeTest.java
+          echo "=== Patched ComposeTest.java ==="
+          grep -A2 "withStartupTimeout\|withExposedService\|import java.time" src/test/java/org/fiware/mintaka/ComposeTest.java
+
       - name: Patch Mintaka docker-compose
         run: |
           # Use our local image (avoids testcontainers variable substitution bugs)
@@ -73,11 +85,20 @@ jobs:
 
       - name: Configure testcontainers
         run: |
-          # Create empty config to suppress "file not found" warning
-          touch ~/.testcontainers.properties
+          # Tell Testcontainers to use host's docker compose CLI (v2) instead of
+          # the containerized docker/compose:1.29.2 image which uses Docker API v1.32
+          # and is incompatible with Docker 29+ (requires API v1.44+)
+          printf '%s\n' \
+            'docker.client.strategy=org.testcontainers.dockerclient.UnixSocketClientProviderStrategy' \
+            'testcontainers.environmentprovider.local.enabled=true' \
+            > ~/.testcontainers.properties
+          # Also set TESTCONTAINERS_DOCKER_COMPOSE_LOCAL=true to force local compose
+          echo "TESTCONTAINERS_DOCKER_COMPOSE_LOCAL=true" >> $GITHUB_ENV
           # Pre-pull the image so testcontainers doesn't need to parse the variable
           docker pull localhost:5000/orion-ld:latest
           docker images | grep orion
+          # Verify docker compose v2 is available
+          docker compose version
 
       - name: Verify orion-ld image
         run: |

--- a/.github/workflows/mintaka-compatibility.yml
+++ b/.github/workflows/mintaka-compatibility.yml
@@ -54,6 +54,13 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - name: Upgrade Testcontainers version
+        run: |
+          # Mintaka uses Testcontainers 1.15.1 (Docker API v1.30) which is too old
+          # for the runner's Docker engine (requires API v1.44+)
+          sed -i 's|<version.org.testcontainers>1.15.1</version.org.testcontainers>|<version.org.testcontainers>1.19.3</version.org.testcontainers>|' pom.xml
+          grep testcontainers pom.xml | head -2
+
       - name: Patch Mintaka docker-compose
         run: |
           # Use our local image (avoids testcontainers variable substitution bugs)

--- a/.github/workflows/mintaka-compatibility.yml
+++ b/.github/workflows/mintaka-compatibility.yml
@@ -83,6 +83,13 @@ jobs:
         run: |
           docker run --rm localhost:5000/orion-ld:latest -u
 
+      - name: Set Docker API version for Testcontainers
+        run: |
+          # Docker 29+ requires API v1.44+, tell docker-java to use it
+          mkdir -p src/test/resources
+          echo "api.version=1.44" > src/test/resources/docker-java.properties
+          cat src/test/resources/docker-java.properties
+
       - name: Run tests
         run: mvn clean test -B -ntp
         env:

--- a/docker/build-ubi/04.install-k-libs.sh
+++ b/docker/build-ubi/04.install-k-libs.sh
@@ -53,9 +53,12 @@ do
     if [ $kproj = "kprom" ]
     then
         branch=release/0.1.0
+    elif [ $kproj = "kjson" ]
+    then
+        branch=release/0.10.1
     fi
     
-    echo checking out $branch
+    echo checking out $kproj $branch
     git checkout $branch
     make
     make install

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_version.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_version.test
@@ -72,7 +72,7 @@ Date: REGEX(.*)
   "ktrace version": "0.10.0",
   "kalloc version": "0.10.0",
   "khash version": "0.10.0",
-  "kjson version": "0.10.0",
+  "kjson version": "0.10.1",
   "kprom version": "0.1.0",
   "microhttpd version": "1.0.2-0",
   "rapidjson version": REGEX(.*),


### PR DESCRIPTION
New base image as a bug has been fixed in kjson - it's release number has changed.
I modified also the functest (needed) but, it's going to fail here as the old base image is used during tests. 
Pity but, not a problem