### PR TITLE
DDS Action: drop redundant per-envelope goalId

### DIFF
--- a/doc/dds/orion-ld-dds.md
+++ b/doc/dds/orion-ld-dds.md
@@ -399,19 +399,16 @@ a status, the broker stores each in the goal's attribute instance:
       "ddsActionFeedback": {             // updated each time a feedback sample arrives
         "type":  "Property",
         "value": { "partial_sequence": [0, 1, 1, 2, 3] },
-        "goalId":      { "type": "Property", "value": "9b…" },
         "publishedAt": { "type": "Property", "value": 1715617200.456 }
       },
       "ddsActionResult": {               // appears once the server returns the result
         "type":  "Property",
         "value": { "sequence": [0, 1, 1, 2, 3, 5] },
-        "goalId":      { "type": "Property", "value": "9b…" },
         "publishedAt": { "type": "Property", "value": 1715617200.789 }
       },
       "ddsActionStatus": {               // status transitions (succeeded, aborted, executing, …)
         "type":  "Property",
         "value": { "code": "succeeded", "message": "" },
-        "goalId":      { "type": "Property", "value": "9b…" },
         "publishedAt": { "type": "Property", "value": 1715617200.790 }
       }
     }
@@ -493,8 +490,9 @@ same point as a REST update, which means:
     attribute instance.
 
 - The notification payload is the standard NGSI-LD notification —
-  no DDS-specific framing. If the consumer needs the goal id, the publish
-  time, etc., those are available as sub-Properties of the attribute (see
+  no DDS-specific framing. The goal id is the instance's `datasetId`
+  (`urn:goal:<uuid>`); the publish time and other DDS envelope metadata are
+  available as sub-Properties of the attribute (see
   [§8.3](#83-feedback--result--status-arrive-as-envelope-sub-properties)).
 
 ### 10.1. Example: subscribing to Fibonacci goal status changes

--- a/src/lib/orionld/dds/ddsActionBuild.cpp
+++ b/src/lib/orionld/dds/ddsActionBuild.cpp
@@ -168,7 +168,6 @@ KjNode* ddsActionBuildSubAttribute
 (
   const char*                                       subName,
   KjNode*                                           payloadValue,
-  const eprosima::ddsenabler::participants::UUID&   goalId,
   const char*                                       instanceHandleId,
   const char*                                       participantId,
   const char*                                       ddsDataType,
@@ -185,9 +184,8 @@ KjNode* ddsActionBuildSubAttribute
   if (payloadValue != NULL)
     kjChildAdd(sub, payloadValue);
 
-  char goalIdStr[37];
-  ddsActionUuidToString(goalId, goalIdStr);
-  kjChildAdd(sub, ddsReplyStringPropertyNode("goalId", goalIdStr));
+  // The goal is already identified by the instance's datasetId ("urn:goal:<uuid>"),
+  // so no per-envelope goalId is stamped here — it would be pure duplication.
 
   if (instanceHandleId != NULL) kjChildAdd(sub, ddsReplyStringPropertyNode("instanceHandleId", instanceHandleId));
   if (participantId    != NULL) kjChildAdd(sub, ddsReplyStringPropertyNode("participantId",    participantId));

--- a/src/lib/orionld/dds/ddsActionBuild.h
+++ b/src/lib/orionld/dds/ddsActionBuild.h
@@ -40,8 +40,10 @@ extern "C"
 //
 // Helpers for building the NGSI-LD sub-attribute Property tree that wraps a
 // DDS action callback (feedback / result / status). Same envelope idea as
-// ddsReplyBuild.cpp uses for services, but keyed by goalId (UUID) instead of
-// requestId (uint64).
+// ddsReplyBuild.cpp uses for services. The service reply carries a requestId
+// because it lives on the default instance; an action envelope needs no such
+// id — its goal is identified by the per-goal datasetId of the instance it
+// sits on.
 //
 // All constructed nodes live in orionldState.kjsonP — callers must have
 // orionldState initialized for the current thread.
@@ -100,10 +102,12 @@ extern const char* ddsActionStatusCodeToString(eprosima::ddsenabler::participant
 //   "<subName>": {
 //     "type": "Property",
 //     "value": <payloadValue>,
-//     "goalId":           { "type": "Property", "value": "<uuid>" },
 //     "publishedAt":      { "type": "Property", "value": <secs since epoch> }
 //     [+ optional: instanceHandleId / participantId / ddsDataType ]
 //   }
+//
+// The goal is identified by the enclosing instance's datasetId
+// ("urn:goal:<uuid>"), so no goalId sub-Property is stamped on the envelope.
 //
 // 'payloadValue' is renamed in-place to "value" — pass a node the caller
 // doesn't need elsewhere.
@@ -112,7 +116,6 @@ extern KjNode* ddsActionBuildSubAttribute
 (
   const char*                                       subName,
   KjNode*                                           payloadValue,
-  const eprosima::ddsenabler::participants::UUID&   goalId,
   const char*                                       instanceHandleId,
   const char*                                       participantId,
   const char*                                       ddsDataType,

--- a/src/lib/orionld/dds/ddsActionSubAttributeUpdate.cpp
+++ b/src/lib/orionld/dds/ddsActionSubAttributeUpdate.cpp
@@ -104,11 +104,10 @@ void ddsActionSubAttributeUpdate
   char* attrLongName = orionldAttributeExpand(orionldState.contextP, attributeName, true, NULL);
 
   //
-  // Envelope sub-attribute (type/value/goalId/publishedAt/...)
+  // Envelope sub-attribute (type/value/publishedAt/...)
   //
   KjNode* envelope = ddsActionBuildSubAttribute(subAttributeName,
                                                 subAttributeValue,
-                                                goalId,
                                                 instanceHandleId,
                                                 participantId,
                                                 ddsDataType,

--- a/test/functionalTest/cases/0000_ld/dds/dds_action_full_roundtrip.test
+++ b/test/functionalTest/cases/0000_ld/dds/dds_action_full_roundtrip.test
@@ -33,7 +33,7 @@
 #
 
 --NAME--
-DDS Action: full goal roundtrip materialises feedback/result/status envelopes per goalId
+DDS Action: full goal roundtrip materialises feedback/result/status envelopes per goal (datasetId)
 
 --SHELL-INIT--
 ddsClean
@@ -191,10 +191,6 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
         {
             "datasetId": "urn:goal:REGEX([0-9a-f-]+)",
             "ddsActionFeedback": {
-                "goalId": {
-                    "type": "Property",
-                    "value": "REGEX([0-9a-f-]+)"
-                },
                 "publishedAt": {
                     "type": "Property",
                     "value": REGEX(\d+)
@@ -214,10 +210,6 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
                 "ddsDataType": {
                     "type": "Property",
                     "value": "REGEX(.*)"
-                },
-                "goalId": {
-                    "type": "Property",
-                    "value": "REGEX([0-9a-f-]+)"
                 },
                 "instanceHandleId": {
                     "type": "Property",
@@ -246,10 +238,6 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
                 }
             },
             "ddsActionStatus": {
-                "goalId": {
-                    "type": "Property",
-                    "value": "REGEX([0-9a-f-]+)"
-                },
                 "publishedAt": {
                     "type": "Property",
                     "value": REGEX(\d+)


### PR DESCRIPTION
## What

Drop the per-envelope `goalId` from DDS action sub-attributes. A goal is already identified by its attribute instance's `datasetId` (`urn:goal:<uuid>`), so stamping `goalId` inside every `ddsActionFeedback` / `ddsActionResult` / `ddsActionStatus` envelope was pure duplication. The now-unused `goalId` parameter of `ddsActionBuildSubAttribute` is removed as well.

The service-reply path keeps its `requestId` — that envelope lives on the default instance, which has no `datasetId` to carry the id.

Updates the user-guide example (`doc/dds/orion-ld-dds.md`) and the full-roundtrip test expectation.

## Verification

- `make di` clean (`-Werror`).
- `dds_action_full_roundtrip.test` passes 4/4 across repeat runs (~26s each), locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
