### PR TITLE
DDS action goals: datasetId-scoped watchedAttributes (attr@datasetId) - concurrent-goal isolation + roundtrip/concurrent functests

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -11,7 +11,7 @@ env:
   # Docker to the test container, so we skip it in CI only. Local runs
   # (CB_SKIP_FUNC_TESTS unset) execute the test normally - required for
   # merging DDS changes.
-  IGNORE_TEST: '0000_ld/dds/dds_service_reply_full_roundtrip.test 0000_ld/dds/dds_service_reply_ddsSync_explicit.test 0000_ld/dds/dds_service_reply_ddsSync_false_override.test 0000_ld/dds/dds_service_reply_attr_async_double.test 0000_ld/dds/dds_action_full_roundtrip.test'
+  IGNORE_TEST: '0000_ld/dds/dds_service_reply_full_roundtrip.test 0000_ld/dds/dds_service_reply_ddsSync_explicit.test 0000_ld/dds/dds_service_reply_ddsSync_false_override.test 0000_ld/dds/dds_service_reply_attr_async_double.test 0000_ld/dds/dds_action_full_roundtrip.test 0000_ld/dds/dds_action_two_concurrent_goals.test'
 
 ## Cancel running tests, get faster test-results for the latest commit
 concurrency:

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -30,6 +30,11 @@
           notification body to the matching dataset instance(s) of every attribute, per NGSI-LD spec
           clause 8.5 (non-matching attributes are dropped; '@none' selects the default instance).
           Persisted, survives broker restart, and rendered back on GET
+  #XXXX - Subscriptions support datasetId-scoped 'watchedAttributes' via the syntax "<attr>@<datasetId>"
+          (Orion-LD extension, proposed to ETSI): the subscription is TRIGGERED only when an instance with
+          that datasetId changes. The datasetId must be a URI; the token '@none' (i.e. "<attr>@@none") scopes
+          to the default no-datasetId instance; a plain "<attr>" still matches any instance. Persisted and
+          rendered back on GET
   #1905 - New CLI option -troeSslMode (env: ORIONLD_TROE_SSL_MODE) for TRoE Postgres SSL connections
   #XXXX - New CLI option -coreContextDir (env: ORIONLD_CORE_CONTEXT_DIR, default: /opt/orion/ldcontexts)
   #XXXX - Replaced prometheus-client-c with KPROM library for Prometheus metrics
@@ -80,6 +85,7 @@
   - Synchronous DDS semantics for PATCH /entities/{id} (when -wip dds is set); opt out with ?ddsSync=false
   - DDS Action goal lifecycle: an 'endpoint' sub-attribute spawns a temporary per-goal subscription that streams the goal's feedback/result/status to the initiator, torn down (instance + subscription) on goal completion
   - datasetId-aware notifications: a subscription's top-level 'datasetId' projects each notification body to the matching dataset instance(s) (NGSI-LD spec clause 8.5; '@none' selects the default instance) - so a goal's temp subscription delivers only that goal's instance
+  - Concurrent action goals no longer cross-talk: each goal's temporary subscription watches "<attr>@<goalDatasetId>" (datasetId-scoped watchedAttributes), so it is TRIGGERED only by its own goal's instance changes, not by sibling goals modifying the same attribute
   - Fixed HTTP 500 on a second consecutive PATCH/attr roundtrip (dotForEq nested-Property names so mongo $set doesn't fragment them across path-separator dots)
   - Renamed reply envelope field xId to instanceHandleId (matches FastDDS InstanceHandle_t terminology, requested by eProsima)
 

--- a/doc/dds/orion-ld-dds.md
+++ b/doc/dds/orion-ld-dds.md
@@ -401,12 +401,22 @@ curl -X PATCH http://localhost:9999/ngsi-ld/v1/entities/urn:ngsi-ld:robot:r1 \
 `endpoint` is control metadata: it is not sent on the DDS wire (only `value`
 is) and it is removed together with the attribute when the goal completes.
 
-> **NOTE (current limitation).** Until datasetId-scoped notification
-> *projection* lands, the notification **body** carries the attribute's
-> default instance, not this goal's per-instance feedback/result/status
-> envelopes. The subscription still fires reliably on every change — it tells
-> the client "the goal progressed"; use `GET …?datasetId=urn:goal:<uuid>` (or
-> the temporal API) for the detail.
+The temporary subscription is **datasetId-scoped to this goal** in two
+independent ways:
+
+- its `watchedAttributes` entry is `"<attr>@<goalDatasetId>"`, so it is
+  *triggered* only by changes to **this** goal's instance; and
+- its top-level `datasetId` *projects* each notification body down to this
+  goal's own feedback / result / status envelope.
+
+So when several goals run on the same action attribute at the same time, each
+initiator receives **only its own goal's** updates — concurrent goals do not
+cross-talk.
+
+> **NOTE.** datasetId in `watchedAttributes` (syntax `"<attr>@<datasetId>"`,
+> with `"<attr>@@none"` for the default instance) is an Orion-LD extension —
+> not yet part of the ETSI NGSI-LD API; an addition has been proposed, so the
+> syntax may change.
 
 ### 8.3. Feedback / result / status arrive as envelope sub-Properties
 

--- a/src/lib/orionld/dbModel/dbModelToApiSubscription.cpp
+++ b/src/lib/orionld/dbModel/dbModelToApiSubscription.cpp
@@ -22,9 +22,13 @@
 *
 * Author: Ken Zangelin
 */
+#include <string.h>                                              // strchr, strlen, strcpy, strcat
+
 extern "C"
 {
 #include "ktrace/kTrace.h"                                       // KT_*
+#include "kalloc/kaAlloc.h"                                      // kaAlloc
+#include "kalloc/kaStrdup.h"                                     // kaStrdup
 #include "kjson/KjNode.h"                                        // KjNode
 #include "kjson/kjLookup.h"                                      // kjLookup
 #include "kjson/kjBuilder.h"                                     // kjObject, kjString, kjChildAdd, ...
@@ -338,12 +342,28 @@ KjNode* dbModelToApiSubscription
     dbConditionsP->name = (char*) "watchedAttributes";
     kjChildAdd(apiSubP, dbConditionsP);
 
-    // Now we need to go over all watched attributes and find their alias according to the current @context
+    // Now we need to go over all watched attributes and find their alias according to the current @context.
+    // A datasetId-scoped entry "attr@datasetId" is aliased on the name part only - the datasetId is kept verbatim.
     if (forSubCache == false)
     {
       for (KjNode* attrNameNodeP = dbConditionsP->value.firstChildP; attrNameNodeP != NULL; attrNameNodeP = attrNameNodeP->next)
       {
-        attrNameNodeP->value.s = orionldContextItemAliasLookup(orionldState.contextP, attrNameNodeP->value.s, NULL, NULL);
+        char* atP = strchr(attrNameNodeP->value.s, '@');
+
+        if (atP == NULL)
+          attrNameNodeP->value.s = orionldContextItemAliasLookup(orionldState.contextP, attrNameNodeP->value.s, NULL, NULL);
+        else
+        {
+          char* dup     = kaStrdup(&orionldState.kalloc, attrNameNodeP->value.s);
+          char* dupAtP  = strchr(dup, '@');
+          *dupAtP       = 0;
+          char* nameAls = orionldContextItemAliasLookup(orionldState.contextP, dup, NULL, NULL);
+          int   len     = strlen(nameAls) + strlen(atP) + 1;   // atP starts at '@'
+          char* combined = kaAlloc(&orionldState.kalloc, len);
+          strcpy(combined, nameAls);
+          strcat(combined, atP);
+          attrNameNodeP->value.s = combined;
+        }
       }
     }
   }

--- a/src/lib/orionld/dds/ddsActionLifecycleNotify.cpp
+++ b/src/lib/orionld/dds/ddsActionLifecycleNotify.cpp
@@ -97,6 +97,7 @@ void ddsActionLifecycleNotify
   altP->alteredAttributeV[0].alterationType = AttributeValueChanged;
   altP->alteredAttributeV[0].attrName       = (char*) attrLongName;
   altP->alteredAttributeV[0].attrNameEq     = attrNameEq;
+  altP->alteredAttributeV[0].datasetId      = NULL;  // lifecycle (instance-delete) notify - not datasetId-scoped
 
   orionldState.alterations = altP;
 

--- a/src/lib/orionld/dds/ddsActionSubscription.cpp
+++ b/src/lib/orionld/dds/ddsActionSubscription.cpp
@@ -23,11 +23,13 @@
 * Author: Ken Zangelin
 */
 #include <stdlib.h>                                              // strdup, free
+#include <string.h>                                              // strlen, strcpy, strcat
 #include <time.h>                                               // time, gmtime_r, strftime
 
 extern "C"
 {
 #include "ktrace/kTrace.h"                                       // trace messages - ktrace library
+#include "kalloc/kaAlloc.h"                                      // kaAlloc
 #include "kjson/KjNode.h"                                        // KjNode
 #include "kjson/kjBuilder.h"                                     // kjObject, kjArray, kjString, kjChildAdd
 #include "kjson/kjChildPrepend.h"                                // kjChildPrepend
@@ -100,12 +102,31 @@ char* ddsActionSubscriptionCreate
   kjChildAdd(entitiesArr, entityObj);
   kjChildAdd(subP, entitiesArr);
 
+  //
+  // watchedAttributes entry. When the goal has a datasetId we scope the TRIGGER
+  // to it with the "attr@datasetId" syntax, so this temp subscription fires ONLY
+  // when THIS goal's instance changes - not when a sibling goal that happens to
+  // be in flight modifies the same attribute (avoids concurrent-goal cross-talk).
+  // attrLongName is already expanded; pCheckSubscription's expansion of the name
+  // part is idempotent.
+  //
+  char* watchedEntry = attrLongName;
+  if (datasetId != NULL)
+  {
+    int len = strlen(attrLongName) + 1 /* '@' */ + strlen(datasetId) + 1 /* '\0' */;
+    watchedEntry = kaAlloc(&orionldState.kalloc, len);
+    strcpy(watchedEntry, attrLongName);
+    strcat(watchedEntry, "@");
+    strcat(watchedEntry, datasetId);
+  }
+
   KjNode* watchedArr = kjArray(orionldState.kjsonP, "watchedAttributes");
-  kjChildAdd(watchedArr, kjString(orionldState.kjsonP, NULL, attrLongName));
+  kjChildAdd(watchedArr, kjString(orionldState.kjsonP, NULL, watchedEntry));
   kjChildAdd(subP, watchedArr);
 
-  // datasetId projection: notifications carry only THIS goal's instance (its
-  // feedback/result/status), not the default instance or sibling goals.
+  // datasetId PROJECTION: notifications carry only THIS goal's instance (its
+  // feedback/result/status), not the default instance or sibling goals. (The
+  // @-suffix above scopes the trigger; this top-level datasetId scopes the body.)
   if (datasetId != NULL)
     kjChildAdd(subP, kjString(orionldState.kjsonP, "datasetId", datasetId));
 

--- a/src/lib/orionld/kjTree/kjTreeFromCachedSubscription.cpp
+++ b/src/lib/orionld/kjTree/kjTreeFromCachedSubscription.cpp
@@ -24,10 +24,13 @@
 */
 #include <map>                                                   // std::map (for httpInfo.headers)
 #include <string>                                                // std::string (for httpInfo.headers iterator)
+#include <string.h>                                              // strchr, strlen, strcpy, strcat
 
 extern "C"
 {
 #include "ktrace/kTrace.h"                                       // KT_*
+#include "kalloc/kaAlloc.h"                                      // kaAlloc
+#include "kalloc/kaStrdup.h"                                     // kaStrdup
 #include "kjson/KjNode.h"                                        // KjNode
 #include "kjson/kjParse.h"                                       // kjParse
 #include "kjson/kjBuilder.h"                                     // kjObject, kjString, ..., kjChildAdd
@@ -181,7 +184,24 @@ KjNode* kjTreeFromCachedSubscription(CachedSubscription* cSubP, bool sysAttrs, b
 
     for (int ix = 0; ix < watchedAttributes; ix++)
     {
-      char* alias = orionldContextItemAliasLookup(orionldState.contextP, cSubP->notifyConditionV[ix].c_str(), NULL, NULL);
+      const char* entry = cSubP->notifyConditionV[ix].c_str();
+      const char* atP   = strchr(entry, '@');
+      char*       alias;
+
+      if (atP == NULL)
+        alias = orionldContextItemAliasLookup(orionldState.contextP, (char*) entry, NULL, NULL);
+      else
+      {
+        // datasetId-scoped entry "attr@datasetId" - alias only the name part, keep the datasetId verbatim
+        char* dup     = kaStrdup(&orionldState.kalloc, entry);
+        char* dupAtP  = strchr(dup, '@');
+        *dupAtP       = 0;
+        char* nameAls = orionldContextItemAliasLookup(orionldState.contextP, dup, NULL, NULL);
+        int   len     = strlen(nameAls) + strlen(atP) + 1;   // atP starts at '@'
+        alias         = kaAlloc(&orionldState.kalloc, len);
+        strcpy(alias, nameAls);
+        strcat(alias, atP);
+      }
 
       nodeP = kjString(orionldState.kjsonP, NULL, alias);
       NULL_CHECK(nodeP);

--- a/src/lib/orionld/notifications/orionldAlterations.cpp
+++ b/src/lib/orionld/notifications/orionldAlterations.cpp
@@ -45,13 +45,21 @@ extern "C"
 //
 // ALTERATION -
 //
-#define ALTERATION(altType)                                 \
-do                                                          \
-{                                                           \
-  aeP->alteredAttributeV[ix].alterationType = altType;      \
-  aeP->alteredAttributeV[ix].attrName       = attrP->name;  \
-  aeP->alteredAttributeV[ix].attrNameEq     = attrNameEq;   \
-  ++ix;                                                     \
+// datasetId of the changed instance, for datasetId-scoped watchedAttributes
+// (syntax "attr@datasetId"). A single-instance patch carries the attribute as
+// an object that still holds its 'datasetId' member at this point (it is moved
+// into orionldState.datasets later). NULL means the default (no-datasetId)
+// instance, or - for a multi-instance Array patch - "unknown" (we can't tell
+// which instances from one char*, so we leave it NULL).
+#define ALTERATION(altType)                                                                              \
+do                                                                                                       \
+{                                                                                                        \
+  KjNode* _dsNodeP = (attrP->type == KjObject)? kjLookup(attrP, "datasetId") : NULL;                     \
+  aeP->alteredAttributeV[ix].alterationType = altType;                                                   \
+  aeP->alteredAttributeV[ix].attrName       = attrP->name;                                               \
+  aeP->alteredAttributeV[ix].attrNameEq     = attrNameEq;                                                \
+  aeP->alteredAttributeV[ix].datasetId      = (_dsNodeP != NULL)? _dsNodeP->value.s : NULL;              \
+  ++ix;                                                                                                  \
 } while (0)
 
 

--- a/src/lib/orionld/notifications/subCacheAlterationMatch.cpp
+++ b/src/lib/orionld/notifications/subCacheAlterationMatch.cpp
@@ -316,6 +316,45 @@ static bool falseUpdate(KjNode* attrP, KjNode* dbAttrsP)
 
 // -----------------------------------------------------------------------------
 //
+// watchedAttributeMatch - does a watchedAttributes entry match this changed attribute?
+//
+// A watchedAttributes entry may be datasetId-scoped using the syntax
+// "attrName@datasetId" (split on the FIRST '@'): the subscription is then only
+// triggered when an instance with that datasetId actually changed. The
+// datasetId part is a URN compared verbatim; the token "@none" (i.e. an entry
+// "attrName@@none") matches the default (no-datasetId) instance. Plain
+// "attrName" entries (no '@') keep the original behaviour - match any instance -
+// so existing subscriptions are completely unaffected.
+//
+// changedDatasetId is the datasetId of the changed instance (NULL = default/none,
+// or unknown for a multi-instance Array patch).
+//
+static bool watchedAttributeMatch(const char* watched, const char* attrName, const char* changedDatasetId)
+{
+  const char* at = strchr(watched, '@');
+
+  if (at == NULL)  // not datasetId-scoped - name-only match (original behaviour)
+    return (strcmp(watched, attrName) == 0);
+
+  size_t nameLen = at - watched;
+  if ((strncmp(watched, attrName, nameLen) != 0) || (attrName[nameLen] != 0))
+    return false;
+
+  const char* wantedDs = at + 1;  // datasetId this subscription is scoped to
+
+  if (strcmp(wantedDs, "@none") == 0)   // subscription wants the default (no-datasetId) instance
+    return (changedDatasetId == NULL);
+
+  if (changedDatasetId == NULL)         // a specific instance is wanted, but the default changed
+    return false;
+
+  return (strcmp(wantedDs, changedDatasetId) == 0);
+}
+
+
+
+// -----------------------------------------------------------------------------
+//
 // attributeMatch -
 //
 static OrionldAlterationMatch* attributeMatch(OrionldAlterationMatch* matchList, CachedSubscription* subP, OrionldAlteration* altP, int* matchesP)
@@ -349,10 +388,13 @@ static OrionldAlterationMatch* attributeMatch(OrionldAlterationMatch* matchList,
         if (strcmp(attrP->name, "id")   == 0) continue;
         if (strcmp(attrP->name, "type") == 0) continue;
 
+        KjNode*     dsP       = kjLookup(attrP, "datasetId");
+        const char* changedDs = ((dsP != NULL) && (dsP->type == KjString))? dsP->value.s : NULL;
+
         for (int ix = 0; ix < watchAttrs; ix++)
         {
           KT_T(KtWatchedAttributes, "Comparing modified '%s' with watched '%s'", attrP->name, subP->notifyConditionV[ix].c_str());
-          if (strcmp(attrP->name, subP->notifyConditionV[ix].c_str()) == 0)
+          if (watchedAttributeMatch(subP->notifyConditionV[ix].c_str(), attrP->name, changedDs) == true)
           {
             if ((dbAttrsP == NULL) || (noNotifyFalseUpdate == false) || (falseUpdate(attrP, dbAttrsP) == false))
             {
@@ -409,7 +451,7 @@ static OrionldAlterationMatch* attributeMatch(OrionldAlterationMatch* matchList,
 
     while (nIx < watchAttrs)
     {
-      if (strcmp(aaP->attrName, subP->notifyConditionV[nIx].c_str()) == 0)
+      if (watchedAttributeMatch(subP->notifyConditionV[nIx].c_str(), aaP->attrName, aaP->datasetId) == true)
         break;
       ++nIx;
     }

--- a/src/lib/orionld/payloadCheck/pCheckSubscription.cpp
+++ b/src/lib/orionld/payloadCheck/pCheckSubscription.cpp
@@ -22,15 +22,20 @@
 *
 * Author: Ken Zangelin
 */
+#include <string.h>                                              // strchr, strlen, strcpy, strcat
+
 extern "C"
 {
 #include "kbase/kMacros.h"                                       // K_FT
 #include "ktrace/kTrace.h"                                       // KT_*
+#include "kalloc/kaAlloc.h"                                      // kaAlloc
+#include "kalloc/kaStrdup.h"                                     // kaStrdup
 #include "kjson/KjNode.h"                                        // KjNode
 #include "kjson/kjBuilder.h"                                     // kjChildRemove
 #include "kjson/kjLookup.h"                                      // kjLookup
 }
 
+#include "orionld/context/orionldAttributeExpand.h"              // orionldAttributeExpand
 #include "orionld/types/QNode.h"                                 // QNode
 #include "orionld/types/OrionldRenderFormat.h"                   // OrionldRenderFormat
 #include "orionld/q/qBuild.h"                                    // qBuild
@@ -217,9 +222,61 @@ bool pCheckSubscription
       PCHECK_ARRAY(watchedAttributesP, 0, NULL, SubscriptionWatchedAttributesPath, 400);
       PCHECK_ARRAY_EMPTY(watchedAttributesP, 0, NULL, SubscriptionWatchedAttributesPath, 400);
 
-      // pCheckStringArray expands (w/ orionldState.contextP) as well as checks validity
-      if (pCheckStringArray(watchedAttributesP, SubscriptionWatchedAttributesItemPath, true) == false)
-        return false;
+      //
+      // A watchedAttributes entry may be datasetId-scoped: "attrName@datasetId"
+      // (split on the FIRST '@'). The subscription is then triggered only when an
+      // instance with that datasetId changes (enforced in subCacheAlterationMatch).
+      // Only the attribute-name part is @context-expanded; the datasetId is a URN,
+      // kept verbatim. Plain entries (no '@') are expanded exactly as before.
+      //
+      for (KjNode* aP = watchedAttributesP->value.firstChildP; aP != NULL; aP = aP->next)
+      {
+        if (aP->type != KjString)
+        {
+          orionldError(OrionldBadRequestData, "Not a JSON String", SubscriptionWatchedAttributesItemPath, 400);
+          return false;
+        }
+
+        char* atP = strchr(aP->value.s, '@');
+
+        if (atP == NULL)
+          aP->value.s = orionldAttributeExpand(orionldState.contextP, aP->value.s, true, NULL);
+        else
+        {
+          char* dup     = kaStrdup(&orionldState.kalloc, aP->value.s);
+          char* dupAtP  = strchr(dup, '@');
+          *dupAtP       = 0;                 // split: dup = attribute name, dataset = datasetId
+          char* dataset = dupAtP + 1;
+
+          if (dup[0] == 0)
+          {
+            orionldError(OrionldBadRequestData, "Empty attribute name", "datasetId-scoped watchedAttributes entry (attr@datasetId)", 400);
+            return false;
+          }
+          if (dataset[0] == 0)
+          {
+            orionldError(OrionldBadRequestData, "Empty datasetId", "datasetId-scoped watchedAttributes entry (attr@datasetId)", 400);
+            return false;
+          }
+
+          // The datasetId must be a URI (NGSI-LD), except the special token "@none"
+          // (i.e. "attr@@none") which scopes to the default, no-datasetId instance.
+          if ((strcmp(dataset, "@none") != 0) && (strchr(dataset, ':') == NULL))
+          {
+            orionldError(OrionldBadRequestData, "Invalid datasetId - must be a URI", "datasetId-scoped watchedAttributes entry (attr@datasetId)", 400);
+            return false;
+          }
+
+          char* expanded = orionldAttributeExpand(orionldState.contextP, dup, true, NULL);
+          int   len      = strlen(expanded) + 1 + strlen(dataset) + 1;
+          char* combined = kaAlloc(&orionldState.kalloc, len);
+
+          strcpy(combined, expanded);
+          strcat(combined, "@");
+          strcat(combined, dataset);
+          aP->value.s = combined;
+        }
+      }
     }
     else if (strcmp(subItemP->name, "timeInterval") == 0)
       PCHECK_DUPLICATE(timeIntervalP, subItemP, 0, NULL, SubscriptionTimeIntervalPath, 400);

--- a/src/lib/orionld/types/OrionldAlteration.h
+++ b/src/lib/orionld/types/OrionldAlteration.h
@@ -68,6 +68,7 @@ typedef struct OrionldAttributeAlteration
   OrionldAlterationType  alterationType;
   char*                  attrName;
   char*                  attrNameEq;
+  char*                  datasetId;       // datasetId of the changed instance (NULL = default/none, or unknown for multi-instance) - for datasetId-scoped watchedAttributes
 } OrionldAttributeAlteration;
 
 

--- a/test/functionalTest/cases/0000_ld/dds/dds_action_full_roundtrip.test
+++ b/test/functionalTest/cases/0000_ld/dds/dds_action_full_roundtrip.test
@@ -35,7 +35,7 @@
 #
 
 --NAME--
-DDS Action: full goal roundtrip with 'endpoint' temp subscription - feedback/result/status notifications, then instance + subscription torn down on completion
+DDS Action: full goal roundtrip (x2 sequential) with 'endpoint' temp subscription - feedback/result/status notifications, then instance + subscription torn down on completion, then the action recreated for a second goal
 
 --SHELL-INIT--
 ddsClean
@@ -48,7 +48,9 @@ $REPO_HOME/scripts/configFile.sh \
 # Start the ROS2 FibonacciServer first so DDS discovery + types are in place
 # by the time the broker comes up. RCL python + action announce takes longer
 # than the AdditionServer used by the service tests, so we wait 10s.
-ros2ActionStart --samples 1
+# --samples 2: the server handles two sequential goals before exiting, so we
+# can drive the goal roundtrip twice (the second is a "recreate the action").
+ros2ActionStart --samples 2
 sleep 10
 
 dbInit CB
@@ -65,28 +67,59 @@ sleep 7
 valgrindSleep 5
 
 #
+# --- Goal 1 ---
 # 01. PATCH the 'fib' attribute WITH an 'endpoint' sub-attribute -> broker sends
 #     an action goal for Fibonacci(5) AND auto-creates a temporary (cache-only)
 #     subscription that streams this goal's feedback/result/status to ftClient.
 # 02. Wait for FibonacciServer to emit feedback (3 samples, 1s apart) + result
 # 03. GET the entity - on completion the goal's datasetId instance was the last
 #     one, so the WHOLE 'fib' attribute is removed (the history lives on in TRoE).
-#     The temp subscription has been torn down too. A later goal-PATCH re-creates fib.
-# 04. Dump the actual notifications ftClient received over the goal lifecycle
+# 04. GET /subscriptions - the temporary 'endpoint' subscription is GONE; it is
+#     torn down when the goal completes (cache-only, never persisted). Empty list.
+# 05. Dump the actual notifications ftClient received over the goal lifecycle
 #     (delivered by the temp subscription; no deletion notification - the sub is
 #     removed BEFORE the instance/attribute is removed). Each body is projected
 #     by the goal's datasetId, so it carries that goal's feedback/result/status
 #     envelope. A follow-on count is printed for convenience.
-# 05. Verify TRoE recorded the goal lifecycle (history survives the attribute removal).
+#
+# --- Goal 2 (recreate the action) ---
+# 06. Reset the ftClient accumulator so goal 2's notifications are checked alone.
+# 07. PATCH 'fib' again with an 'endpoint' -> a SECOND, sequential goal. The
+#     'fib' attribute + a fresh temp subscription are re-created from scratch.
+# 08. Wait for FibonacciServer to run the second goal.
+# 09. GET the entity - again the goal instance was the last one, so 'fib' is
+#     removed once more.
+# 10. GET /subscriptions - the second temp subscription is gone as well.
+# 11. Dump goal 2's notifications - a full fresh roundtrip, independent of goal 1.
+#
+# 12. Verify TRoE recorded BOTH goal lifecycles (history survives the removals).
 #
 # NOTE: GET /entities/{id}/attrs/{attrName} (and the synonym ?goal=<uuid>) is
 # not exercised here - that path currently bails out on multi-instance
 # (datasetId) attributes via ntocAttribute. The entity-level GET is enough to
 # prove the full DDS goal lifecycle.
 #
+# A small shell helper renders the (timing-non-deterministic) notification
+# stream in a stable, canonical form - reused for both goals.
+dumpNotifs()
+{
+  dump=$(orionCurl --url /dump --port $FT_PORT --noPayloadCheck)
+  bodies=$(echo "$dump" | grep -vE '^(POST |HTTP/|Content-|User-Agent|Host:|Accept:|Ngsild-|Link:|Date:|====)')
 
-echo "01. PATCH 'fib' attribute (order=5) with notification 'endpoint' sub-attr"
-echo "========================================================================="
+  echo "Total notifications received: $(echo "$dump" | grep -c 'POST /notify')"
+  echo
+  echo "ddsActionStatus codes delivered (sorted, unique):"
+  echo "$bodies" | jq -r '.data[].fib.ddsActionStatus.value.code // empty' 2>/dev/null | sort -u | sed 's/^/  /'
+  echo
+  echo "ddsActionFeedback partial_sequence(s) delivered (sorted, unique):"
+  echo "$bodies" | jq -rc '.data[].fib.ddsActionFeedback.value.partial_sequence // empty' 2>/dev/null | sort -u | sed 's/^/  /'
+  echo
+  echo "Terminal notification body (the final 'succeeded' snapshot, key-sorted):"
+  echo "$bodies" | jq -s -S '.[-1]' 2>/dev/null
+}
+
+echo "01. Goal 1: PATCH 'fib' attribute (order=5) with notification 'endpoint' sub-attr"
+echo "================================================================================="
 payload='{
   "fib": {
     "type": "Property",
@@ -115,57 +148,103 @@ echo
 echo
 
 
-echo "04. Notifications ftClient received over the goal lifecycle (via temp sub)"
-echo "==========================================================================="
+echo "04. GET /subscriptions - the temporary 'endpoint' subscription is gone"
+echo "======================================================================"
+# The 'endpoint' sub-attribute spawned a cache-only subscription for this goal.
+# It is torn down when the goal completes (BEFORE the instance/attribute removal),
+# and it was never persisted, so the subscription list is empty.
+orionCurl --url /ngsi-ld/v1/subscriptions
+echo
+echo
+
+
+echo "05. Goal 1 notifications ftClient received over the goal lifecycle (via temp sub)"
+echo "================================================================================="
 # The temp subscription carries the goal's datasetId, so notificationSend projects
 # each notification body down to the matching per-goal dataset instance - i.e. each
 # body carries that goal's feedback/result/status envelope, not the default instance.
-#
-# The exact per-notification body is timing-dependent (each notification is a
-# cumulative snapshot of the 'fib' instance, and the feedback/status DDS callbacks
-# race), so we show the delivered content in a stable, canonical form: the distinct
-# status codes, the feedback partial_sequences, and the (stable) terminal body.
-dump=$(orionCurl --url /dump --port $FT_PORT --noPayloadCheck)
-bodies=$(echo "$dump" | grep -vE '^(POST |HTTP/|Content-|User-Agent|Host:|Accept:|Ngsild-|Link:|Date:|====)')
-
-echo "Total notifications received: $(echo "$dump" | grep -c 'POST /notify')"
-echo
-echo "ddsActionStatus codes delivered (sorted, unique):"
-echo "$bodies" | jq -r '.data[].fib.ddsActionStatus.value.code // empty' 2>/dev/null | sort -u | sed 's/^/  /'
-echo
-echo "ddsActionFeedback partial_sequence(s) delivered (sorted, unique):"
-echo "$bodies" | jq -rc '.data[].fib.ddsActionFeedback.value.partial_sequence // empty' 2>/dev/null | sort -u | sed 's/^/  /'
-echo
-echo "Terminal notification body (the final 'succeeded' snapshot, key-sorted):"
-echo "$bodies" | jq -s -S '.[-1]' 2>/dev/null
+dumpNotifs
 echo
 echo
 
 
-echo "05. Verify TRoE recorded the goal lifecycle"
-echo "============================================"
+echo "06. Reset the ftClient accumulator before recreating the action"
+echo "==============================================================="
+orionCurl --url /dump --port $FT_PORT -X DELETE
+echo
+echo
+
+
+echo "07. Goal 2 (recreate the action): PATCH 'fib' again with an 'endpoint' sub-attr"
+echo "==============================================================================="
+# 'fib' was removed when goal 1 completed; this PATCH re-creates the attribute and
+# a fresh temporary subscription, and fires a second, sequential goal.
+payload='{
+  "fib": {
+    "type": "Property",
+    "value": { "order": 5 },
+    "endpoint": {
+      "type": "Property",
+      "value": "http://127.0.0.1:'${FT_PORT}'/notify"
+    }
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:robot:r1 -X PATCH --payload "$payload"
+echo
+echo
+
+
+echo "08. Wait for FibonacciServer to run the second goal"
+echo "==================================================="
+sleep 6
+echo
+
+
+echo "09. GET urn:ngsi-ld:robot:r1 - goal 2 instance done, so 'fib' attribute removed again"
+echo "====================================================================================="
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:robot:r1
+echo
+echo
+
+
+echo "10. GET /subscriptions - goal 2's temporary subscription is gone as well"
+echo "========================================================================"
+orionCurl --url /ngsi-ld/v1/subscriptions
+echo
+echo
+
+
+echo "11. Goal 2 notifications - a full fresh roundtrip, independent of goal 1"
+echo "======================================================================="
+dumpNotifs
+echo
+echo
+
+
+echo "12. Verify TRoE recorded BOTH goal lifecycles"
+echo "============================================="
 # Each PatchEntity2 call drives the standard TRoE pipeline via
 # serviceP->troeRoutine(). For a fib PATCH with body-level datasetId,
-# pgAttributeBuild emits an INSERT into attributes with the datasetId
-# tagged. Count goal-tagged rows.
-# (a) the per-goal lifecycle PATCHes were recorded (>=5 attribute rows tagged
-#     with the goal's datasetId), (b) exactly one goal was recorded, and
-#     (c) the terminal 'succeeded' status landed in TRoE as a sub-attribute -
-#     i.e. the history survives the attribute removal.
+# pgAttributeBuild emits an INSERT into attributes with the datasetId tagged.
+# After two goals we expect:
+# (a) the per-goal lifecycle PATCHes were recorded (>=10 attribute rows tagged
+#     with a goal datasetId - >=5 per goal), (b) exactly two distinct goals, and
+# (c) the terminal 'succeeded' status landed in TRoE for both goals -
+#     i.e. the history survives the attribute removals.
 goalRows=$(postgresCmd -sql "SELECT COUNT(*) FROM attributes WHERE entityid='urn:ngsi-ld:robot:r1' AND datasetid LIKE 'urn:goal:%'" 2>&1 | tail -1 | tr -d ' \r\n')
 goals=$(postgresCmd -sql "SELECT COUNT(DISTINCT datasetid) FROM attributes WHERE entityid='urn:ngsi-ld:robot:r1' AND datasetid LIKE 'urn:goal:%'" 2>&1 | tail -1 | tr -d ' \r\n')
 succ=$(postgresCmd -sql "SELECT COUNT(*) FROM subattributes WHERE entityid='urn:ngsi-ld:robot:r1' AND compound::text LIKE '%succeeded%'" 2>&1 | tail -1 | tr -d ' \r\n')
 
-if [ "$goalRows" -ge 5 ]; then echo "TRoE goal lifecycle rows: OK (>=5)"; else echo "TRoE goal lifecycle rows: TOO FEW ($goalRows)"; fi
-if [ "$goals" -eq 1 ];    then echo "TRoE distinct goals: OK (1)";        else echo "TRoE distinct goals: UNEXPECTED ($goals)"; fi
-if [ "$succ" -ge 1 ];     then echo "TRoE recorded terminal 'succeeded': OK"; else echo "TRoE recorded terminal 'succeeded': MISSING"; fi
+if [ "$goalRows" -ge 10 ]; then echo "TRoE goal lifecycle rows: OK (>=10)"; else echo "TRoE goal lifecycle rows: TOO FEW ($goalRows)"; fi
+if [ "$goals" -eq 2 ];     then echo "TRoE distinct goals: OK (2)";          else echo "TRoE distinct goals: UNEXPECTED ($goals)"; fi
+if [ "$succ" -ge 2 ];      then echo "TRoE recorded terminal 'succeeded' for both goals: OK"; else echo "TRoE recorded terminal 'succeeded' for both goals: MISSING ($succ)"; fi
 echo
 echo
 
 
 --REGEXPECT--
-01. PATCH 'fib' attribute (order=5) with notification 'endpoint' sub-attr
-=========================================================================
+01. Goal 1: PATCH 'fib' attribute (order=5) with notification 'endpoint' sub-attr
+=================================================================================
 HTTP/1.1 204 No Content
 Date: REGEX(.*)
 
@@ -177,10 +256,10 @@ Date: REGEX(.*)
 03. GET urn:ngsi-ld:robot:r1 - last goal instance done, so 'fib' attribute removed
 ==================================================================================
 HTTP/1.1 200 OK
-Content-Length: REGEX(\d+)
+Content-Length: 92
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "ddsType": {
@@ -192,8 +271,19 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
 }
 
 
-04. Notifications ftClient received over the goal lifecycle (via temp sub)
-===========================================================================
+04. GET /subscriptions - the temporary 'endpoint' subscription is gone
+======================================================================
+HTTP/1.1 200 OK
+Content-Length: 2
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+[]
+
+
+05. Goal 1 notifications ftClient received over the goal lifecycle (via temp sub)
+=================================================================================
 Total notifications received: 9
 
 ddsActionStatus codes delivered (sorted, unique):
@@ -255,11 +345,120 @@ Terminal notification body (the final 'succeeded' snapshot, key-sorted):
 }
 
 
-05. Verify TRoE recorded the goal lifecycle
-============================================
-TRoE goal lifecycle rows: OK (>=5)
-TRoE distinct goals: OK (1)
-TRoE recorded terminal 'succeeded': OK
+06. Reset the ftClient accumulator before recreating the action
+===============================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+07. Goal 2 (recreate the action): PATCH 'fib' again with an 'endpoint' sub-attr
+===============================================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+08. Wait for FibonacciServer to run the second goal
+===================================================
+
+09. GET urn:ngsi-ld:robot:r1 - goal 2 instance done, so 'fib' attribute removed again
+=====================================================================================
+HTTP/1.1 200 OK
+Content-Length: 92
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+{
+    "ddsType": {
+        "type": "Property",
+        "value": "fastdds"
+    },
+    "id": "urn:ngsi-ld:robot:r1",
+    "type": "Robot"
+}
+
+
+10. GET /subscriptions - goal 2's temporary subscription is gone as well
+========================================================================
+HTTP/1.1 200 OK
+Content-Length: 2
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+[]
+
+
+11. Goal 2 notifications - a full fresh roundtrip, independent of goal 1
+=======================================================================
+Total notifications received: 9
+
+ddsActionStatus codes delivered (sorted, unique):
+  accepted
+  executing
+  succeeded
+
+ddsActionFeedback partial_sequence(s) delivered (sorted, unique):
+  [0,1,1,2,3]
+  [0,1,1,2]
+  [0,1,1]
+
+Terminal notification body (the final 'succeeded' snapshot, key-sorted):
+{
+  "data": [
+    {
+      "fib": {
+        "datasetId": "REGEX(urn:goal:.*)",
+        "ddsActionFeedback": {
+          "publishedAt": {
+            "type": "Property",
+            "value": REGEX(\d+)
+          },
+          "type": "Property",
+          "value": {
+            "partial_sequence": [
+              0,
+              1,
+              1,
+              2,
+              3
+            ]
+          }
+        },
+        "ddsActionStatus": {
+          "publishedAt": {
+            "type": "Property",
+            "value": REGEX(\d+)
+          },
+          "type": "Property",
+          "value": {
+            "code": "succeeded",
+            "message": "The goal was achieved successfully by the action server"
+          }
+        },
+        "type": "Property",
+        "value": {
+          "order": 5
+        }
+      },
+      "id": "urn:ngsi-ld:robot:r1",
+      "type": "Robot"
+    }
+  ],
+  "id": "REGEX(urn:ngsi-ld:Notification:.*)",
+  "notifiedAt": "REGEX(.*)",
+  "subscriptionId": "REGEX(urn:ngsi-ld:subscription:.*)",
+  "type": "Notification"
+}
+
+
+12. Verify TRoE recorded BOTH goal lifecycles
+=============================================
+TRoE goal lifecycle rows: OK (>=10)
+TRoE distinct goals: OK (2)
+TRoE recorded terminal 'succeeded' for both goals: OK
 
 
 --TEARDOWN--

--- a/test/functionalTest/cases/0000_ld/dds/dds_action_full_roundtrip.test
+++ b/test/functionalTest/cases/0000_ld/dds/dds_action_full_roundtrip.test
@@ -284,7 +284,7 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="h
 
 05. Goal 1 notifications ftClient received over the goal lifecycle (via temp sub)
 =================================================================================
-Total notifications received: 9
+Total notifications received: 8
 
 ddsActionStatus codes delivered (sorted, unique):
   accepted
@@ -393,7 +393,7 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="h
 
 11. Goal 2 notifications - a full fresh roundtrip, independent of goal 1
 =======================================================================
-Total notifications received: 9
+Total notifications received: 8
 
 ddsActionStatus codes delivered (sorted, unique):
   accepted

--- a/test/functionalTest/cases/0000_ld/dds/dds_action_two_concurrent_goals.test
+++ b/test/functionalTest/cases/0000_ld/dds/dds_action_two_concurrent_goals.test
@@ -1,0 +1,297 @@
+# Copyright 2026 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+#
+# This test requires Docker and the eprosima/vulcanexus:jazzy-desktop image.
+# Skipped in GitHub Actions (the test container can't reach the docker daemon).
+#
+# ============================================================================
+# KNOWN LIMITATION documented by this test: concurrent-goal notification
+# cross-talk.
+#
+# Each DDS action goal that carries an 'endpoint' spawns a temporary
+# subscription with watchedAttributes:["fib"] and a top-level datasetId set to
+# that goal's per-goal datasetId. In NGSI-LD the subscription datasetId is a
+# PROJECTION of the notification body only - there is NO datasetId in
+# 'watchedAttributes', so the notification TRIGGER cannot be scoped to a single
+# datasetId instance. (A datasetId-aware 'watchedAttributes' is not in the ETSI
+# spec; an addition has been proposed.)
+#
+# Consequence with two goals in flight at once: every change to EITHER goal's
+# 'fib' instance fires BOTH temp subscriptions. The delivered DATA is always
+# correct - notificationSend's datasetFilter projects each body down to the
+# subscription's own goal instance (a single object, never the sibling goal) -
+# but it is OVER-DELIVERED:
+#   - duplicate snapshots: a goal's subscriber re-receives its own (unchanged)
+#     instance every time the sibling goal changes 'fib';
+#   - a few empty notifications (id+type only): a subscriber fires before its
+#     own goal's instance has materialised, so datasetFilter finds no matching
+#     instance and drops 'fib' from the body.
+# Both stem from the single missing feature; neither is a data-correctness bug.
+# This test asserts the lifecycle is correct (overlap, per-goal projection,
+# cleanup, TRoE) AND pins the cross-talk as the expected, documented behaviour.
+# ============================================================================
+#
+
+--NAME--
+DDS Action: two concurrent goals - overlapping instances/subs + KNOWN notification cross-talk limitation
+
+--SHELL-INIT--
+ddsClean
+
+$REPO_HOME/scripts/configFile.sh \
+  --ddsAction "fibonacci,Robot,urn:ngsi-ld:robot:r1,fib" \
+  --ddsTypesDirectory "$REPO_HOME/test/functionalTest/ddsTypes" \
+  > $HOME/.orionld
+
+# The server must handle two goals (here: two overlapping/concurrent goals).
+ros2ActionStart --samples 2
+sleep 10
+
+dbInit CB
+pgInit $CB_DB_NAME
+orionldStart CB -mongocOnly -wip dds -troe
+
+ftClientStart -v -t 200
+
+# Allow discovery + type propagation between broker and action server.
+sleep 7
+
+--SHELL--
+
+#
+# Fire TWO action goals back-to-back (each PATCH of 'fib' fires a fresh goal with
+# its own per-goal datasetId instance and its own temporary 'endpoint' subscription).
+# Then observe, WHILE both should be in flight:
+#   - how many per-goal datasetId instances 'fib' carries
+#   - how many temporary subscriptions exist
+# and after both complete:
+#   - 'fib' removed, subscriptions empty
+#   - the notifications ftClient received, grouped per goal (datasetId) and per
+#     subscription, which surfaces any cross-talk (each temp sub watches 'fib',
+#     and datasetId is only a PROJECTION, not a trigger filter - so a change to
+#     one goal's instance also fires the other goal's subscription).
+#
+# 01. Fire goal 1 (PATCH 'fib' order=5 with 'endpoint')
+# 02. Fire goal 2 (PATCH 'fib' order=5 with 'endpoint') - immediately, no wait
+# 03. Mid-flight: both goals' 'fib' datasetId instances are in flight (>=2)
+# 04. Mid-flight: both temp subscriptions are present (>=2)
+# 05. Wait for both goals to complete
+# 06. GET entity - both done, 'fib' removed
+# 07. GET /subscriptions - both temp subs gone
+# 08. Notifications: amplification + the KNOWN cross-talk limitation, AND
+#     per-goal projection is still correct (no body ever carries both instances)
+# 09. TRoE: two distinct goals recorded
+#
+
+echo "01. Fire goal 1: PATCH 'fib' (order=5) with 'endpoint'"
+echo "====================================================="
+payload='{
+  "fib": {
+    "type": "Property",
+    "value": { "order": 5 },
+    "endpoint": {
+      "type": "Property",
+      "value": "http://127.0.0.1:'${FT_PORT}'/notify"
+    }
+  }
+}'
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:robot:r1 -X PATCH --payload "$payload"
+echo
+echo
+
+
+echo "02. Fire goal 2: PATCH 'fib' (order=5) with 'endpoint' - immediately"
+echo "==================================================================="
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:robot:r1 -X PATCH --payload "$payload"
+echo
+echo
+
+
+echo "03. Mid-flight: are both goals' 'fib' datasetId instances in flight?"
+echo "===================================================================="
+sleep 1
+ent=$(orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:robot:r1 --noPayloadCheck 2>/dev/null)
+body=$(echo "$ent" | sed -n '/^{/,$p')
+inst=$(echo "$body" | jq '[.. | .datasetId? // empty] | map(select(startswith("urn:goal:"))) | length' 2>/dev/null)
+echo "in-flight fib goal datasetId instances: $inst"
+if [ "$inst" -ge 2 ]; then echo "VERDICT two goals concurrently in flight: YES"; else echo "VERDICT two goals concurrently in flight: NO ($inst)"; fi
+echo
+echo
+
+
+echo "04. Mid-flight: are both temporary subscriptions present?"
+echo "========================================================="
+subs=$(orionCurl --url /ngsi-ld/v1/subscriptions --noPayloadCheck 2>/dev/null)
+sbody=$(echo "$subs" | sed -n '/^\[/,$p')
+nsub=$(echo "$sbody" | jq 'length' 2>/dev/null)
+echo "temp subscriptions in flight: $nsub"
+if [ "$nsub" -ge 2 ]; then echo "VERDICT two temp subscriptions in flight: YES"; else echo "VERDICT two temp subscriptions in flight: NO ($nsub)"; fi
+echo
+echo
+
+
+echo "05. Wait for both goals to complete"
+echo "==================================="
+sleep 8
+echo
+
+
+echo "06. GET entity - both goals done, 'fib' removed"
+echo "==============================================="
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:robot:r1
+echo
+echo
+
+
+echo "07. GET /subscriptions - both temp subscriptions gone"
+echo "====================================================="
+orionCurl --url /ngsi-ld/v1/subscriptions
+echo
+echo
+
+
+echo "08. Notifications ftClient received - amplification + KNOWN cross-talk limitation"
+echo "================================================================================="
+# KNOWN LIMITATION (see the header NOTE): each goal's temp subscription watches
+# the 'fib' attribute, and a subscription's datasetId is a PROJECTION only - the
+# NGSI-LD spec has no datasetId in 'watchedAttributes', so the TRIGGER cannot be
+# scoped to one goal's instance. While both goals are in flight, every change to
+# EITHER goal's instance fires BOTH temp subscriptions. The data is always
+# correct (each body is projected to its own goal's single instance), but it is
+# over-delivered:
+#   - duplicate snapshots: a goal's sub re-fires its unchanged instance whenever
+#     the sibling goal changes 'fib';
+#   - a few "empty" notifications (id+type only): a sub fires before its own
+#     goal's instance exists, so datasetFilter finds nothing and drops 'fib'.
+# A single goal delivers ~9 notifications; two INDEPENDENT goals without
+# cross-talk would total ~18. Cross-talk pushes it well above that.
+dump=$(orionCurl --url /dump --port $FT_PORT --noPayloadCheck)
+bodies=$(echo "$dump" | grep -vE '^(POST |HTTP/|Content-|User-Agent|Host:|Accept:|Ngsild-|Link:|Date:|====)')
+
+total=$(echo "$dump" | grep -c 'POST /notify')
+dgoals=$(echo "$bodies"  | jq -r '.data[0].fib.datasetId // empty'              2>/dev/null | sort -u | grep -c 'urn:goal:')
+arrays=$(echo "$bodies"  | jq -r 'select((.data[0].fib|type)=="array")  | "x"'  2>/dev/null | wc -l | tr -d ' ')
+empties=$(echo "$bodies" | jq -r 'select(.data[0].fib == null)          | "x"'  2>/dev/null | wc -l | tr -d ' ')
+
+echo "Total notifications received: $total"
+echo "Distinct goal datasetIds carried in bodies: $dgoals"
+echo "Notifications carrying BOTH instances (fib as array - projection leak): $arrays"
+echo "Empty notifications - sub fired before its own goal instance existed: $empties"
+echo
+if [ "$total" -gt 18 ]; then echo "VERDICT cross-talk amplification (well above the ~18 no-cross-talk baseline): YES"; else echo "VERDICT cross-talk amplification: NO ($total)"; fi
+if [ "$dgoals" -eq 2 ]; then echo "VERDICT both goals' own data delivered (2 distinct goal datasetIds): YES"; else echo "VERDICT distinct goals: UNEXPECTED ($dgoals)"; fi
+if [ "$arrays" -eq 0 ]; then echo "VERDICT per-goal projection correct (no body ever carried both instances): YES"; else echo "VERDICT projection LEAK ($arrays bodies carried both instances)"; fi
+echo
+echo
+
+
+echo "09. TRoE: two distinct goals recorded"
+echo "====================================="
+goals=$(postgresCmd -sql "SELECT COUNT(DISTINCT datasetid) FROM attributes WHERE entityid='urn:ngsi-ld:robot:r1' AND datasetid LIKE 'urn:goal:%'" 2>&1 | tail -1 | tr -d ' \r\n')
+if [ "$goals" -eq 2 ]; then echo "TRoE distinct goals: OK (2)"; else echo "TRoE distinct goals: UNEXPECTED ($goals)"; fi
+echo
+echo
+
+
+--REGEXPECT--
+01. Fire goal 1: PATCH 'fib' (order=5) with 'endpoint'
+=====================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+02. Fire goal 2: PATCH 'fib' (order=5) with 'endpoint' - immediately
+===================================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+03. Mid-flight: are both goals' 'fib' datasetId instances in flight?
+====================================================================
+in-flight fib goal datasetId instances: REGEX([0-9]+)
+VERDICT two goals concurrently in flight: YES
+
+
+04. Mid-flight: are both temporary subscriptions present?
+=========================================================
+temp subscriptions in flight: REGEX([0-9]+)
+VERDICT two temp subscriptions in flight: YES
+
+
+05. Wait for both goals to complete
+===================================
+
+06. GET entity - both goals done, 'fib' removed
+===============================================
+HTTP/1.1 200 OK
+Content-Length: 92
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+{
+    "ddsType": {
+        "type": "Property",
+        "value": "fastdds"
+    },
+    "id": "urn:ngsi-ld:robot:r1",
+    "type": "Robot"
+}
+
+
+07. GET /subscriptions - both temp subscriptions gone
+=====================================================
+HTTP/1.1 200 OK
+Content-Length: 2
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+[]
+
+
+08. Notifications ftClient received - amplification + KNOWN cross-talk limitation
+=================================================================================
+Total notifications received: REGEX([0-9]+)
+Distinct goal datasetIds carried in bodies: 2
+Notifications carrying BOTH instances (fib as array - projection leak): 0
+Empty notifications - sub fired before its own goal instance existed: REGEX([0-9]+)
+
+VERDICT cross-talk amplification (well above the ~18 no-cross-talk baseline): YES
+VERDICT both goals' own data delivered (2 distinct goal datasetIds): YES
+VERDICT per-goal projection correct (no body ever carried both instances): YES
+
+
+09. TRoE: two distinct goals recorded
+=====================================
+TRoE distinct goals: OK (2)
+
+
+--TEARDOWN--
+ddsClean
+ros2ActionStop
+brokerStop CB
+ftClientStop
+dbDrop CB
+pgDrop $CB_DB_NAME
+rm -f $HOME/.orionld

--- a/test/functionalTest/cases/0000_ld/dds/dds_action_two_concurrent_goals.test
+++ b/test/functionalTest/cases/0000_ld/dds/dds_action_two_concurrent_goals.test
@@ -23,35 +23,34 @@
 # Skipped in GitHub Actions (the test container can't reach the docker daemon).
 #
 # ============================================================================
-# KNOWN LIMITATION documented by this test: concurrent-goal notification
-# cross-talk.
+# What this test verifies: concurrent-goal notification ISOLATION via
+# datasetId-scoped watchedAttributes.
 #
 # Each DDS action goal that carries an 'endpoint' spawns a temporary
-# subscription with watchedAttributes:["fib"] and a top-level datasetId set to
-# that goal's per-goal datasetId. In NGSI-LD the subscription datasetId is a
-# PROJECTION of the notification body only - there is NO datasetId in
-# 'watchedAttributes', so the notification TRIGGER cannot be scoped to a single
-# datasetId instance. (A datasetId-aware 'watchedAttributes' is not in the ETSI
-# spec; an addition has been proposed.)
+# subscription. The subscription's watchedAttributes entry is datasetId-scoped
+# using the "attr@datasetId" syntax - here "fib@<goal's datasetId>" - so the
+# notification TRIGGER is bound to that goal's own instance, and the top-level
+# datasetId still PROJECTS the body to that instance.
 #
-# Consequence with two goals in flight at once: every change to EITHER goal's
-# 'fib' instance fires BOTH temp subscriptions. The delivered DATA is always
-# correct - notificationSend's datasetFilter projects each body down to the
-# subscription's own goal instance (a single object, never the sibling goal) -
-# but it is OVER-DELIVERED:
-#   - duplicate snapshots: a goal's subscriber re-receives its own (unchanged)
-#     instance every time the sibling goal changes 'fib';
-#   - a few empty notifications (id+type only): a subscriber fires before its
-#     own goal's instance has materialised, so datasetFilter finds no matching
-#     instance and drops 'fib' from the body.
-# Both stem from the single missing feature; neither is a data-correctness bug.
-# This test asserts the lifecycle is correct (overlap, per-goal projection,
-# cleanup, TRoE) AND pins the cross-talk as the expected, documented behaviour.
+# Consequence with two goals in flight at once: a change to one goal's 'fib'
+# instance fires ONLY that goal's subscription; the sibling goal's subscriber is
+# not woken. Each subscriber therefore receives ~the notifications of a single
+# goal (~9), and the total stays near the two-independent-goals baseline (~18),
+# rather than ~doubling (~34) as it would if the trigger fired on every change
+# to 'fib' regardless of datasetId (the pre-fix cross-talk).
+#
+# NOTE: datasetId in 'watchedAttributes' ("attr@datasetId") is an Orion-LD
+# extension - not (yet) in the ETSI NGSI-LD spec; an addition has been proposed.
+# The syntax may change once ETSI decides.
+#
+# This test asserts: both goals overlap, per-goal trigger isolation (no
+# cross-talk amplification), correct per-goal body projection, full lifecycle
+# cleanup, and TRoE recording both goals.
 # ============================================================================
 #
 
 --NAME--
-DDS Action: two concurrent goals - overlapping instances/subs + KNOWN notification cross-talk limitation
+DDS Action: two concurrent goals - datasetId-scoped watchedAttributes isolates each goal's notifications (no cross-talk)
 
 --SHELL-INIT--
 ddsClean
@@ -96,8 +95,8 @@ sleep 7
 # 05. Wait for both goals to complete
 # 06. GET entity - both done, 'fib' removed
 # 07. GET /subscriptions - both temp subs gone
-# 08. Notifications: amplification + the KNOWN cross-talk limitation, AND
-#     per-goal projection is still correct (no body ever carries both instances)
+# 08. Notifications: per-goal trigger isolation (no cross-talk amplification),
+#     each goal got ~one goal's worth, projection correct (no body has both)
 # 09. TRoE: two distinct goals recorded
 #
 
@@ -168,37 +167,35 @@ echo
 echo
 
 
-echo "08. Notifications ftClient received - amplification + KNOWN cross-talk limitation"
-echo "================================================================================="
-# KNOWN LIMITATION (see the header NOTE): each goal's temp subscription watches
-# the 'fib' attribute, and a subscription's datasetId is a PROJECTION only - the
-# NGSI-LD spec has no datasetId in 'watchedAttributes', so the TRIGGER cannot be
-# scoped to one goal's instance. While both goals are in flight, every change to
-# EITHER goal's instance fires BOTH temp subscriptions. The data is always
-# correct (each body is projected to its own goal's single instance), but it is
-# over-delivered:
-#   - duplicate snapshots: a goal's sub re-fires its unchanged instance whenever
-#     the sibling goal changes 'fib';
-#   - a few "empty" notifications (id+type only): a sub fires before its own
-#     goal's instance exists, so datasetFilter finds nothing and drops 'fib'.
-# A single goal delivers ~9 notifications; two INDEPENDENT goals without
-# cross-talk would total ~18. Cross-talk pushes it well above that.
+echo "08. Notifications ftClient received - per-goal isolation (no cross-talk)"
+echo "========================================================================"
+# Each goal's temp subscription watches "fib@<its goal datasetId>" (datasetId-
+# scoped watchedAttributes), so the TRIGGER is bound to that goal's own instance.
+# While both goals are in flight, a change to one goal's instance fires ONLY that
+# goal's subscription - the sibling goal is not notified. So each subscriber
+# receives ~the same number of notifications a single goal produces (~9), and the
+# total stays near the 2-independent-goals baseline (~18) instead of doubling
+# (~34) as it would if the trigger fired on every 'fib' change. The body is also
+# projected (top-level datasetId) to that goal's single instance.
 dump=$(orionCurl --url /dump --port $FT_PORT --noPayloadCheck)
 bodies=$(echo "$dump" | grep -vE '^(POST |HTTP/|Content-|User-Agent|Host:|Accept:|Ngsild-|Link:|Date:|====)')
 
 total=$(echo "$dump" | grep -c 'POST /notify')
-dgoals=$(echo "$bodies"  | jq -r '.data[0].fib.datasetId // empty'              2>/dev/null | sort -u | grep -c 'urn:goal:')
-arrays=$(echo "$bodies"  | jq -r 'select((.data[0].fib|type)=="array")  | "x"'  2>/dev/null | wc -l | tr -d ' ')
-empties=$(echo "$bodies" | jq -r 'select(.data[0].fib == null)          | "x"'  2>/dev/null | wc -l | tr -d ' ')
+dgoals=$(echo "$bodies"  | jq -r '.data[0].fib.datasetId // empty'             2>/dev/null | sort -u | grep -c 'urn:goal:')
+arrays=$(echo "$bodies"  | jq -r 'select((.data[0].fib|type)=="array") | "x"'  2>/dev/null | wc -l | tr -d ' ')
+maxPer=$(echo "$bodies"  | jq -r '.data[0].fib.datasetId // empty'             2>/dev/null | sort | uniq -c | sort -rn | head -1 | awk '{print $1+0}')
 
 echo "Total notifications received: $total"
 echo "Distinct goal datasetIds carried in bodies: $dgoals"
 echo "Notifications carrying BOTH instances (fib as array - projection leak): $arrays"
-echo "Empty notifications - sub fired before its own goal instance existed: $empties"
+echo "Max notifications delivered for any single goal: $maxPer"
 echo
-if [ "$total" -gt 18 ]; then echo "VERDICT cross-talk amplification (well above the ~18 no-cross-talk baseline): YES"; else echo "VERDICT cross-talk amplification: NO ($total)"; fi
-if [ "$dgoals" -eq 2 ]; then echo "VERDICT both goals' own data delivered (2 distinct goal datasetIds): YES"; else echo "VERDICT distinct goals: UNEXPECTED ($dgoals)"; fi
-if [ "$arrays" -eq 0 ]; then echo "VERDICT per-goal projection correct (no body ever carried both instances): YES"; else echo "VERDICT projection LEAK ($arrays bodies carried both instances)"; fi
+# Clean (isolated) run: total ~18-20, max-per-goal ~9-10. Cross-talk would give
+# total ~34 and max-per-goal ~17. The thresholds below cleanly separate the two.
+if [ "$total" -lt 26 ];  then echo "VERDICT trigger scoped per goal - no cross-talk amplification: YES"; else echo "VERDICT cross-talk amplification still present: total=$total"; fi
+if [ "$maxPer" -lt 13 ]; then echo "VERDICT each goal got ~one goal's worth of notifications: YES"; else echo "VERDICT a goal over-notified (cross-talk): maxPer=$maxPer"; fi
+if [ "$dgoals" -eq 2 ];  then echo "VERDICT both goals' own data delivered (2 distinct goal datasetIds): YES"; else echo "VERDICT distinct goals: UNEXPECTED ($dgoals)"; fi
+if [ "$arrays" -eq 0 ];  then echo "VERDICT per-goal projection correct (no body ever carried both instances): YES"; else echo "VERDICT projection LEAK ($arrays bodies carried both instances)"; fi
 echo
 echo
 
@@ -270,14 +267,15 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="h
 []
 
 
-08. Notifications ftClient received - amplification + KNOWN cross-talk limitation
-=================================================================================
+08. Notifications ftClient received - per-goal isolation (no cross-talk)
+========================================================================
 Total notifications received: REGEX([0-9]+)
 Distinct goal datasetIds carried in bodies: 2
 Notifications carrying BOTH instances (fib as array - projection leak): 0
-Empty notifications - sub fired before its own goal instance existed: REGEX([0-9]+)
+Max notifications delivered for any single goal: REGEX([0-9]+)
 
-VERDICT cross-talk amplification (well above the ~18 no-cross-talk baseline): YES
+VERDICT trigger scoped per goal - no cross-talk amplification: YES
+VERDICT each goal got ~one goal's worth of notifications: YES
 VERDICT both goals' own data delivered (2 distinct goal datasetIds): YES
 VERDICT per-goal projection correct (no body ever carried both instances): YES
 

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_subscription_watchedAttributes_datasetId.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_subscription_watchedAttributes_datasetId.test
@@ -1,0 +1,374 @@
+# Copyright 2026 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+--NAME--
+Subscription datasetId-scoped watchedAttributes (attr@datasetId) - trigger isolation, @none, cache reload
+
+--SHELL-INIT--
+dbInit CB
+orionldStart CB -experimental
+accumulatorStart --pretty-print 127.0.0.1 ${LISTENER_PORT}
+
+--SHELL--
+
+#
+# A watchedAttributes entry may be datasetId-scoped using the syntax
+# "attrName@datasetId" (split on the FIRST '@'): the subscription is then
+# triggered ONLY when an instance with that datasetId actually changes. The
+# datasetId part is a URN, kept verbatim; only the attribute name is
+# @context-expanded. The token "@none" (entry "attr@@none") matches the default
+# (no-datasetId) instance. Plain "attr" entries keep the original behaviour.
+#
+# (Orion-LD extension - datasetId in watchedAttributes is not yet in the ETSI
+# NGSI-LD spec; an addition has been proposed. Syntax may change.)
+#
+# Ordering note: a separate PRE-EXISTING bug corrupts an attribute once a
+# datasetId instance is added (via PATCH) to an attribute that already has a
+# default instance - the NEXT operation that reads the entity then 500s. The
+# datasetId-creating PATCH (step 10) is therefore the LAST entity operation:
+# its own notification builds fine, and nothing reads the entity afterwards.
+# All the safe checks (default + control + reload) run before it.
+#
+# 01. Create entity E1 - attr A (default), attr B (default, a control attribute)
+# 02. Sub1 watchedAttributes ["A@urn:ngsi-ld:dataset:D1"]  (scoped to D1)
+# 03. Sub2 watchedAttributes ["A@@none"]                   (scoped to the default instance)
+# 04. GET Sub1 - watchedAttributes rendered back as "A@urn:ngsi-ld:dataset:D1"
+# 05. GET Sub2 - watchedAttributes rendered back as "A@@none"
+# 06. Restart broker (cache reloads from mongo) - all trigger checks run reloaded
+# 07. GET Sub1 - the datasetId-scoped watchedAttributes survived the reload
+# 08. PATCH B (control)         -> neither fires (B is not watched)
+# 09. PATCH A default instance  -> only Sub2 fires (Sub1 is scoped to D1)
+# 10. PATCH A, create D1        -> only Sub1 fires (Sub2 is scoped to default) [LAST entity op]
+# 11. A non-URI datasetId in watchedAttributes is rejected (400) - datasetId must be a URI
+#
+
+echo "01. Create entity urn:ngsi-ld:E1 (A default, B default control)"
+echo "==============================================================="
+payload='{
+  "id": "urn:ngsi-ld:E1",
+  "type": "T",
+  "A": { "type": "Property", "value": 0 },
+  "B": { "type": "Property", "value": "b" }
+}'
+orionCurl --url /ngsi-ld/v1/entities -X POST --payload "$payload"
+echo
+echo
+
+
+echo "02. Sub1 - watchedAttributes [A@urn:ngsi-ld:dataset:D1]"
+echo "======================================================="
+payload='{
+  "id": "urn:ngsi-ld:Sub1",
+  "type": "Subscription",
+  "entities": [ { "id": "urn:ngsi-ld:E1", "type": "T" } ],
+  "watchedAttributes": [ "A@urn:ngsi-ld:dataset:D1" ],
+  "notification": {
+    "endpoint": { "uri": "http://127.0.0.1:'${LISTENER_PORT}'/notify" }
+  }
+}'
+orionCurl --url /ngsi-ld/v1/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo "03. Sub2 - watchedAttributes [A@@none] (default instance)"
+echo "========================================================="
+payload='{
+  "id": "urn:ngsi-ld:Sub2",
+  "type": "Subscription",
+  "entities": [ { "id": "urn:ngsi-ld:E1", "type": "T" } ],
+  "watchedAttributes": [ "A@@none" ],
+  "notification": {
+    "endpoint": { "uri": "http://127.0.0.1:'${LISTENER_PORT}'/notify" }
+  }
+}'
+orionCurl --url /ngsi-ld/v1/subscriptions --payload "$payload"
+echo
+echo
+
+
+echo "04. GET Sub1 - watchedAttributes rendered as A@urn:ngsi-ld:dataset:D1"
+echo "===================================================================="
+orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Sub1
+echo
+echo
+
+
+echo "05. GET Sub2 - watchedAttributes rendered as A@@none"
+echo "===================================================="
+orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Sub2
+echo
+echo
+
+
+echo "06. Restart broker (cache reloads from mongo)"
+echo "============================================="
+brokerStop CB
+orionldStart CB -experimental
+echo
+echo
+
+
+echo "07. GET Sub1 - datasetId-scoped watchedAttributes survived the reload"
+echo "====================================================================="
+orionCurl --url /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Sub1
+echo
+echo
+
+
+echo "08. PATCH B (control - not watched) -> neither fires"
+echo "===================================================="
+accumulatorReset
+payload='{ "B": { "type": "Property", "value": "b2" } }'
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:E1/attrs -X PATCH --payload "$payload"
+sleep .3
+dump=$(accumulatorDump)
+echo "notifications: $(echo "$dump" | grep -c '"subscriptionId"')"
+accumulatorReset
+echo
+echo
+
+
+echo "09. PATCH A default instance -> only Sub2 (A@@none) fires"
+echo "========================================================="
+payload='{ "A": { "type": "Property", "value": 1 } }'
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:E1/attrs -X PATCH --payload "$payload"
+sleep .3
+dump=$(accumulatorDump)
+echo "notifications: $(echo "$dump" | grep -c '"subscriptionId"')"
+echo "$dump" | grep '"subscriptionId"' | sed 's/.*: *"//; s/".*//' | sort -u | sed 's/^/  from: /'
+accumulatorReset
+echo
+echo
+
+
+echo "10. PATCH A - create the D1 instance -> only Sub1 (A@D1) fires"
+echo "=============================================================="
+# LAST entity operation (see the ordering note above): adding the D1 instance to
+# an attribute that already has a default instance corrupts the DB row, so any
+# subsequent read would 500 (pre-existing bug). This PATCH's own notification is
+# built before the corruption matters, so the trigger check below is valid.
+payload='{ "A": { "type": "Property", "value": 2, "datasetId": "urn:ngsi-ld:dataset:D1" } }'
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:E1/attrs -X PATCH --payload "$payload"
+sleep .3
+dump=$(accumulatorDump)
+echo "notifications: $(echo "$dump" | grep -c '"subscriptionId"')"
+echo "$dump" | grep '"subscriptionId"' | sed 's/.*: *"//; s/".*//' | sort -u | sed 's/^/  from: /'
+echo
+echo
+
+
+echo "11. Reject a non-URI datasetId in watchedAttributes (datasetId must be a URI)"
+echo "============================================================================"
+payload='{
+  "id": "urn:ngsi-ld:Sub3",
+  "type": "Subscription",
+  "entities": [ { "id": "urn:ngsi-ld:E1", "type": "T" } ],
+  "watchedAttributes": [ "A@notAUri" ],
+  "notification": {
+    "endpoint": { "uri": "http://127.0.0.1:'${LISTENER_PORT}'/notify" }
+  }
+}'
+orionCurl --url /ngsi-ld/v1/subscriptions --payload "$payload"
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity urn:ngsi-ld:E1 (A default, B default control)
+===============================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:E1
+
+
+
+02. Sub1 - watchedAttributes [A@urn:ngsi-ld:dataset:D1]
+=======================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Sub1
+
+
+
+03. Sub2 - watchedAttributes [A@@none] (default instance)
+=========================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/subscriptions/urn:ngsi-ld:Sub2
+
+
+
+04. GET Sub1 - watchedAttributes rendered as A@urn:ngsi-ld:dataset:D1
+====================================================================
+HTTP/1.1 200 OK
+Content-Length: 409
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+{
+    "entities": [
+        {
+            "id": "urn:ngsi-ld:E1",
+            "type": "T"
+        }
+    ],
+    "id": "urn:ngsi-ld:Sub1",
+    "isActive": true,
+    "jsonldContext": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+    "notification": {
+        "endpoint": {
+            "accept": "application/json",
+            "uri": "http://127.0.0.1:9997/notify"
+        },
+        "format": "normalized",
+        "status": "ok"
+    },
+    "origin": "cache",
+    "status": "active",
+    "type": "Subscription",
+    "watchedAttributes": [
+        "A@urn:ngsi-ld:dataset:D1"
+    ]
+}
+
+
+05. GET Sub2 - watchedAttributes rendered as A@@none
+====================================================
+HTTP/1.1 200 OK
+Content-Length: 392
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+{
+    "entities": [
+        {
+            "id": "urn:ngsi-ld:E1",
+            "type": "T"
+        }
+    ],
+    "id": "urn:ngsi-ld:Sub2",
+    "isActive": true,
+    "jsonldContext": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+    "notification": {
+        "endpoint": {
+            "accept": "application/json",
+            "uri": "http://127.0.0.1:9997/notify"
+        },
+        "format": "normalized",
+        "status": "ok"
+    },
+    "origin": "cache",
+    "status": "active",
+    "type": "Subscription",
+    "watchedAttributes": [
+        "A@@none"
+    ]
+}
+
+
+06. Restart broker (cache reloads from mongo)
+=============================================
+
+
+07. GET Sub1 - datasetId-scoped watchedAttributes survived the reload
+=====================================================================
+HTTP/1.1 200 OK
+Content-Length: 409
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+{
+    "entities": [
+        {
+            "id": "urn:ngsi-ld:E1",
+            "type": "T"
+        }
+    ],
+    "id": "urn:ngsi-ld:Sub1",
+    "isActive": true,
+    "jsonldContext": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+    "notification": {
+        "endpoint": {
+            "accept": "application/json",
+            "uri": "http://127.0.0.1:9997/notify"
+        },
+        "format": "normalized",
+        "status": "ok"
+    },
+    "origin": "cache",
+    "status": "active",
+    "type": "Subscription",
+    "watchedAttributes": [
+        "A@urn:ngsi-ld:dataset:D1"
+    ]
+}
+
+
+08. PATCH B (control - not watched) -> neither fires
+====================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+notifications: 0
+
+
+09. PATCH A default instance -> only Sub2 (A@@none) fires
+=========================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+notifications: 1
+  from: urn:ngsi-ld:Sub2
+
+
+10. PATCH A - create the D1 instance -> only Sub1 (A@D1) fires
+==============================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+notifications: 1
+  from: urn:ngsi-ld:Sub1
+
+
+11. Reject a non-URI datasetId in watchedAttributes (datasetId must be a URI)
+============================================================================
+HTTP/1.1 400 Bad Request
+Content-Length: 174
+Content-Type: application/json
+Date: REGEX(.*)
+
+{
+    "detail": "datasetId-scoped watchedAttributes entry (attr@datasetId)",
+    "title": "Invalid datasetId - must be a URI",
+    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+accumulatorStop
+dbDrop CB

--- a/test/functionalTest/cases/0706_direct_https_notifications/direct_https_notifications_no_accept_selfsigned.test
+++ b/test/functionalTest/cases/0706_direct_https_notifications/direct_https_notifications_no_accept_selfsigned.test
@@ -85,6 +85,8 @@ echo
 # - Older: "Peer certificate cannot be authenticated with known/given CA certificates"
 # - Newer: "SSL peer certificate or SSH remote key was not OK"
 
+sleep .5  # Give it some time
+
 echo "04. Look in the CB log for the warning about cert not accepted"
 echo "=============================================================="
 grep "curl_easy_perform failed:.*\(ertificate\|SSL peer\)" /tmp/Orion-LD.log | awk -F "curl_easy_perform" '{ print $2 }' | awk -F ")" '{ print $1 }'


### PR DESCRIPTION
## What

Adds **datasetId-scoped `watchedAttributes`** — the syntax `"attr@datasetId"` — and uses it to fix **notification cross-talk between concurrent DDS action goals**. Also extends the DDS action functests (full roundtrip teardown + sequential recreate, and a new concurrent-goals test).

Builds on #1954 (top-level subscription `datasetId` *projection*), now merged. This PR adds the complementary *trigger* scoping.

## Why

Two concurrent DDS action goals each spawn a temporary subscription on the same action attribute (`fib`). With a name-only trigger, a change to one goal's instance woke **both** subscriptions (datasetId was projection-only), so each goal's initiator also received the sibling goal's notifications (~2× amplification, plus duplicate/empty bodies). Scoping the *trigger* to the goal's datasetId isolates each goal.

## The feature: `watchedAttributes: ["attr@datasetId"]`

- Split on the **first** `@`: left = attribute name (`@context`-expanded as usual), right = datasetId, kept **verbatim**.
- The subscription is **triggered only when an instance with that datasetId changes**.
- The datasetId **must be a URI** (validated, 400 otherwise); the JSON-LD token `@none` (written `"attr@@none"`) scopes to the **default** (no-datasetId) instance.
- A plain `"attr"` entry is **unchanged** — matches any instance.
- Persisted (mongo `conditions`), survives restart, rendered back on GET (name aliased, datasetId verbatim).

> Note: datasetId in `watchedAttributes` is an **Orion-LD extension**, not yet in the ETSI NGSI-LD API — an addition has been proposed; the syntax may change.

## Implementation

All paths are guarded by the presence of `@` in a watched entry, so **existing subscriptions are completely unaffected**:

- `OrionldAttributeAlteration` gains a `datasetId` field (the changed instance's datasetId; NULL = default), set where alterations are built.
- `subCacheAlterationMatch.cpp`: `watchedAttributeMatch()` gates both match branches (`@none` ⇒ NULL/default, URI ⇒ exact, no `@` ⇒ original name-only).
- `pCheckSubscription.cpp`: `@`-aware expansion (name part only) + URI validation.
- GET render (cache + DB paths): alias the name part only.
- `ddsActionSubscription.cpp`: the temp action subscription now watches `"fib@<goalDatasetId>"` (trigger scope) and keeps the top-level `datasetId` (body projection).

## Tests

- **`ngsild_subscription_watchedAttributes_datasetId.test`** (new, general / non-DDS): parse, GET render, trigger isolation (default vs D1 vs unwatched control), `@@none`, cache reload, non-URI rejected (400). Runs in GA.
- **`dds_action_two_concurrent_goals.test`** (new): asserts per-goal isolation — total notifications 34→19, max-per-goal 17→10, no cross-talk; both goals' projection correct; full cleanup; TRoE records both goals.
- **`dds_action_full_roundtrip.test`** (extended): GET /subscriptions teardown check + a sequential "recreate the action" second goal; single-goal notification count 9→8 (the one spurious pre-instance notification is now correctly suppressed).
- Minor: hardened `direct_https_notifications_no_accept_selfsigned.test` against a pre-existing log-scrape timing race (unrelated flaky test).

## Verification

The new general test + the two DDS tests each green over 3 consecutive local runs; subscription suite 182/0; notification + dataset suites clean. DDS tests remain CI-skipped (no Docker in GA); verified locally against the eProsima vulcanexus image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)