### PR TITLE
test(batch-update): regression test for duplicated Entity IDs (spec 10.3.4)

### DIFF
--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_batch_update_duplicate_ids.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_batch_update_duplicate_ids.test
@@ -1,0 +1,211 @@
+# Copyright 2026 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+--NAME--
+Batch update with a duplicated Entity ID (spec clause 10.3.4: instances processed in chronological order, no duplicate error)
+
+--SHELL-INIT--
+dbInit CB
+orionldStart CB -experimental
+
+--SHELL--
+
+#
+# NGSI-LD spec clause 10.3.4: when the same Entity ID appears more than once in a batch
+# update, the instances are processed IN CHRONOLOGICAL ORDER (lower array index = earlier).
+# There is NO duplicate error. Batch update only touches EXISTING entities.
+#  - default mode: attributes are OVERWRITTEN -> for a repeated attribute, the last
+#    (chronological) occurrence wins; attributes accumulate across occurrences
+#  - ?options=noOverwrite: an attribute that ALREADY exists is left untouched (existing in
+#    the DB, or added by an earlier occurrence in this same batch) -> the FIRST occurrence
+#    of a given attribute wins; only genuinely new attributes are added
+#
+# 01/02. Setup: create E1 and E2
+# 03. UPDATE (default) [ E1(P=p-first,B), E1(P=p-second,C) ] -> chronological merge, P overwritten
+# 04. GET E1 -> A kept, P=p-second (last wins), B and C accumulated
+# 05. UPDATE ?options=noOverwrite [ E2(P,Q=q-first), E2(P,Q=q-second,R) ]
+# 06. GET E2 -> P kept (existing), Q=q-first (first occurrence wins), R added
+#
+
+echo "01. Setup: create E1 with A and P"
+echo "================================="
+payload='{ "id": "urn:ngsi-ld:E1", "type": "T", "A": { "type": "Property", "value": "orig-a" }, "P": { "type": "Property", "value": "orig-p" } }'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "02. Setup: create E2 with P"
+echo "==========================="
+payload='{ "id": "urn:ngsi-ld:E2", "type": "T", "P": { "type": "Property", "value": "keep-me" } }'
+orionCurl --url /ngsi-ld/v1/entities --payload "$payload"
+echo
+echo
+
+
+echo "03. UPDATE (default/overwrite) [ E1(P=p-first,B), E1(P=p-second,C) ] - E1 duplicated"
+echo "===================================================================================="
+payload='[
+  {
+    "id": "urn:ngsi-ld:E1",
+    "type": "T",
+    "P": { "type": "Property", "value": "p-first" },
+    "B": { "type": "Property", "value": "b-first" }
+  },
+  {
+    "id": "urn:ngsi-ld:E1",
+    "type": "T",
+    "P": { "type": "Property", "value": "p-second" },
+    "C": { "type": "Property", "value": "c-second" }
+  }
+]'
+orionCurl --url /ngsi-ld/v1/entityOperations/update -X POST --payload "$payload"
+echo
+echo
+
+
+echo "04. GET E1 -> A kept, P=p-second (last wins), B and C accumulated"
+echo "================================================================"
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:E1
+echo
+echo
+
+
+echo "05. UPDATE ?options=noOverwrite [ E2(P,Q=q-first), E2(P,Q=q-second,R) ] - E2 duplicated"
+echo "======================================================================================="
+payload='[
+  {
+    "id": "urn:ngsi-ld:E2",
+    "type": "T",
+    "P": { "type": "Property", "value": "overwrite-attempt-1" },
+    "Q": { "type": "Property", "value": "q-first" }
+  },
+  {
+    "id": "urn:ngsi-ld:E2",
+    "type": "T",
+    "P": { "type": "Property", "value": "overwrite-attempt-2" },
+    "Q": { "type": "Property", "value": "q-second" },
+    "R": { "type": "Property", "value": "r-second" }
+  }
+]'
+orionCurl --url '/ngsi-ld/v1/entityOperations/update?options=noOverwrite' -X POST --payload "$payload"
+echo
+echo
+
+
+echo "06. GET E2 -> P kept (existing untouched), Q=q-first (first occurrence wins), R added"
+echo "===================================================================================="
+orionCurl --url /ngsi-ld/v1/entities/urn:ngsi-ld:E2
+echo
+echo
+
+
+--REGEXPECT--
+01. Setup: create E1 with A and P
+=================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:E1
+
+
+
+02. Setup: create E2 with P
+===========================
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/entities/urn:ngsi-ld:E2
+
+
+
+03. UPDATE (default/overwrite) [ E1(P=p-first,B), E1(P=p-second,C) ] - E1 duplicated
+====================================================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+04. GET E1 -> A kept, P=p-second (last wins), B and C accumulated
+================================================================
+HTTP/1.1 200 OK
+Content-Length: 203
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+{
+    "A": {
+        "type": "Property",
+        "value": "orig-a"
+    },
+    "B": {
+        "type": "Property",
+        "value": "b-first"
+    },
+    "C": {
+        "type": "Property",
+        "value": "c-second"
+    },
+    "P": {
+        "type": "Property",
+        "value": "p-second"
+    },
+    "id": "urn:ngsi-ld:E1",
+    "type": "T"
+}
+
+
+05. UPDATE ?options=noOverwrite [ E2(P,Q=q-first), E2(P,Q=q-second,R) ] - E2 duplicated
+=======================================================================================
+HTTP/1.1 204 No Content
+Date: REGEX(.*)
+
+
+
+06. GET E2 -> P kept (existing untouched), Q=q-first (first occurrence wins), R added
+====================================================================================
+HTTP/1.1 200 OK
+Content-Length: 161
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+{
+    "P": {
+        "type": "Property",
+        "value": "keep-me"
+    },
+    "Q": {
+        "type": "Property",
+        "value": "q-first"
+    },
+    "R": {
+        "type": "Property",
+        "value": "r-second"
+    },
+    "id": "urn:ngsi-ld:E2",
+    "type": "T"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
Adds a regression functest for NGSI-LD batch **Update** when the same Entity ID appears more than once in one payload (ETSI clause **10.3.4**). This completes the per-op batch duplicate-instance series (10.3).

## Expected behaviour

Instances are processed **in chronological order** (lower array index = earlier), and there is **no duplicate error**. Batch Update only touches **existing** entities:
- **default**: attributes are overwritten → for a repeated attribute the last chronological value wins; attributes accumulate across occurrences
- **`?options=noOverwrite`**: an attribute that already exists (in the DB, or added by an earlier occurrence in this same batch) is left untouched → the first occurrence of a given attribute wins; only genuinely new attributes are added

## Why

The non-legacy (`-experimental`) handler already implements this correctly — `orionldPostBatchUpdate` detects the repeat via `batchMultipleInstances()`, removes the prior DB-array item and reprocesses with it as the base; `noOverwrite` is passed through to `batchUpdateEntity` as the "ignore existing" flag. This test locks that behaviour in.

## Test

`ngsild_batch_update_duplicate_ids.test`:
- default `[E1(P=p-first,B), E1(P=p-second,C)]` → `204`; `GET E1` = `{A kept, B=b-first, C=c-second, P=p-second}` (P overwritten to last; B/C accumulated)
- noOverwrite `[E2(P,Q=q-first), E2(P,Q=q-second,R)]` → `204`; `GET E2` = `{P=keep-me kept, Q=q-first, R=r-second}` (second occurrence's Q ignored as already-existing → first wins; R added)

Passes locally (1/1).

## Notes

- Test-only, no behaviour change → no `CHANGES_NEXT_RELEASE` entry.
- Completes the clause-10.3 series: Delete fix #1959 (merged), Create test #1961, Upsert test #1963, Update test (this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)