### PR TITLE
doc: fix stale anchors in DDS guide

### DIFF
--- a/doc/dds/orion-ld-dds.md
+++ b/doc/dds/orion-ld-dds.md
@@ -86,7 +86,7 @@ sub-Properties (metadata) — `observedAt`, `unitCode`, `lang`, etc.
 ```
 
 Attributes are CRUD'd over REST. The endpoints relevant to DDS are listed in
-[§9](#9-which-rest-endpoints-trigger-dds).
+[§11](#11-which-rest-endpoints-trigger-dds).
 
 For DDS purposes you only need to remember: **one attribute = one DDS
 endpoint** (topic, service, or action), and the JSON `value` is what travels.
@@ -110,7 +110,7 @@ Runtime requirements:
   (multicast or discovery server).
 - The FIWARE-DDS-Enabler shared libraries on the broker's `LD_LIBRARY_PATH`.
 - For services/actions: matching IDL `.bin` type files in the directory
-  pointed to by `typesDirectory` (see [§10](#10-type-discovery)).
+  pointed to by `typesDirectory` (see [§12](#12-type-discovery)).
 
 ---
 
@@ -163,7 +163,7 @@ The relevant fields for DDS users:
 | `ngsild.topics["<TopicName>"]` | Maps the DDS topic `<TopicName>` to an `(entityType, entityId, attribute)` triple. |
 | `ngsild.services["<ServiceName>"]` | Same, for DDS services. |
 | `ngsild.actions["<ActionName>"]` | Same, for DDS actions. |
-| `ngsild.typesDirectory` | Directory of pre-built `.bin` IDL type files (required for services and actions — see [§10](#10-type-discovery)). |
+| `ngsild.typesDirectory` | Directory of pre-built `.bin` IDL type files (required for services and actions — see [§12](#12-type-discovery)). |
 | `ngsild.syncTimeoutMs` | Default timeout (ms) for synchronous service requests. |
 
 ### 4.1. The `configFile.sh` helper


### PR DESCRIPTION
Trivial follow-up to #1944.

When §9 (atomic-PATCH) and §10 (subscriptions) were inserted into the DDS user guide, the in-doc links to "Which REST endpoints trigger DDS" and "Type discovery" weren't renumbered:

- `#9-which-rest-endpoints-trigger-dds` → no longer exists (that anchor became §11)
- `#10-type-discovery` → no longer exists (became §12)

GitHub's renderer keeps the reader at the top of the page when an anchor doesn't resolve, which is what Ken hit when he tried to follow the links. Both links updated.

## Test plan

- [ ] Click the §11 link in the rendered doc — lands on "Which REST endpoints trigger DDS"
- [ ] Click the §12 link — lands on "Type discovery"