### PR TITLE
DDS Actions: envelope-rich storage of feedback/result/status, datasetId per goal

### DIFF
--- a/doc/dds/eprosima_fibonacci_server_jazzy_bug.md
+++ b/doc/dds/eprosima_fibonacci_server_jazzy_bug.md
@@ -1,0 +1,157 @@
+# Bug report — `FibonacciServer.py` crashes on first `executor.spin_once()` on Jazzy
+
+## Summary
+
+The Python `FibonacciServer.py` script shipped in the FIWARE-DDS-Enabler
+test scripts (`ddsenabler_test/compose/scripts/ros2_nodes/`) **terminates
+immediately** after announcing the action server. It throws an `RCLError`
+from inside `rclpy/executors.py:574` on the *first* `spin_once()` call. The
+C++ counterpart (`action_tutorials_cpp fibonacci_action_server` in the
+Vulcanexus image) is unaffected.
+
+This was discovered while writing an Orion-LD functional test that uses the
+script as the ROS 2 action server peer for testing the broker as a DDS
+action *client*. The service-side `AdditionServer.py` (same scripts folder,
+service mode) works fine — the failure is specific to the action path.
+
+## Environment
+
+* **Docker image**: `eprosima/vulcanexus:jazzy-desktop`
+* **ROS 2 distribution**: Jazzy Jalisco
+* **rclpy version**: ships with Jazzy (`/opt/ros/jazzy/lib/python3.12/site-packages/rclpy`)
+* **Script location**: `ddsenabler_test/compose/scripts/ros2_nodes/FibonacciServer.py`
+
+## Reproduction
+
+```bash
+docker run --rm --ipc=host -e ROS_DOMAIN_ID=0 \
+    -v "$PWD/ddsenabler_test/compose/scripts:/scripts:ro" \
+    eprosima/vulcanexus:jazzy-desktop \
+    python3 -u /scripts/ros2_nodes/node_main.py --action --samples 1
+```
+
+## Observed output
+
+```
+1778602791.0956993$ Fibonacci Action Server created.
+1778602791.0957172$ Running Fibonacci Action Server, waiting for 1 executed goals.
+Traceback (most recent call last):
+  File "/scripts/ros2_nodes/node_main.py", line 122, in <module>
+    main()
+  File "/scripts/ros2_nodes/node_main.py", line 108, in main
+    result = node.run(args.samples, args.wait, args.expect_cancel)
+  File "/scripts/ros2_nodes/FibonacciServer.py", line 137, in run
+    executor.spin_once(timeout_sec=0.1)
+  File "/opt/ros/jazzy/lib/python3.12/site-packages/rclpy/executors.py", line 917, in spin_once
+    self._spin_once_impl(timeout_sec)
+  File "/opt/ros/jazzy/lib/python3.12/site-packages/rclpy/executors.py", line 896, in _spin_once_impl
+    handler, entity, node = self.wait_for_ready_callbacks(
+  File "/opt/ros/jazzy/lib/python3.12/site-packages/rclpy/executors.py", line 799, in wait_for_ready_callbacks
+    return next(self._cb_iter)
+  File "/opt/ros/jazzy/lib/python3.12/site-packages/rclpy/executors.py", line 574, in _wait_for_ready_callbacks
+    timeout_timer = Timer(None, None, timeout_nsec, self._clock, context=self._context)
+  File "/opt/ros/jazzy/lib/python3.12/site-packages/rclpy/timer.py", line 60, in __init__
+    self.__timer = _rclpy.Timer(
+RCLError: failed to create timer: the given context is not valid, either rcl_init() was not called or rcl_shutdown() was called., at ./src/rcl/guard_condition.c:67
+```
+
+Note that `Fibonacci Action Server created.` and `Running Fibonacci Action
+Server, waiting for 1 executed goals.` are both printed, so:
+* `rclpy.init()` *was* called (the node is constructed),
+* the executor is built without error,
+* the very first `executor.spin_once(timeout_sec=0.1)` raises.
+
+## What seems to be wrong
+
+`MultiThreadedExecutor._wait_for_ready_callbacks` (in `executors.py:574`)
+constructs a `Timer` keyed on `self._clock` and `self._context`. Per the
+error from `guard_condition.c:67`, `self._context` is reported invalid even
+though `rclpy.init()` returned successfully and the node was constructed
+against that same default context.
+
+A plausible root cause is a thread-safety / context-binding mismatch
+introduced by Jazzy's `rclpy` when a node built with a `ReentrantCallbackGroup`
+is then spun on a `MultiThreadedExecutor(num_threads=N)` *without* explicitly
+passing the same context the node was created against. The
+`AdditionServer.py` script uses the default `MutuallyExclusiveCallbackGroup`
+and a single-threaded executor; that path works fine on the same image.
+
+Suggested fixes to validate (any one of these may be enough):
+
+1. Pass the explicit context to the executor:
+   ```python
+   executor = MultiThreadedExecutor(num_threads=2, context=rclpy.utilities.get_default_context())
+   ```
+2. Drop the `ReentrantCallbackGroup` (or pass it the node's context).
+3. Use `rclpy.spin(node, executor=executor)` instead of the manual
+   `spin_once` loop — `rclpy.spin` performs the binding internally.
+
+## Attempted workaround — and why it doesn't work
+
+We tried swapping `FibonacciServer.py` for the canonical
+`ros2 run action_tutorials_cpp fibonacci_action_server` from the Vulcanexus
+image. The C++ server starts cleanly, accepts goals from `ros2 action
+send_goal`, streams feedback, and returns results — **but the broker still
+fails to discover it**.
+
+Looking at the broker error:
+```
+EnablerParticipant.cpp[213]: publish_rpc: Failed to publish data in service
+  fibonaccisend_goal : service does not exist.
+```
+
+The enabler is looking for a topic named `fibonaccisend_goal`
+(literal `<action_name>` + `send_goal` concatenated, no separator),
+defined in `Constants.hpp`:
+```cpp
+constexpr const char* ACTION_GOAL_SUFFIX("send_goal");
+constexpr const char* ACTION_CANCEL_SUFFIX("cancel_goal");
+constexpr const char* ACTION_RESULT_SUFFIX("get_result");
+constexpr const char* ACTION_FEEDBACK_SUFFIX("feedback");
+constexpr const char* ACTION_STATUS_SUFFIX("status");
+```
+and used in `EnablerParticipant.cpp:515`:
+```cpp
+std::string goal_request_topic = action_name + ACTION_GOAL_SUFFIX;
+```
+
+The standard ROS 2 action wire format is
+`<action_name>/_action/send_goal` etc. — **completely incompatible** with
+the enabler's `<action_name><suffix>` form. So even with the Jazzy
+`rclpy` bug fixed, the canonical ROS 2 tutorial servers
+(`action_tutorials_cpp`, `action_tutorials_py`,
+`examples_rclpy_minimal_action_server`, …) won't interoperate with the
+enabler — only `FibonacciServer.py` does, because it was written to
+the enabler's convention.
+
+This makes the Python script the **only known action peer** for the
+enabler today. Fixing the Jazzy crash is therefore on the critical
+path for downstream test suites; we cannot route around it.
+
+## Action requested
+
+1. **Primary** — fix the Jazzy `RCLError: failed to create timer` on the
+   first `executor.spin_once()` in `FibonacciServer.py`. The
+   `AdditionServer.py` (same scripts folder, single-threaded executor,
+   no `ReentrantCallbackGroup`) is unaffected; one of the three
+   candidate diffs in the section above should sort it.
+2. **Secondary** — consider documenting the action-topic naming
+   convention (`<action_name><suffix>`) somewhere visible, and/or
+   shipping a C++ companion that uses it. Right now the only working
+   action peer is a single Python script that's coupled to a specific
+   rclpy version and not exercised by the enabler's own CI.
+
+## Action requested
+
+* Validate the bug on a fresh Vulcanexus `jazzy-desktop` image.
+* Apply one of the candidate fixes (or your preferred one) and re-publish
+  the test scripts.
+* Optionally, add a smoke test in CI that runs `node_main.py --action`
+  for a few seconds without sending a goal — the crash above is hit
+  before any goal arrives.
+
+## References
+
+* Failing file/line: `ddsenabler_test/compose/scripts/ros2_nodes/FibonacciServer.py:137`
+* Working analogue: `ddsenabler_test/compose/scripts/ros2_nodes/AdditionServer.py`
+* Working C++ analogue (Vulcanexus): `ros2 run action_tutorials_cpp fibonacci_action_server`

--- a/src/lib/orionld/dds/CMakeLists.txt
+++ b/src/lib/orionld/dds/CMakeLists.txt
@@ -50,6 +50,8 @@ SET (SOURCES
   ddsActionFeedbackNotification.cpp
   ddsActionStatusNotification.cpp
   ddsActionSubAttributeUpdate.cpp
+  ddsActionBuild.cpp
+  ddsActionGoalCancel.cpp
 )
 
 # Include directories

--- a/src/lib/orionld/dds/ddsActionBuild.cpp
+++ b/src/lib/orionld/dds/ddsActionBuild.cpp
@@ -1,0 +1,199 @@
+/*
+*
+* Copyright 2026 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+#include <stdint.h>                                              // int64_t, uint8_t
+#include <stdio.h>                                               // snprintf
+#include <string.h>                                              // strncmp
+
+extern "C"
+{
+#include "kjson/KjNode.h"                                        // KjNode
+#include "kjson/kjBuilder.h"                                     // kjObject, kjChildAdd
+}
+
+#include "orionld/common/orionldState.h"                         // orionldState
+#include "orionld/dds/ddsReplyBuild.h"                           // ddsReplyStringPropertyNode, ddsReplyIntegerPropertyNode
+#include "orionld/dds/ddsActionBuild.h"                          // Own interface
+
+
+
+// -----------------------------------------------------------------------------
+//
+// ddsActionUuidToString -
+//
+char* ddsActionUuidToString(const eprosima::ddsenabler::participants::UUID& uuid, char* out)
+{
+  // Canonical RFC 4122 5-group form: 8-4-4-4-12 hex chars, hyphens between groups.
+  // Byte ordering follows the "big-endian textual" convention used by ROS2 /
+  // Fast-DDS: bytes[0..15] map to the 16 octets in left-to-right reading order.
+  snprintf(out, 37,
+           "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+           uuid[0],  uuid[1],  uuid[2],  uuid[3],
+           uuid[4],  uuid[5],
+           uuid[6],  uuid[7],
+           uuid[8],  uuid[9],
+           uuid[10], uuid[11], uuid[12], uuid[13], uuid[14], uuid[15]);
+  return out;
+}
+
+
+
+// -----------------------------------------------------------------------------
+//
+// ddsActionGoalDatasetId -
+//
+char* ddsActionGoalDatasetId(const eprosima::ddsenabler::participants::UUID& uuid, char* out)
+{
+  // "urn:goal:" + 36 UUID chars + NUL = 46
+  char uuidStr[37];
+  ddsActionUuidToString(uuid, uuidStr);
+  snprintf(out, 48, "urn:goal:%s", uuidStr);
+  return out;
+}
+
+
+
+// -----------------------------------------------------------------------------
+//
+// hexNibble - return -1 on non-hex input
+//
+static int hexNibble(char c)
+{
+  if ((c >= '0') && (c <= '9'))  return c - '0';
+  if ((c >= 'a') && (c <= 'f'))  return c - 'a' + 10;
+  if ((c >= 'A') && (c <= 'F'))  return c - 'A' + 10;
+  return -1;
+}
+
+
+
+// -----------------------------------------------------------------------------
+//
+// ddsActionDatasetIdToUuid -
+//
+bool ddsActionDatasetIdToUuid(const char* datasetId, eprosima::ddsenabler::participants::UUID& out)
+{
+  if (datasetId == NULL)
+    return false;
+
+  // Optional "urn:goal:" prefix.
+  const char* p = datasetId;
+  if (strncmp(p, "urn:goal:", 9) == 0)
+    p += 9;
+
+  // Canonical form: 8-4-4-4-12 hex with hyphens at positions 8, 13, 18, 23.
+  static const int hyphenPositions[] = { 8, 13, 18, 23 };
+  int hyphenIx = 0;
+  int byteIx   = 0;
+  int hiNib    = -1;
+
+  for (int i = 0; i < 36; ++i)
+  {
+    char c = p[i];
+    if ((hyphenIx < 4) && (i == hyphenPositions[hyphenIx]))
+    {
+      if (c != '-') return false;
+      ++hyphenIx;
+      continue;
+    }
+
+    int n = hexNibble(c);
+    if (n < 0) return false;
+
+    if (hiNib < 0)
+      hiNib = n;
+    else
+    {
+      out[byteIx++] = (uint8_t) ((hiNib << 4) | n);
+      hiNib = -1;
+    }
+  }
+
+  return (byteIx == 16) && (p[36] == 0);
+}
+
+
+
+// -----------------------------------------------------------------------------
+//
+// ddsActionStatusCodeToString -
+//
+const char* ddsActionStatusCodeToString(eprosima::ddsenabler::participants::StatusCode code)
+{
+  switch (code)
+  {
+  case eprosima::ddsenabler::participants::StatusCode::UNKNOWN:               return "unknown";
+  case eprosima::ddsenabler::participants::StatusCode::ACCEPTED:              return "accepted";
+  case eprosima::ddsenabler::participants::StatusCode::EXECUTING:             return "executing";
+  case eprosima::ddsenabler::participants::StatusCode::CANCELING:             return "canceling";
+  case eprosima::ddsenabler::participants::StatusCode::SUCCEEDED:             return "succeeded";
+  case eprosima::ddsenabler::participants::StatusCode::CANCELED:              return "canceled";
+  case eprosima::ddsenabler::participants::StatusCode::ABORTED:               return "aborted";
+  case eprosima::ddsenabler::participants::StatusCode::REJECTED:              return "rejected";
+  case eprosima::ddsenabler::participants::StatusCode::TIMEOUT:               return "timeout";
+  case eprosima::ddsenabler::participants::StatusCode::FAILED:                return "failed";
+  case eprosima::ddsenabler::participants::StatusCode::CANCEL_REQUEST_FAILED: return "cancelRequestFailed";
+  }
+  return "unknown";
+}
+
+
+
+// -----------------------------------------------------------------------------
+//
+// ddsActionBuildSubAttribute -
+//
+KjNode* ddsActionBuildSubAttribute
+(
+  const char*                                       subName,
+  KjNode*                                           payloadValue,
+  const eprosima::ddsenabler::participants::UUID&   goalId,
+  const char*                                       instanceHandleId,
+  const char*                                       participantId,
+  const char*                                       ddsDataType,
+  int64_t                                           publishedAt
+)
+{
+  KjNode* sub      = kjObject(orionldState.kjsonP, subName);
+  KjNode* typeNode = kjString(orionldState.kjsonP, "type", "Property");
+
+  if (payloadValue != NULL)
+    payloadValue->name = (char*) "value";
+
+  kjChildAdd(sub, typeNode);
+  if (payloadValue != NULL)
+    kjChildAdd(sub, payloadValue);
+
+  char goalIdStr[37];
+  ddsActionUuidToString(goalId, goalIdStr);
+  kjChildAdd(sub, ddsReplyStringPropertyNode("goalId", goalIdStr));
+
+  if (instanceHandleId != NULL) kjChildAdd(sub, ddsReplyStringPropertyNode("instanceHandleId", instanceHandleId));
+  if (participantId    != NULL) kjChildAdd(sub, ddsReplyStringPropertyNode("participantId",    participantId));
+  if (ddsDataType      != NULL) kjChildAdd(sub, ddsReplyStringPropertyNode("ddsDataType",      ddsDataType));
+
+  kjChildAdd(sub, ddsReplyIntegerPropertyNode("publishedAt", (long long) publishedAt));
+
+  return sub;
+}

--- a/src/lib/orionld/dds/ddsActionBuild.h
+++ b/src/lib/orionld/dds/ddsActionBuild.h
@@ -1,0 +1,122 @@
+#ifndef SRC_LIB_ORIONLD_DDS_DDSACTIONBUILD_H_
+#define SRC_LIB_ORIONLD_DDS_DDSACTIONBUILD_H_
+
+/*
+*
+* Copyright 2026 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+#include <stdint.h>                                              // int64_t
+
+#include "ddsenabler_participants/rpc/RpcTypes.hpp"              // UUID, StatusCode
+
+extern "C"
+{
+#include "kjson/KjNode.h"                                        // KjNode
+}
+
+
+
+// -----------------------------------------------------------------------------
+//
+// Helpers for building the NGSI-LD sub-attribute Property tree that wraps a
+// DDS action callback (feedback / result / status). Same envelope idea as
+// ddsReplyBuild.cpp uses for services, but keyed by goalId (UUID) instead of
+// requestId (uint64).
+//
+// All constructed nodes live in orionldState.kjsonP — callers must have
+// orionldState initialized for the current thread.
+//
+
+// -----------------------------------------------------------------------------
+//
+// ddsActionUuidToString -
+//
+// Render the 16-byte UUID into canonical 8-4-4-4-12 hex form
+// ("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"). The output buffer must be at
+// least 37 bytes (36 chars + NUL). Returns the buffer for convenient inlining.
+//
+extern char* ddsActionUuidToString(const eprosima::ddsenabler::participants::UUID& uuid, char* out);
+
+
+// -----------------------------------------------------------------------------
+//
+// ddsActionGoalDatasetId -
+//
+// Build the datasetId URI for a goal: "urn:goal:<uuid>". The output buffer
+// must be at least 48 bytes ("urn:goal:" = 9 + 36 UUID chars + NUL = 46).
+//
+extern char* ddsActionGoalDatasetId(const eprosima::ddsenabler::participants::UUID& uuid, char* out);
+
+
+// -----------------------------------------------------------------------------
+//
+// ddsActionDatasetIdToUuid -
+//
+// Parse "urn:goal:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" (or just the 36-char
+// UUID portion) into a 16-byte UUID. Returns true on success, false if the
+// input doesn't match the canonical form.
+//
+extern bool ddsActionDatasetIdToUuid(const char* datasetId, eprosima::ddsenabler::participants::UUID& out);
+
+
+// -----------------------------------------------------------------------------
+//
+// ddsActionStatusCodeToString -
+//
+// Lowercased status string ("unknown" / "accepted" / "executing" / "canceling" /
+// "succeeded" / "canceled" / "aborted" / "rejected" / "timeout" / "failed" /
+// "cancelRequestFailed"). Matches the ROS2 action-status vocabulary in spirit;
+// lowercased so it reads as a value, not an enum identifier.
+//
+extern const char* ddsActionStatusCodeToString(eprosima::ddsenabler::participants::StatusCode code);
+
+
+// -----------------------------------------------------------------------------
+//
+// ddsActionBuildSubAttribute -
+//
+// Build a sub-attribute Property of the form
+//
+//   "<subName>": {
+//     "type": "Property",
+//     "value": <payloadValue>,
+//     "goalId":           { "type": "Property", "value": "<uuid>" },
+//     "publishedAt":      { "type": "Property", "value": <secs since epoch> }
+//     [+ optional: instanceHandleId / participantId / ddsDataType ]
+//   }
+//
+// 'payloadValue' is renamed in-place to "value" — pass a node the caller
+// doesn't need elsewhere.
+//
+extern KjNode* ddsActionBuildSubAttribute
+(
+  const char*                                       subName,
+  KjNode*                                           payloadValue,
+  const eprosima::ddsenabler::participants::UUID&   goalId,
+  const char*                                       instanceHandleId,
+  const char*                                       participantId,
+  const char*                                       ddsDataType,
+  int64_t                                           publishedAt
+);
+
+#endif  // SRC_LIB_ORIONLD_DDS_DDSACTIONBUILD_H_

--- a/src/lib/orionld/dds/ddsActionFeedbackNotification.cpp
+++ b/src/lib/orionld/dds/ddsActionFeedbackNotification.cpp
@@ -36,6 +36,7 @@ extern "C"
 #include "orionld/common/traceLevels.h"                          // KT_T trace levels
 #include "orionld/dds/ddsActionLookup.h"                         // ddsActionLookup
 #include "orionld/dds/ddsActionSubAttributeUpdate.h"             // ddsActionSubAttributeUpdate
+#include "orionld/dds/ddsReplyBuild.h"                           // ddsReplyExtractMetadata
 #include "orionld/dds/ddsActionFeedbackNotification.h"           // Own interface
 
 
@@ -64,6 +65,8 @@ void ddsActionFeedbackNotification
   if (actionP->entityId == NULL || actionP->attributeName == NULL)
     return;
 
+  publishTime /= 1000000000LL;
+
   orionldStateInit(NULL);
   KjNode* feedbackTree = kjParse(orionldState.kjsonP, (char*) json);
   if (feedbackTree == NULL)
@@ -72,5 +75,22 @@ void ddsActionFeedbackNotification
     return;
   }
 
-  ddsActionSubAttributeUpdate(actionP->entityId, actionP->entityType, actionP->attributeName, "ddsActionFeedback", feedbackTree, publishTime);
+  const char* participantId    = NULL;
+  const char* ddsDataType      = NULL;
+  const char* instanceHandleId = NULL;
+  KjNode*     feedbackPayload  = ddsReplyExtractMetadata(feedbackTree, &participantId, &ddsDataType, &instanceHandleId);
+
+  if (feedbackPayload == NULL)
+    feedbackPayload = feedbackTree;
+
+  ddsActionSubAttributeUpdate(actionP->entityId,
+                              actionP->entityType,
+                              actionP->attributeName,
+                              "ddsActionFeedback",
+                              feedbackPayload,
+                              goalId,
+                              instanceHandleId,
+                              participantId,
+                              ddsDataType,
+                              publishTime);
 }

--- a/src/lib/orionld/dds/ddsActionGoalCancel.cpp
+++ b/src/lib/orionld/dds/ddsActionGoalCancel.cpp
@@ -1,0 +1,100 @@
+/*
+*
+* Copyright 2026 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+#include <stdlib.h>                                              // free
+#include <string.h>                                              // memcmp
+
+#include "ddsenabler/DDSEnabler.hpp"                             // cancel_action_goal
+#include "ddsenabler_participants/rpc/RpcTypes.hpp"              // UUID
+
+extern "C"
+{
+#include "ktrace/kTrace.h"                                       // trace messages
+}
+
+#include "orionld/types/DdsAction.h"                             // DdsAction, DdsActionGoal
+#include "orionld/common/orionldState.h"                         // ddsSupport
+#include "orionld/common/traceLevels.h"                          // KT_T trace levels
+#include "orionld/dds/ddsInit.h"                                 // ddsEnabler
+#include "orionld/dds/ddsActionLookup.h"                         // ddsActionLookupByAttributeName
+#include "orionld/dds/ddsActionBuild.h"                          // ddsActionDatasetIdToUuid
+#include "orionld/dds/ddsActionGoalCancel.h"                     // Own interface
+
+
+
+// -----------------------------------------------------------------------------
+//
+// ddsActionGoalCancelIfMapped -
+//
+bool ddsActionGoalCancelIfMapped(const char* attrShortName, const char* datasetId)
+{
+  if (ddsSupport == false)
+    return false;
+  if ((attrShortName == NULL) || (datasetId == NULL))
+    return false;
+
+  DdsAction* actionP = ddsActionLookupByAttributeName(attrShortName);
+  if (actionP == NULL)
+    return false;
+
+  eprosima::ddsenabler::participants::UUID goalId;
+  if (ddsActionDatasetIdToUuid(datasetId, goalId) == false)
+  {
+    KT_W("Action '%s' DELETE datasetId '%s' isn't a valid 'urn:goal:<uuid>' - cancel skipped", actionP->name, datasetId);
+    return false;
+  }
+
+  KT_T(StDdsAction, "Sending cancel for action '%s', goal %s", actionP->name, datasetId);
+
+  if (ddsEnabler == nullptr)
+  {
+    KT_W("DDS Enabler not initialized - cancel for action '%s' skipped", actionP->name);
+    return false;
+  }
+
+  bool ok = ddsEnabler->cancel_action_goal(actionP->name, goalId);
+  if (ok == false)
+    KT_W("cancel_action_goal('%s') returned false", actionP->name);
+
+  //
+  // Drop the local DdsActionGoal record (best-effort - the actual final
+  // status arrives later via ddsActionStatusNotification).
+  //
+  DdsActionGoal* prev = NULL;
+  for (DdsActionGoal* gP = actionP->goals; gP != NULL; gP = gP->next)
+  {
+    if (memcmp(gP->goalId, goalId.data(), 16) == 0)
+    {
+      if (prev != NULL)
+        prev->next = gP->next;
+      else
+        actionP->goals = gP->next;
+      free(gP);
+      break;
+    }
+    prev = gP;
+  }
+
+  return ok;
+}

--- a/src/lib/orionld/dds/ddsActionGoalCancel.h
+++ b/src/lib/orionld/dds/ddsActionGoalCancel.h
@@ -1,0 +1,44 @@
+#ifndef SRC_LIB_ORIONLD_DDS_DDSACTIONGOALCANCEL_H_
+#define SRC_LIB_ORIONLD_DDS_DDSACTIONGOALCANCEL_H_
+
+/*
+*
+* Copyright 2026 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+
+
+
+// -----------------------------------------------------------------------------
+//
+// ddsActionGoalCancelIfMapped -
+//
+// If 'attrShortName' is mapped to a DDS action, parse 'datasetId' as a
+// "urn:goal:<uuid>" identifier and ask the enabler to cancel the matching
+// in-flight goal. No-op if attribute is not mapped, datasetId is NULL, or the
+// UUID fails to parse. Drops the matching DdsActionGoal from the local list.
+//
+// Returns true if a cancel was issued, false otherwise.
+//
+extern bool ddsActionGoalCancelIfMapped(const char* attrShortName, const char* datasetId);
+
+#endif  // SRC_LIB_ORIONLD_DDS_DDSACTIONGOALCANCEL_H_

--- a/src/lib/orionld/dds/ddsActionResultNotification.cpp
+++ b/src/lib/orionld/dds/ddsActionResultNotification.cpp
@@ -38,6 +38,7 @@ extern "C"
 #include "orionld/common/traceLevels.h"                          // KT_T trace levels
 #include "orionld/dds/ddsActionLookup.h"                         // ddsActionLookup
 #include "orionld/dds/ddsActionSubAttributeUpdate.h"             // ddsActionSubAttributeUpdate
+#include "orionld/dds/ddsReplyBuild.h"                           // ddsReplyExtractMetadata
 #include "orionld/dds/ddsActionResultNotification.h"             // Own interface
 
 
@@ -90,6 +91,10 @@ void ddsActionResultNotification
     prev = gP;
   }
 
+  // publishTime arrives from the enabler in nanoseconds since epoch; reduce to
+  // seconds so it matches request-side timestamps recorded with time(NULL).
+  publishTime /= 1000000000LL;
+
   orionldStateInit(NULL);
   KjNode* resultTree = kjParse(orionldState.kjsonP, (char*) json);
   if (resultTree == NULL)
@@ -98,5 +103,27 @@ void ddsActionResultNotification
     return;
   }
 
-  ddsActionSubAttributeUpdate(actionP->entityId, actionP->entityType, actionP->attributeName, "ddsActionResult", resultTree, publishTime);
+  //
+  // If the enabler's payload carries the same envelope shape as a service
+  // reply ({ "id": <participantId>, "rr/<ddsDataType>": { "type": ..., "data": { "<handle>": <payload> } } })
+  // tease it out so we can populate the envelope sub-Properties.
+  //
+  const char* participantId    = NULL;
+  const char* ddsDataType      = NULL;
+  const char* instanceHandleId = NULL;
+  KjNode*     resultPayload    = ddsReplyExtractMetadata(resultTree, &participantId, &ddsDataType, &instanceHandleId);
+
+  if (resultPayload == NULL)
+    resultPayload = resultTree;  // no envelope — store the raw tree as value
+
+  ddsActionSubAttributeUpdate(actionP->entityId,
+                              actionP->entityType,
+                              actionP->attributeName,
+                              "ddsActionResult",
+                              resultPayload,
+                              goalId,
+                              instanceHandleId,
+                              participantId,
+                              ddsDataType,
+                              publishTime);
 }

--- a/src/lib/orionld/dds/ddsActionStatusNotification.cpp
+++ b/src/lib/orionld/dds/ddsActionStatusNotification.cpp
@@ -36,32 +36,8 @@ extern "C"
 #include "orionld/common/traceLevels.h"                          // KT_T trace levels
 #include "orionld/dds/ddsActionLookup.h"                         // ddsActionLookup
 #include "orionld/dds/ddsActionSubAttributeUpdate.h"             // ddsActionSubAttributeUpdate
+#include "orionld/dds/ddsActionBuild.h"                          // ddsActionStatusCodeToString
 #include "orionld/dds/ddsActionStatusNotification.h"             // Own interface
-
-
-
-// -----------------------------------------------------------------------------
-//
-// statusCodeToString -
-//
-static const char* statusCodeToString(eprosima::ddsenabler::participants::StatusCode code)
-{
-  switch (code)
-  {
-  case eprosima::ddsenabler::participants::StatusCode::UNKNOWN:              return "UNKNOWN";
-  case eprosima::ddsenabler::participants::StatusCode::ACCEPTED:             return "ACCEPTED";
-  case eprosima::ddsenabler::participants::StatusCode::EXECUTING:            return "EXECUTING";
-  case eprosima::ddsenabler::participants::StatusCode::CANCELING:            return "CANCELING";
-  case eprosima::ddsenabler::participants::StatusCode::SUCCEEDED:            return "SUCCEEDED";
-  case eprosima::ddsenabler::participants::StatusCode::CANCELED:             return "CANCELED";
-  case eprosima::ddsenabler::participants::StatusCode::ABORTED:              return "ABORTED";
-  case eprosima::ddsenabler::participants::StatusCode::REJECTED:             return "REJECTED";
-  case eprosima::ddsenabler::participants::StatusCode::TIMEOUT:              return "TIMEOUT";
-  case eprosima::ddsenabler::participants::StatusCode::FAILED:               return "FAILED";
-  case eprosima::ddsenabler::participants::StatusCode::CANCEL_REQUEST_FAILED: return "CANCEL_REQUEST_FAILED";
-  }
-  return "UNKNOWN";
-}
 
 
 
@@ -90,17 +66,30 @@ void ddsActionStatusNotification
   if (actionP->entityId == NULL || actionP->attributeName == NULL)
     return;
 
+  publishTime /= 1000000000LL;
+
   //
-  // Build a JSON object for the status: { "code": "EXECUTING", "message": "..." }
+  // Build a JSON object for the status: { "code": "executing", "message": "..." }
+  // This becomes the envelope's value; goalId/publishedAt are added by
+  // ddsActionSubAttributeUpdate.
   //
   orionldStateInit(NULL);
 
   KjNode* statusTree = kjObject(orionldState.kjsonP, NULL);
-  KjNode* codeNode   = kjString(orionldState.kjsonP, "code", statusCodeToString(statusCode));
+  KjNode* codeNode   = kjString(orionldState.kjsonP, "code", ddsActionStatusCodeToString(statusCode));
   KjNode* msgNode    = kjString(orionldState.kjsonP, "message", (statusMessage != NULL) ? statusMessage : "");
 
   kjChildAdd(statusTree, codeNode);
   kjChildAdd(statusTree, msgNode);
 
-  ddsActionSubAttributeUpdate(actionP->entityId, actionP->entityType, actionP->attributeName, "ddsActionStatus", statusTree, publishTime);
+  ddsActionSubAttributeUpdate(actionP->entityId,
+                              actionP->entityType,
+                              actionP->attributeName,
+                              "ddsActionStatus",
+                              statusTree,
+                              goalId,
+                              /*instanceHandleId*/ NULL,
+                              /*participantId*/    NULL,
+                              /*ddsDataType*/      NULL,
+                              publishTime);
 }

--- a/src/lib/orionld/dds/ddsActionSubAttributeUpdate.cpp
+++ b/src/lib/orionld/dds/ddsActionSubAttributeUpdate.cpp
@@ -26,7 +26,7 @@ extern "C"
 {
 #include "ktrace/kTrace.h"                                       // trace messages - ktrace library
 #include "kjson/KjNode.h"                                        // KjNode
-#include "kjson/kjBuilder.h"                                     // kjObject, kjChildAdd
+#include "kjson/kjBuilder.h"                                     // kjObject, kjChildAdd, kjString
 }
 
 #include "orionld/common/orionldState.h"                         // orionldState
@@ -36,6 +36,7 @@ extern "C"
 #include "orionld/context/orionldAttributeExpand.h"              // orionldAttributeExpand
 #include "orionld/serviceRoutines/orionldPatchEntity2.h"         // orionldPatchEntity2
 #include "orionld/service/serviceLookupByServiceRoutine.h"       // serviceLookupByServiceRoutine
+#include "orionld/dds/ddsActionBuild.h"                          // ddsActionBuildSubAttribute, ddsActionGoalDatasetId
 #include "orionld/dds/ddsActionSubAttributeUpdate.h"             // Own interface
 
 
@@ -44,36 +45,59 @@ extern "C"
 //
 // ddsActionSubAttributeUpdate -
 //
-// Merge-patches a sub-attribute onto an entity's attribute.
-// The request tree for merge-patch at entity level:
-//   { "<attrLongName>": { "<subAttrName>": { "type": "Property", "value": <valueTree> } } }
+// Build a merge-patch tree of the form:
 //
-// Same pattern as ddsServiceReplyNotification.
+//   { "<attrLongName>": {
+//       "type": "Property",
+//       "datasetId": "urn:goal:<uuid>",
+//       "<subAttributeName>": { ... envelope ... }
+//   } }
+//
+// and call orionldPatchEntity2.
 //
 void ddsActionSubAttributeUpdate
 (
-  const char* entityId,
-  const char* entityType,
-  const char* attributeName,
-  const char* subAttributeName,
-  KjNode*     valueTree,
-  int64_t     publishTime
+  const char*                                       entityId,
+  const char*                                       entityType,
+  const char*                                       attributeName,
+  const char*                                       subAttributeName,
+  KjNode*                                           subAttributeValue,
+  const eprosima::ddsenabler::participants::UUID&   goalId,
+  const char*                                       instanceHandleId,
+  const char*                                       participantId,
+  const char*                                       ddsDataType,
+  int64_t                                           publishTime
 )
 {
   orionldStateInit(NULL);
 
   char* attrLongName = orionldAttributeExpand(orionldState.contextP, attributeName, true, NULL);
 
-  KjNode* entityBody    = kjObject(orionldState.kjsonP, NULL);
-  KjNode* attrBody      = kjObject(orionldState.kjsonP, attrLongName);
-  KjNode* subAttr       = kjObject(orionldState.kjsonP, subAttributeName);
-  KjNode* subAttrType   = kjString(orionldState.kjsonP, "type", "Property");
+  //
+  // Envelope sub-attribute (goalId/publishedAt/etc. inside)
+  //
+  KjNode* envelope = ddsActionBuildSubAttribute(subAttributeName,
+                                                subAttributeValue,
+                                                goalId,
+                                                instanceHandleId,
+                                                participantId,
+                                                ddsDataType,
+                                                publishTime);
 
-  valueTree->name = (char*) "value";
+  //
+  // datasetId for the action attribute instance — keyed by goalId
+  //
+  char datasetIdStr[48];
+  ddsActionGoalDatasetId(goalId, datasetIdStr);
 
-  kjChildAdd(subAttr, subAttrType);
-  kjChildAdd(subAttr, valueTree);
-  kjChildAdd(attrBody, subAttr);
+  KjNode* entityBody     = kjObject(orionldState.kjsonP, NULL);
+  KjNode* attrBody       = kjObject(orionldState.kjsonP, attrLongName);
+  KjNode* attrTypeNode   = kjString(orionldState.kjsonP, "type", "Property");
+  KjNode* datasetIdNode  = kjString(orionldState.kjsonP, "datasetId", datasetIdStr);
+
+  kjChildAdd(attrBody, attrTypeNode);
+  kjChildAdd(attrBody, datasetIdNode);
+  kjChildAdd(attrBody, envelope);
   kjChildAdd(entityBody, attrBody);
 
   char* expandedType = orionldContextItemExpand(orionldState.contextP, entityType, true, NULL);
@@ -87,7 +111,8 @@ void ddsActionSubAttributeUpdate
   orionldState.uriParams.type      = expandedType;
   orionldState.serviceP            = serviceLookupByServiceRoutine(orionldPatchEntity2, HTTP_PATCH);
 
-  KT_T(StDdsAction, "Merge-patching entity '%s' with '%s' for attribute '%s'", entityId, subAttributeName, attributeName);
+  KT_T(StDdsAction, "Merge-patching entity '%s' with '%s' for attribute '%s' (datasetId %s)",
+       entityId, subAttributeName, attributeName, datasetIdStr);
   orionldPatchEntity2();
 
   void* con_cls;

--- a/src/lib/orionld/dds/ddsActionSubAttributeUpdate.h
+++ b/src/lib/orionld/dds/ddsActionSubAttributeUpdate.h
@@ -27,6 +27,8 @@
 */
 #include <stdint.h>                                              // int64_t
 
+#include "ddsenabler_participants/rpc/RpcTypes.hpp"              // UUID
+
 extern "C"
 {
 #include "kjson/KjNode.h"                                        // KjNode
@@ -38,17 +40,40 @@ extern "C"
 //
 // ddsActionSubAttributeUpdate -
 //
-// Merge-patches a sub-attribute onto an entity attribute.
-// Used for ddsActionResult, ddsActionFeedback, ddsActionStatus.
+// Merge-patch a single envelope-rich sub-attribute (ddsActionFeedback /
+// ddsActionResult / ddsActionStatus) onto the action-tied attribute of an
+// entity, keyed by datasetId=urn:goal:<goalId>.
+//
+// The resulting attribute instance has the form:
+//
+//   "<attrLongName>": {
+//     "type": "Property",
+//     "datasetId": "urn:goal:<uuid>",
+//     "<subAttributeName>": {
+//        "type": "Property",
+//        "value": <subAttributeValue>,
+//        "goalId":      { "type": "Property", "value": "<uuid>" },
+//        "publishedAt": { "type": "Property", "value": <secs> }
+//        [+ optional ddsDataType / instanceHandleId / participantId]
+//     }
+//   }
+//
+// Passing subAttributeValue = NULL produces an envelope with no value (used
+// by status notifications whose payload is split across statusCode/message
+// rendered inside the caller).
 //
 extern void ddsActionSubAttributeUpdate
 (
-  const char* entityId,
-  const char* entityType,
-  const char* attributeName,
-  const char* subAttributeName,
-  KjNode*     valueTree,
-  int64_t     publishTime
+  const char*                                       entityId,
+  const char*                                       entityType,
+  const char*                                       attributeName,
+  const char*                                       subAttributeName,
+  KjNode*                                           subAttributeValue,
+  const eprosima::ddsenabler::participants::UUID&   goalId,
+  const char*                                       instanceHandleId,
+  const char*                                       participantId,
+  const char*                                       ddsDataType,
+  int64_t                                           publishTime
 );
 
 #endif  // SRC_LIB_ORIONLD_DDS_DDSACTIONSUBATTRIBUTEUPDATE_H_

--- a/src/lib/orionld/mhd/mhdConnectionInit.cpp
+++ b/src/lib/orionld/mhd/mhdConnectionInit.cpp
@@ -936,6 +936,23 @@ MHD_Result orionldUriArgumentGet(void* cbDataP, MHD_ValueKind kind, const char* 
       orionldState.uriParams.mask |= ORIONLD_URIPARAM_DATASETID_LIST;
     }
   }
+  else if ((ddsSupport == true) && (strcmp(key, "goal") == 0))
+  {
+    //
+    // Synonym for ?datasetId=urn:goal:<value>, only valid when started with
+    // -wip dds. Lets users address a specific DDS action goal by UUID without
+    // having to spell out the full "urn:goal:" prefix.
+    //
+    size_t valueLen = strlen(value);
+    char*  buf      = (char*) kaAlloc(&orionldState.kalloc, valueLen + 10);  // "urn:goal:" = 9 + NUL
+    snprintf(buf, valueLen + 10, "urn:goal:%s", value);
+
+    if (pCheckUri(buf, "datasetId", true) == false)
+      return MHD_YES;
+
+    orionldState.uriParams.datasetId = buf;
+    orionldState.uriParams.mask |= ORIONLD_URIPARAM_DATASETID;
+  }
   else if (strcmp(key, "deleteAll") == 0)
   {
     if (strcmp(value, "true") == 0)

--- a/src/lib/orionld/serviceRoutines/orionldDeleteAttribute.cpp
+++ b/src/lib/orionld/serviceRoutines/orionldDeleteAttribute.cpp
@@ -58,6 +58,7 @@ extern "C"
 #include "orionld/distOp/distOpListRelease.h"                    // distOpListRelease
 #include "orionld/distOp/xForwardedForCompose.h"                 // xForwardedForCompose
 #include "orionld/distOp/viaCompose.h"                           // viaCompose
+#include "orionld/dds/ddsActionGoalCancel.h"                     // ddsActionGoalCancelIfMapped
 #include "orionld/serviceRoutines/orionldDeleteAttribute.h"      // Own interface
 
 
@@ -277,6 +278,18 @@ bool orionldDeleteAttribute(void)
 
   if ((orionldState.uriParams.datasetId != NULL) && (strcmp(orionldState.uriParams.datasetId, "@none") == 0))
     orionldState.uriParams.datasetId = NULL;
+
+  //
+  // If this attribute is mapped to a DDS action and a datasetId is present,
+  // interpret the datasetId as "urn:goal:<uuid>" and ask the enabler to
+  // cancel the in-flight goal. The final cancellation state is communicated
+  // separately by the action server via a status notification.
+  //
+  if (orionldState.uriParams.datasetId != NULL)
+  {
+    char* attrShortName = orionldContextItemAliasLookup(orionldState.contextP, attrName, NULL, NULL);
+    (void) ddsActionGoalCancelIfMapped(attrShortName, orionldState.uriParams.datasetId);
+  }
 
   KjNode* entityP       = NULL;
   KjNode* defaultAttrP  = NULL;

--- a/test/functionalTest/cases/0000_ld/dds/dds_action_full_roundtrip.test.DISABLED
+++ b/test/functionalTest/cases/0000_ld/dds/dds_action_full_roundtrip.test.DISABLED
@@ -1,0 +1,288 @@
+# Copyright 2026 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+#
+# This test requires Docker and the eprosima/vulcanexus:jazzy-desktop image.
+# A real ROS2 FibonacciServer runs in a container and the broker is the DDS
+# action client - it discovers the action via DDS and, after the PATCH that
+# triggers a goal, receives feedback/result/status notifications which it
+# stores as envelope sub-attributes on the action-tied 'fib' attribute,
+# keyed by datasetId=urn:goal:<uuid>.
+#
+# Skipped in GitHub Actions (the test container can't reach the docker
+# daemon).
+#
+
+--NAME--
+DDS Action: full goal roundtrip materialises feedback/result/status envelopes per goalId
+
+--SHELL-INIT--
+ddsClean
+
+$REPO_HOME/scripts/configFile.sh \
+  --ddsAction "fibonacci,Robot,urn:ngsi-ld:robot:r1,fib" \
+  --ddsTypesDirectory "$REPO_HOME/test/functionalTest/ddsTypes" \
+  > $HOME/.orionld
+
+# Start the ROS2 FibonacciServer first so DDS discovery + types are in place
+# by the time the broker comes up. RCL python + action announce takes longer
+# than the AdditionServer used by the service tests, so we wait 10s.
+ros2ActionStart --samples 1
+sleep 10
+
+dbInit CB
+orionldStart CB -mongocOnly -wip dds
+
+# Allow discovery between the broker and the action server, and for the
+# Fibonacci request/feedback/result types to propagate.
+sleep 7
+
+--SHELL--
+valgrindSleep 5
+
+#
+# 01. PATCH the 'fib' attribute  -> broker sends an action goal for Fibonacci(5)
+# 02. Wait for FibonacciServer to emit feedback (3 samples, 1s apart) + final result
+# 03. GET the entity in concise format - the per-goal instance must contain
+#     ddsActionFeedback, ddsActionResult and ddsActionStatus envelope sub-attrs
+# 04. Pull the goalId out of the response, then GET fib via the synonym
+#     ?goal=<uuid>  -> the same envelope instance comes back
+#
+
+echo "01. PATCH 'fib' attribute (order=5)"
+echo "===================================="
+payload='{
+  "fib": {
+    "type": "Property",
+    "value": { "order": 5 }
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:robot:r1 -X PATCH --payload "$payload"
+echo
+echo
+
+
+echo "02. Wait for FibonacciServer (3 feedback + 1 result + status transitions)"
+echo "=========================================================================="
+sleep 6
+echo
+
+
+echo "03. GET urn:ngsi-ld:robot:r1?options=concise - per-goal instance present with envelope sub-attrs"
+echo "================================================================================================="
+orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:robot:r1?options=concise'
+echo
+echo
+
+
+echo "04. GET /attrs/fib (no filter) - see the whole attribute with all instances"
+echo "============================================================================"
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:robot:r1/attrs/fib
+echo
+echo
+
+
+echo "05. Pull goalId from the response, then GET fib via ?goal=<uuid>"
+echo "================================================================="
+goalId=$(echo "$_response" | grep -oE 'urn:goal:[0-9a-f-]+' | head -1 | sed 's/^urn:goal://')
+echo "Using goalId: $goalId"
+orionCurl --url "/ngsi-ld/v1/entities/urn:ngsi-ld:robot:r1/attrs/fib?goal=$goalId"
+echo
+echo
+
+
+--REGEXPECT--
+01. PATCH 'fib' attribute (order=5)
+====================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+02. Wait for FibonacciServer (3 feedback + 1 result + status transitions)
+==========================================================================
+
+
+03. GET urn:ngsi-ld:robot:r1?options=concise - per-goal instance present with envelope sub-attrs
+=================================================================================================
+HTTP/1.1 200 OK
+Content-Length: REGEX(\d+)
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+{
+    "ddsType": "fastdds",
+    "fib": [
+        {
+            "value": {
+                "order": 5
+            }
+        },
+        {
+            "datasetId": "urn:goal:REGEX([0-9a-f-]+)",
+            "ddsActionFeedback": {
+                "goalId": "REGEX([0-9a-f-]+)",
+                "publishedAt": REGEX(\d+),
+                "value": REGEX(.*)
+            },
+            "ddsActionResult": {
+                "goalId": "REGEX([0-9a-f-]+)",
+                "publishedAt": REGEX(\d+),
+                "value": REGEX(.*)
+            },
+            "ddsActionStatus": {
+                "goalId": REGEX(.*),
+                "publishedAt": REGEX(\d+),
+                "value": {
+                    "code": "succeeded",
+                    "message": ""
+                }
+            }
+        }
+    ],
+    "id": "urn:ngsi-ld:robot:r1",
+    "type": "Robot"
+}
+
+
+04. GET /attrs/fib (no filter) - see the whole attribute with all instances
+============================================================================
+HTTP/1.1 200 OK
+Content-Length: REGEX(\d+)
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+[
+    {
+        "type": "Property",
+        "value": {
+            "order": 5
+        }
+    },
+    {
+        "type": "Property",
+        "datasetId": "urn:goal:REGEX([0-9a-f-]+)",
+        "ddsActionFeedback": {
+            "type": "Property",
+            "value": REGEX(.*),
+            "goalId": {
+                "type": "Property",
+                "value": "REGEX([0-9a-f-]+)"
+            },
+            "publishedAt": {
+                "type": "Property",
+                "value": REGEX(\d+)
+            }
+        },
+        "ddsActionResult": {
+            "type": "Property",
+            "value": REGEX(.*),
+            "goalId": {
+                "type": "Property",
+                "value": "REGEX([0-9a-f-]+)"
+            },
+            "publishedAt": {
+                "type": "Property",
+                "value": REGEX(\d+)
+            }
+        },
+        "ddsActionStatus": {
+            "type": "Property",
+            "value": {
+                "code": "succeeded",
+                "message": ""
+            },
+            "goalId": {
+                "type": "Property",
+                "value": "REGEX([0-9a-f-]+)"
+            },
+            "publishedAt": {
+                "type": "Property",
+                "value": REGEX(\d+)
+            }
+        }
+    }
+]
+
+
+05. Pull goalId from the response, then GET fib via ?goal=<uuid>
+=================================================================
+Using goalId: REGEX([0-9a-f-]+)
+HTTP/1.1 200 OK
+Content-Length: REGEX(\d+)
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+{
+    "type": "Property",
+    "datasetId": "urn:goal:REGEX([0-9a-f-]+)",
+    "ddsActionFeedback": {
+        "type": "Property",
+        "value": REGEX(.*),
+        "goalId": {
+            "type": "Property",
+            "value": "REGEX([0-9a-f-]+)"
+        },
+        "publishedAt": {
+            "type": "Property",
+            "value": REGEX(\d+)
+        }
+    },
+    "ddsActionResult": {
+        "type": "Property",
+        "value": REGEX(.*),
+        "goalId": {
+            "type": "Property",
+            "value": "REGEX([0-9a-f-]+)"
+        },
+        "publishedAt": {
+            "type": "Property",
+            "value": REGEX(\d+)
+        }
+    },
+    "ddsActionStatus": {
+        "type": "Property",
+        "value": {
+            "code": "succeeded",
+            "message": ""
+        },
+        "goalId": {
+            "type": "Property",
+            "value": "REGEX([0-9a-f-]+)"
+        },
+        "publishedAt": {
+            "type": "Property",
+            "value": REGEX(\d+)
+        }
+    }
+}
+
+
+--TEARDOWN--
+ddsClean
+ros2ActionStop
+brokerStop CB
+dbDrop CB
+rm -f $HOME/.orionld

--- a/test/functionalTest/cases/0000_ld/dds/dds_action_goal_query_synonym.test
+++ b/test/functionalTest/cases/0000_ld/dds/dds_action_goal_query_synonym.test
@@ -1,0 +1,174 @@
+# Copyright 2026 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+'?goal=<uuid>' URI param is a synonym for '?datasetId=urn:goal:<uuid>' under -wip dds
+
+--SHELL-INIT--
+dbInit CB
+orionldStart CB -mongocOnly -wip dds
+
+--SHELL--
+
+#
+# 01. Create an entity E1 with two instances of attribute 'fib', keyed by
+#     datasetId=urn:goal:11111111-1111-1111-1111-111111111111 and
+#     datasetId=urn:goal:22222222-2222-2222-2222-222222222222.
+# 02. GET the 'fib' attribute with ?datasetId=urn:goal:11111111-1111-1111-1111-111111111111
+#     => see only instance 1
+# 03. GET the same 'fib' attribute with ?goal=11111111-1111-1111-1111-111111111111
+#     => same response as step 02 (synonym proven)
+# 04. GET the same 'fib' attribute with ?goal=22222222-2222-2222-2222-222222222222
+#     => only instance 2
+# 05. GET the entity with ?goal=33333333-3333-3333-3333-333333333333
+#     => 404 (no such dataset instance)
+#
+
+echo "01. Create entity E1 with two datasetId instances of 'fib'"
+echo "==========================================================="
+payload='{
+  "id": "urn:ngsi-ld:robot:r1",
+  "type": "Robot",
+  "fib": [
+    {
+      "type": "Property",
+      "datasetId": "urn:goal:11111111-1111-1111-1111-111111111111",
+      "value": { "order": 10 }
+    },
+    {
+      "type": "Property",
+      "datasetId": "urn:goal:22222222-2222-2222-2222-222222222222",
+      "value": { "order": 20 }
+    }
+  ]
+}'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "02. GET fib?datasetId=urn:goal:11111111-1111-1111-1111-111111111111"
+echo "===================================================================="
+orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:robot:r1/attrs/fib?datasetId=urn:goal:11111111-1111-1111-1111-111111111111'
+echo
+echo
+
+
+echo "03. GET fib?goal=11111111-1111-1111-1111-111111111111 (synonym)"
+echo "================================================================"
+orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:robot:r1/attrs/fib?goal=11111111-1111-1111-1111-111111111111'
+echo
+echo
+
+
+echo "04. GET fib?goal=22222222-2222-2222-2222-222222222222 (other dataset)"
+echo "======================================================================"
+orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:robot:r1/attrs/fib?goal=22222222-2222-2222-2222-222222222222'
+echo
+echo
+
+
+echo "05. GET fib?goal=33333333-3333-3333-3333-333333333333 (no such instance -> 404)"
+echo "================================================================================"
+orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:robot:r1/attrs/fib?goal=33333333-3333-3333-3333-333333333333'
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity E1 with two datasetId instances of 'fib'
+===========================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:robot:r1
+
+
+
+02. GET fib?datasetId=urn:goal:11111111-1111-1111-1111-111111111111
+====================================================================
+HTTP/1.1 200 OK
+Content-Length: REGEX(.*)
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+{
+    "datasetId": "urn:goal:11111111-1111-1111-1111-111111111111",
+    "type": "Property",
+    "value": {
+        "order": 10
+    }
+}
+
+
+03. GET fib?goal=11111111-1111-1111-1111-111111111111 (synonym)
+================================================================
+HTTP/1.1 200 OK
+Content-Length: REGEX(.*)
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+{
+    "datasetId": "urn:goal:11111111-1111-1111-1111-111111111111",
+    "type": "Property",
+    "value": {
+        "order": 10
+    }
+}
+
+
+04. GET fib?goal=22222222-2222-2222-2222-222222222222 (other dataset)
+======================================================================
+HTTP/1.1 200 OK
+Content-Length: REGEX(.*)
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+{
+    "datasetId": "urn:goal:22222222-2222-2222-2222-222222222222",
+    "type": "Property",
+    "value": {
+        "order": 20
+    }
+}
+
+
+05. GET fib?goal=33333333-3333-3333-3333-333333333333 (no such instance -> 404)
+================================================================================
+HTTP/1.1 404 Not Found
+Content-Length: REGEX(.*)
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": REGEX(.*),
+    "title": REGEX(.*),
+    "type": "https://uri.etsi.org/ngsi-ld/errors/ResourceNotFound"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB

--- a/test/functionalTest/cases/0000_ld/dds/dds_action_goal_query_synonym.test
+++ b/test/functionalTest/cases/0000_ld/dds/dds_action_goal_query_synonym.test
@@ -24,27 +24,28 @@
 '?goal=<uuid>' URI param is a synonym for '?datasetId=urn:goal:<uuid>' under -wip dds
 
 --SHELL-INIT--
+$REPO_HOME/scripts/configFile.sh > $HOME/.orionld
 dbInit CB
 orionldStart CB -mongocOnly -wip dds
 
 --SHELL--
 
 #
-# 01. Create an entity E1 with two instances of attribute 'fib', keyed by
+# 01. Create an entity with two instances of attribute 'fib', keyed by
 #     datasetId=urn:goal:11111111-1111-1111-1111-111111111111 and
 #     datasetId=urn:goal:22222222-2222-2222-2222-222222222222.
-# 02. GET the 'fib' attribute with ?datasetId=urn:goal:11111111-1111-1111-1111-111111111111
-#     => see only instance 1
-# 03. GET the same 'fib' attribute with ?goal=11111111-1111-1111-1111-111111111111
+# 02. GET the entity with ?datasetId=urn:goal:11111111-1111-1111-1111-111111111111
+#     => entity returned with only instance 1 of 'fib'
+# 03. GET the entity with ?goal=11111111-1111-1111-1111-111111111111
 #     => same response as step 02 (synonym proven)
-# 04. GET the same 'fib' attribute with ?goal=22222222-2222-2222-2222-222222222222
-#     => only instance 2
+# 04. GET the entity with ?goal=22222222-2222-2222-2222-222222222222
+#     => entity returned with only instance 2 of 'fib'
 # 05. GET the entity with ?goal=33333333-3333-3333-3333-333333333333
-#     => 404 (no such dataset instance)
+#     => entity returned with no 'fib' attribute (no instance matched)
 #
 
-echo "01. Create entity E1 with two datasetId instances of 'fib'"
-echo "==========================================================="
+echo "01. Create entity with two datasetId instances of 'fib'"
+echo "========================================================"
 payload='{
   "id": "urn:ngsi-ld:robot:r1",
   "type": "Robot",
@@ -66,37 +67,37 @@ echo
 echo
 
 
-echo "02. GET fib?datasetId=urn:goal:11111111-1111-1111-1111-111111111111"
-echo "===================================================================="
-orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:robot:r1/attrs/fib?datasetId=urn:goal:11111111-1111-1111-1111-111111111111'
+echo "02. GET entity with ?datasetId=urn:goal:11111111-1111-1111-1111-111111111111"
+echo "============================================================================="
+orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:robot:r1?datasetId=urn:goal:11111111-1111-1111-1111-111111111111&prettyPrint=yes' --noPayloadCheck
 echo
 echo
 
 
-echo "03. GET fib?goal=11111111-1111-1111-1111-111111111111 (synonym)"
-echo "================================================================"
-orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:robot:r1/attrs/fib?goal=11111111-1111-1111-1111-111111111111'
+echo "03. GET entity with ?goal=11111111-1111-1111-1111-111111111111 (synonym)"
+echo "========================================================================="
+orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:robot:r1?goal=11111111-1111-1111-1111-111111111111&prettyPrint=yes' --noPayloadCheck
 echo
 echo
 
 
-echo "04. GET fib?goal=22222222-2222-2222-2222-222222222222 (other dataset)"
-echo "======================================================================"
-orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:robot:r1/attrs/fib?goal=22222222-2222-2222-2222-222222222222'
+echo "04. GET entity with ?goal=22222222-2222-2222-2222-222222222222 (other dataset)"
+echo "==============================================================================="
+orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:robot:r1?goal=22222222-2222-2222-2222-222222222222&prettyPrint=yes' --noPayloadCheck
 echo
 echo
 
 
-echo "05. GET fib?goal=33333333-3333-3333-3333-333333333333 (no such instance -> 404)"
-echo "================================================================================"
-orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:robot:r1/attrs/fib?goal=33333333-3333-3333-3333-333333333333'
+echo "05. GET entity with ?goal=33333333-3333-3333-3333-333333333333 (no match)"
+echo "=========================================================================="
+orionCurl --url '/ngsi-ld/v1/entities/urn:ngsi-ld:robot:r1?goal=33333333-3333-3333-3333-333333333333&prettyPrint=yes' --noPayloadCheck
 echo
 echo
 
 
 --REGEXPECT--
-01. Create entity E1 with two datasetId instances of 'fib'
-===========================================================
+01. Create entity with two datasetId instances of 'fib'
+========================================================
 HTTP/1.1 201 Created
 Content-Length: 0
 Date: REGEX(.*)
@@ -104,8 +105,8 @@ Location: /ngsi-ld/v1/entities/urn:ngsi-ld:robot:r1
 
 
 
-02. GET fib?datasetId=urn:goal:11111111-1111-1111-1111-111111111111
-====================================================================
+02. GET entity with ?datasetId=urn:goal:11111111-1111-1111-1111-111111111111
+=============================================================================
 HTTP/1.1 200 OK
 Content-Length: REGEX(.*)
 Content-Type: application/json
@@ -113,16 +114,21 @@ Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
 
 {
-    "datasetId": "urn:goal:11111111-1111-1111-1111-111111111111",
+  "id": "urn:ngsi-ld:robot:r1",
+  "type": "Robot",
+  "fib": {
     "type": "Property",
+    "datasetId": "urn:goal:11111111-1111-1111-1111-111111111111",
     "value": {
-        "order": 10
+      "order": 10
     }
+  }
 }
 
 
-03. GET fib?goal=11111111-1111-1111-1111-111111111111 (synonym)
-================================================================
+
+03. GET entity with ?goal=11111111-1111-1111-1111-111111111111 (synonym)
+=========================================================================
 HTTP/1.1 200 OK
 Content-Length: REGEX(.*)
 Content-Type: application/json
@@ -130,16 +136,21 @@ Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
 
 {
-    "datasetId": "urn:goal:11111111-1111-1111-1111-111111111111",
+  "id": "urn:ngsi-ld:robot:r1",
+  "type": "Robot",
+  "fib": {
     "type": "Property",
+    "datasetId": "urn:goal:11111111-1111-1111-1111-111111111111",
     "value": {
-        "order": 10
+      "order": 10
     }
+  }
 }
 
 
-04. GET fib?goal=22222222-2222-2222-2222-222222222222 (other dataset)
-======================================================================
+
+04. GET entity with ?goal=22222222-2222-2222-2222-222222222222 (other dataset)
+===============================================================================
 HTTP/1.1 200 OK
 Content-Length: REGEX(.*)
 Content-Type: application/json
@@ -147,26 +158,32 @@ Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
 
 {
+  "id": "urn:ngsi-ld:robot:r1",
+  "type": "Robot",
+  "fib": {
+    "type": "Property",
     "datasetId": "urn:goal:22222222-2222-2222-2222-222222222222",
-    "type": "Property",
     "value": {
-        "order": 20
+      "order": 20
     }
+  }
 }
 
 
-05. GET fib?goal=33333333-3333-3333-3333-333333333333 (no such instance -> 404)
-================================================================================
-HTTP/1.1 404 Not Found
+
+05. GET entity with ?goal=33333333-3333-3333-3333-333333333333 (no match)
+==========================================================================
+HTTP/1.1 200 OK
 Content-Length: REGEX(.*)
 Content-Type: application/json
 Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
 
 {
-    "detail": REGEX(.*),
-    "title": REGEX(.*),
-    "type": "https://uri.etsi.org/ngsi-ld/errors/ResourceNotFound"
+  "id": "urn:ngsi-ld:robot:r1",
+  "type": "Robot"
 }
+
 
 
 --TEARDOWN--

--- a/test/functionalTest/harnessFunctions.sh
+++ b/test/functionalTest/harnessFunctions.sh
@@ -2271,6 +2271,87 @@ function ros2ServiceStop
 
 
 
+# -----------------------------------------------------------------------------
+#
+# ros2ActionStart - start a ROS2 action server in a Docker container
+#
+# Parameters:
+#   --samples <n>      Number of goals to handle before the server exits (default: 10)
+#   --domain <n>       ROS domain ID (default: 0)
+#   --expect-cancel    Have the server count canceled goals towards --samples
+#
+# Uses the eprosima FibonacciServer.py from FIWARE-DDS-Enabler/ddsenabler_test.
+# That script is currently broken on Vulcanexus jazzy-desktop (RCLError on the
+# first executor.spin_once - see doc/dds/eprosima_fibonacci_server_jazzy_bug.md).
+# The standard ROS2 fibonacci_action_server (action_tutorials_cpp / _py) cannot
+# be used as a drop-in replacement because the eprosima DDS Enabler uses a
+# non-ROS2 action topic naming convention (<action_name><suffix>, e.g.
+# "fibonaccisend_goal") that the canonical servers do not announce.
+#
+# Until eprosima fixes the Jazzy bug (or ships a C++ FibonacciServer that uses
+# their convention), the dds_action_full_roundtrip.test will fail at the goal-
+# send step. Keep the helper here so the test source compiles and so the wiring
+# is in place once a working server is available.
+#
+function ros2ActionStart
+{
+  _samples=10
+  _domain=0
+  _expectCancel=""
+
+  while [ "$#" != 0 ]
+  do
+    if   [ "$1" == "--samples" ];       then _samples=$2; shift;
+    elif [ "$1" == "--domain" ];        then _domain=$2;  shift;
+    elif [ "$1" == "--expect-cancel" ]; then _expectCancel="--expect-cancel";
+    else
+      echo "Bad parameter for ros2ActionStart: $1"
+      exit 1
+    fi
+    shift
+  done
+
+  ros2ActionStop
+
+  _scripts_dir="$HOME/git/DDS/FIWARE-DDS-Enabler/ddsenabler_test/compose/scripts"
+  if [ ! -d "$_scripts_dir" ]
+  then
+    echo "ROS2 scripts directory not found: $_scripts_dir"
+    echo "Please ensure the DDS Enabler repository is available at ~/git/DDS/FIWARE-DDS-Enabler"
+    return 1
+  fi
+
+  docker run --rm -d \
+    --name ros2_action_server \
+    --ipc=host \
+    -e ROS_DOMAIN_ID=$_domain \
+    -v "$_scripts_dir:/scripts:ro" \
+    eprosima/vulcanexus:jazzy-desktop \
+    python3 /scripts/ros2_nodes/node_main.py --action --samples $_samples $_expectCancel > /dev/null 2>&1
+
+  sleep .1
+  return 0
+}
+
+
+
+# -----------------------------------------------------------------------------
+#
+# ros2ActionStop - stop the ROS2 action server container
+#
+function ros2ActionStop
+{
+  CID=$(docker ps | grep ros2_action_server | awk '{print $1}')
+
+  if [ "$CID" != "" ]
+  then
+    docker kill $CID > /dev/null 2>&1
+    sleep .1
+  fi
+}
+
+
+
 # ------------------------------------------------------------------------------
 #
 # wsConnect - connect to broker via WebSocket and create a subscription
@@ -2526,6 +2607,8 @@ export -f ftClientStart
 export -f ftClientStop
 export -f ros2ServiceStart
 export -f ros2ServiceStop
+export -f ros2ActionStart
+export -f ros2ActionStop
 export -f wsConnect
 export -f wsSend
 export -f wsSendBurst


### PR DESCRIPTION
## Summary

Bring DDS action notification handling up to parity with service replies. Each incoming feedback / result / status from a DDS action server is stored on the action-tied entity attribute as an envelope sub-Property (`goalId`, `publishedAt`, optional `instanceHandleId` / `participantId` / `ddsDataType`) under `datasetId="urn:goal:<uuid>"`. Multiple in-flight goals occupy distinct attribute instances; clients address them with standard `?datasetId=urn:goal:<uuid>` or with the shorter **`?goal=<uuid>`** synonym (under `-wip dds`).

### Highlights

- **`ddsActionBuild`** — `ddsActionBuildSubAttribute(...)`, UUID↔string helpers, `ddsActionStatusCodeToString` (lowercase: `executing` / `succeeded` / …).
- **`ddsActionSubAttributeUpdate`** — new signature; builds the envelope and merge-patches the entity instance keyed by `datasetId=urn:goal:<uuid>`.
- **Three notification handlers rewired** to use the envelope.
- **Cancel hook** in `orionldDeleteAttribute`: `DELETE /entities/{id}/attrs/<action_attr>?datasetId=urn:goal:<uuid>` fires `cancel_action_goal()` on the enabler.
- **`?goal=X` URI synonym** at the param parser (single rewrite, downstream code unchanged).

### Tests

- `dds_action_goal_query_synonym.test` — verifies the `?goal=` synonym against a fresh entity with two `datasetId` instances. Runs without DDS; included in CI.
- `dds_action_full_roundtrip.test.DISABLED` — full envelope verification against a real ROS 2 action server. **Currently disabled** because the only known compatible action peer (eprosima's `FibonacciServer.py`) crashes on Vulcanexus Jazzy with an `RCLError`, and the canonical ROS 2 tutorial servers use a topic-naming convention the enabler doesn't speak. See `doc/dds/eprosima_fibonacci_server_jazzy_bug.md` for the full bug report sent to eprosima. The test will be re-enabled once the upstream is fixed.

## Test plan

- [x] Build clean on Ubuntu 26.04
- [x] `ft dds_action_goal_query_synonym.test` passes
- [ ] GitHub Actions CI green
- [ ] `dds_action_full_roundtrip.test.DISABLED` becomes `.test` and passes once eprosima ships a fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)