### PR TITLE
TRoE migration: don't build the correlator index (footgun on large ta…

### DIFF
--- a/database/sql/current.sql
+++ b/database/sql/current.sql
@@ -79,4 +79,4 @@ CREATE TABLE IF NOT EXISTS subAttributes (
     CONSTRAINT subattributes_pkey PRIMARY KEY (instanceId,ts));
 
 CREATE INDEX subattributes_attributeid_index ON subAttributes (attrInstanceId,attrDatasetId);
-CREATE INDEX attributes_correlator_index ON attributes (correlator);
+CREATE INDEX attributes_correlator_index ON attributes (correlator) WHERE correlator IS NOT NULL;

--- a/src/lib/orionld/troe/pgSchemaMigrate.cpp
+++ b/src/lib/orionld/troe/pgSchemaMigrate.cpp
@@ -73,13 +73,22 @@ typedef struct PgMigrationStep
 //
 static const PgMigrationStep pgMigrationSteps[] =
 {
+  //
+  // NOTE: 'attributes_correlator_index' is deliberately NOT (re)created by the migration. A migration
+  // step runs inside a transaction, so the index would be a plain (non-CONCURRENT) CREATE INDEX holding
+  // a write-blocking lock on 'attributes' for the entire build - during broker startup. On a large
+  // (billions of rows), partitioned or Citus-distributed 'attributes' that means hours of blocked writes
+  // or a cluster-wide stall. The correlator column is write-only (the broker never queries it; the index
+  // only serves operator/audit lookups), so the index is optional for the broker and is left to the
+  // operator, who can build it partial + CONCURRENTLY (partition/Citus-aware) at a suitable time. Fresh
+  // databases still get it via current.sql (instant on an empty table).
+  //
   {
     2,
-    "write correlator column on entities/attributes/subAttributes (+ index)",
+    "add the correlator column to entities/attributes/subAttributes",
     "ALTER TABLE entities      ADD COLUMN IF NOT EXISTS correlator TEXT;"
     "ALTER TABLE attributes    ADD COLUMN IF NOT EXISTS correlator TEXT;"
     "ALTER TABLE subAttributes ADD COLUMN IF NOT EXISTS correlator TEXT;"
-    "CREATE INDEX IF NOT EXISTS attributes_correlator_index ON attributes (correlator);"
   }
 };
 
@@ -301,6 +310,13 @@ bool pgSchemaMigrate(PGconn* connectionP, const char* dbName, bool schemaPreExis
     currentVersion = pgMigrationSteps[ix].toVersion;
     KT_I("TRoE schema migration: now at v%d", currentVersion);
   }
+
+  // The correlator index is intentionally left out of the migration (see the pgMigrationSteps note).
+  // Reaching here means -migrate was given and a migration ran, so remind the operator to build it.
+  if (ok)
+    KT_I("TRoE: 'attributes_correlator_index' is not created by the migration (a non-concurrent build "
+         "would block writes on a large 'attributes' table). If you query TRoE by correlator, create it "
+         "manually - partial + CONCURRENTLY (partition/Citus-aware).");
 
   pgSchemaUnlock(connectionP);
   return ok;


### PR DESCRIPTION
…bles)

The v1->v2 migration created attributes_correlator_index with a plain CREATE INDEX. A migration step runs inside a transaction, so it cannot be CONCURRENT - it holds a write-blocking lock on 'attributes' for the whole build, during broker startup (after '-migrate'). On a large (billions of rows), partitioned or Citus-distributed table that is hours of blocked writes or a cluster-wide stall - an operator opting into a quick column add gets a very long, blocking index build instead.

The correlator column is write-only (the broker never queries it; the index only serves operator/audit lookups), so the index is optional for the broker:
- Drop the CREATE INDEX from the migration step; keep only the instant ADD COLUMNs.
- Make the fresh-DB index in current.sql partial (WHERE correlator IS NOT NULL) - smaller and semantically correct (only rows that actually carry a correlator).
- Log a hint after a migration so operators know to build the index themselves - partial + CONCURRENTLY (partition/Citus-aware) - when they query by correlator.