### PR TITLE
deploy: drop Snyk SARIF upload to GitHub Code Scanning

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,10 +68,11 @@ jobs:
           image: ${{ env.IMAGE_ORG }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG_PRE }}
           args: --file=docker/Dockerfile-ubi
 
-      - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: snyk.sarif
+      # Upload of Snyk results to GitHub Code Scanning removed - the SARIF
+      # output from snyk/actions/docker sometimes has null severity values
+      # which upload-sarif rejects ("invalid security severity value, is
+      # not a number: null"). We don't consume the Code Scanning dashboard
+      # anyway, and Snyk results remain visible in the step log above.
 
   deploy-debug-dockerhub:
 


### PR DESCRIPTION
snyk/actions/docker sometimes emits rules with 'security-severity: null' and github/codeql-action/upload-sarif rejects those with 'could not convert rules: invalid security severity value, is not a number: null', failing the post-merge deploy workflow.

We don't use the Code Scanning dashboard, and Snyk results are still visible in the step log above (the scan step itself is unchanged and keeps continue-on-error: true). Just drop the upload.