### PR TITLE
feat(dds): mirror DDS startup pre-population into TRoE (Postgres), not just MongoDB

### DIFF
--- a/src/lib/orionld/dds/ddsPrePopulateDb.cpp
+++ b/src/lib/orionld/dds/ddsPrePopulateDb.cpp
@@ -35,6 +35,7 @@ extern "C"
 #include "kjson/kjBuilder.h"                                // kjObject, kjArray, kjString, ...
 #include "kjson/kjNavigate.h"                               // kjNavigate
 #include "kjson/kjChildCount.h"                             // kjChildCount
+#include "kjson/kjClone.h"                                  // kjClone
 }
 
 #include "orionld/types/StringArray.h"                      // StringArray
@@ -52,12 +53,17 @@ extern "C"
 #include "orionld/mongoc/mongocEntitiesQuery.h"             // mongocEntitiesQuery
 #include "orionld/mongoc/mongocEntitiesUpsert.h"            // mongocEntitiesUpsert
 #include "orionld/mongoc/mongocAttributesAdd.h"             // mongocAttributesAdd
+#include "orionld/troe/troePostEntities.h"                  // troePostEntities
 #include "orionld/dds/ddsPrePopulateDb.h"                   // DdsConceptType, DdsPrePopulateInput
 #include "orionld/dds/ddsServiceLookup.h"                   // ddsServiceLookup
 #include "orionld/dds/ddsServiceCreate.h"                   // ddsServiceCreate
 #include "orionld/dds/ddsActionLookup.h"                    // ddsActionLookup
 #include "orionld/dds/ddsActionCreate.h"                    // ddsActionCreate
 #include "orionld/kjTree/kjTreeLog.h"                       // KT_TREE
+
+
+
+extern bool troe;  // Is TRoE enabled? (defined in orionld.cpp)
 
 
 
@@ -207,6 +213,13 @@ static void* ddsPrePopulateDbInThread(void* vP)
   //
   KjNode* dbCreateV = kjArray(orionldState.kjsonP, NULL);
 
+  //
+  // TRoE mirror: when TRoE is enabled, the entities/attributes we pre-create must also be
+  // recorded in Postgres - not only in MongoDB. troeCreateV keeps the API-form copies (id,
+  // type, attrs) that troePostEntities() needs; dbCreateV holds the DB-model copies for mongo.
+  //
+  KjNode* troeCreateV = (troe == true)? kjArray(orionldState.kjsonP, NULL) : NULL;
+
   for (KjNode* topic = topics->value.firstChildP; topic != NULL; topic = topic->next)
   {
     KjNode* entityTypeNode = kjLookup(topic, "entityType");
@@ -293,6 +306,10 @@ static void* ddsPrePopulateDbInThread(void* vP)
 
       kjChildAdd(entity, attribute);
 
+      // Keep an API-form copy for TRoE before dbModelFromApiEntity destructively rewrites 'entity'
+      if (troeCreateV != NULL)
+        kjChildAdd(troeCreateV, kjClone(orionldState.kjsonP, entity));
+
       dbModelFromApiEntity(entity, NULL, true, entityId, entityType);
       kjChildAdd(dbCreateV, entity);
       KT_T(StDdsPrePopulate, "Added entity '%s' to dbCreateV array", entityId);
@@ -333,6 +350,22 @@ static void* ddsPrePopulateDbInThread(void* vP)
         KjNode* attrsP = kjLookup(preEntityP, "attrs");
 
         kjChildAdd(attrsP, attribute);
+
+        // Mirror the attribute into the API-form TRoE copy of the same pre-entity
+        if (troeCreateV != NULL)
+        {
+          KjNode* troeEntityP = kjEntityIdLookupInEntityArray(troeCreateV, entityId);
+          if (troeEntityP != NULL)
+          {
+            KjNode* apiAttr  = kjObject(orionldState.kjsonP, longAttrName);
+            KjNode* apiAType = kjString(orionldState.kjsonP, "type", "Property");
+            KjNode* apiAVal  = kjString(orionldState.kjsonP, "value", "uninitialized");
+
+            kjChildAdd(apiAttr, apiAType);
+            kjChildAdd(apiAttr, apiAVal);
+            kjChildAdd(troeEntityP, apiAttr);
+          }
+        }
       }
     }
   }
@@ -341,6 +374,39 @@ static void* ddsPrePopulateDbInThread(void* vP)
   {
     // KT_TREE(dbCreateV, "dbCreateV", StDdsPrePopulate);
     mongocEntitiesUpsert(dbCreateV, NULL);
+  }
+
+  //
+  // Mirror the freshly pre-created entities into TRoE (Postgres). Without this, the entity
+  // has a row in MongoDB (current state) but none in the Postgres 'entities' table, so the
+  // broker can't reconstruct it for temporal queries even though later attribute updates do
+  // land in the 'attributes' table.
+  //
+  if ((troeCreateV != NULL) && (troeCreateV->value.firstChildP != NULL))
+  {
+    orionldState.troeOpMode = TROE_ENTITY_CREATE;
+
+    for (KjNode* troeEntityP = troeCreateV->value.firstChildP; troeEntityP != NULL; troeEntityP = troeEntityP->next)
+    {
+      KjNode* idP   = kjLookup(troeEntityP, "id");
+      KjNode* typeP = kjLookup(troeEntityP, "type");
+
+      if ((idP == NULL) || (typeP == NULL))
+        continue;
+
+      //
+      // troePostEntities expects requestTree to hold attributes ONLY (id/type removed), with
+      // payloadIdNode/payloadTypeNode pointing at the now-detached id/type nodes.
+      //
+      kjChildRemove(troeEntityP, idP);
+      kjChildRemove(troeEntityP, typeP);
+
+      orionldState.requestTree     = troeEntityP;
+      orionldState.payloadIdNode   = idP;
+      orionldState.payloadTypeNode = typeP;
+
+      troePostEntities();
+    }
   }
 
   free(entityIds.array);

--- a/test/functionalTest/cases/0000_ld/dds/dds_action_full_roundtrip.test
+++ b/test/functionalTest/cases/0000_ld/dds/dds_action_full_roundtrip.test
@@ -242,6 +242,42 @@ echo
 echo
 
 
+echo "13. Verify the entity itself was recorded in the TRoE 'entities' table"
+echo "====================================================================="
+# The per-goal attribute history above lives in 'attributes'/'subattributes', but the
+# entity itself belongs in the 'entities' table. The entity was pre-created at startup
+# from the DDS config file (with an "uninitialized" value); that pre-creation must mirror
+# into TRoE, not only MongoDB. If startup wrote MongoDB only and skipped TRoE, this row
+# is MISSING even though the attribute rows are present.
+entRows=$(postgresCmd -sql "SELECT COUNT(*) FROM entities WHERE id='urn:ngsi-ld:robot:r1'" 2>&1 | tail -1 | tr -d ' \r\n')
+if [ "$entRows" -ge 1 ]; then echo "TRoE entities-table row: OK (>=1)"; else echo "TRoE entities-table row: MISSING ($entRows)"; fi
+echo
+echo
+
+
+echo "14. Temporal query to the broker - the entity's history is retrievable via the API"
+echo "=================================================================================="
+# Better than reading Postgres directly: ask the broker for the temporal representation.
+# This exercises the full TRoE read path end-to-end. If the entity is missing from the
+# 'entities' table, the broker cannot reconstruct it and the temporal query comes back
+# empty/incomplete.
+#
+# timeproperty=modifiedAt: DDS attributes carry no observedAt, and the default temporal
+# timeproperty filters on the observedAt column - which would exclude every instance
+# (NULL <= timeAt is never true). modifiedAt filters on 'ts' instead, which is always set.
+#
+# The body is captured (not printed) so the per-instance volatile bits (instanceIds,
+# datasetIds, timestamps) don't make the test flaky - we only assert on stable substrings.
+# The raw captured body is compact JSON (no spaces after colons), hence "type":"Robot".
+tq=$(orionCurl --url '/ngsi-ld/v1/temporal/entities/urn:ngsi-ld:robot:r1?timerel=before&timeAt=2099-12-31T23:59:59Z&timeproperty=modifiedAt' --noPayloadCheck)
+if echo "$tq" | grep -q '200 OK';         then echo "Temporal query: OK (200)";                     else echo "Temporal query: FAILED";                          fi
+if echo "$tq" | grep -q '"type":"Robot"'; then echo "Temporal entity (type Robot): OK";              else echo "Temporal entity (type Robot): MISSING";            fi
+if echo "$tq" | grep -q '"fib"';          then echo "Temporal 'fib' history present: OK";            else echo "Temporal 'fib' history present: MISSING";          fi
+if echo "$tq" | grep -q 'uninitialized';  then echo "Startup 'uninitialized' default in TRoE: OK";   else echo "Startup 'uninitialized' default in TRoE: MISSING"; fi
+echo
+echo
+
+
 --REGEXPECT--
 01. Goal 1: PATCH 'fib' attribute (order=5) with notification 'endpoint' sub-attr
 =================================================================================
@@ -521,6 +557,19 @@ Terminal notification body (the final 'succeeded' snapshot, key-sorted):
 TRoE goal lifecycle rows: OK (>=10)
 TRoE distinct goals: OK (2)
 TRoE recorded terminal 'succeeded' for both goals: OK
+
+
+13. Verify the entity itself was recorded in the TRoE 'entities' table
+=====================================================================
+TRoE entities-table row: OK (>=1)
+
+
+14. Temporal query to the broker - the entity's history is retrievable via the API
+==================================================================================
+Temporal query: OK (200)
+Temporal entity (type Robot): OK
+Temporal 'fib' history present: OK
+Startup 'uninitialized' default in TRoE: OK
 
 
 --TEARDOWN--


### PR DESCRIPTION
## What

At startup, `ddsPrePopulateDb` creates the entities/attributes declared in the DDS config file (with an `"uninitialized"` value) so the current state exists before the first goal/service runs. That pre-creation only wrote to **MongoDB**, so a DDS entity had **no row in the Postgres `entities` table**.

Later attribute updates from a running action landed in `attributes`, but the entity itself was never recorded temporally — so the broker could not reconstruct it for a temporal query.

## Fix

When TRoE is enabled, the pre-created entities are now mirrored into Postgres via `troePostEntities()`:
- a parallel API-form array (`troeCreateV`) keeps the entity trees `troePostEntities()` needs, captured **before** `dbModelFromApiEntity()` destructively rewrites them for the mongo upsert;
- each is written with `troeOpMode = TROE_ENTITY_CREATE` after the mongo upsert;
- the merge-into-pre-entity branch mirrors added attributes into the matching TRoE copy too.

Confirmed startup ordering (`troeInit` → `ddsInit`) so the pg pool + `tenant0.troeDbName` are ready, and `orionldStateInit()` populates `requestTimeString` so TRoE rows get a valid `ts`.

## Verification

Extended `dds_action_full_roundtrip.test`:
- **step 13** — the entity now has a row in the Postgres `entities` table;
- **step 14** — a broker temporal query (`timeproperty=modifiedAt`, since DDS attributes carry no `observedAt`) returns the entity with its full `fib` history, including the startup `"uninitialized"` default.

Full local DDS suite green (25/25).

## Note / out of scope

The "attribute added to a pre-existing DB entity at restart" branch (`mongocAttributesAdd`) still writes to MongoDB only. It is not exercised by the fresh-DB action roundtrip and can be addressed separately for full restart parity.

No `CHANGES_NEXT_RELEASE` entry: this completes an unreleased feature with no user-visible bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)