### PR TITLE
subCache: a per-tenant subscription cache, in the reg-cache image

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,7 @@ SET (ORION_LIBS
     orionld_context
     orionld_contextCache
     orionld_regCache
+    orionld_subCache
     orionld_notifications
     orionld_db
     orionld_mongoc
@@ -403,6 +404,7 @@ if (error EQUAL 0)
   ADD_SUBDIRECTORY(src/lib/orionld/context)
   ADD_SUBDIRECTORY(src/lib/orionld/contextCache)
   ADD_SUBDIRECTORY(src/lib/orionld/regCache)
+  ADD_SUBDIRECTORY(src/lib/orionld/subCache)
   ADD_SUBDIRECTORY(src/lib/orionld/kjTree)
   ADD_SUBDIRECTORY(src/lib/orionld/db)
   ADD_SUBDIRECTORY(src/lib/orionld/dbModel)

--- a/src/app/orionld/orionld.cpp
+++ b/src/app/orionld/orionld.cpp
@@ -119,6 +119,7 @@ extern "C"
 #include "orionld/db/dbInit.h"                                // dbInit
 #include "orionld/mqtt/mqttRelease.h"                         // mqttRelease
 #include "orionld/regCache/regCacheInit.h"                    // regCacheInit
+#include "orionld/subCache/subCachesInit.h"                // subCachesInit
 #include "orionld/regCache/regCacheCreate.h"                  // regCacheCreate
 #include "orionld/regCache/regCacheRelease.h"                 // regCacheRelease
 #include "orionld/pernot/pernotSubCacheInit.h"                // pernotSubCacheInit
@@ -1338,6 +1339,18 @@ int main(int argC, char* argV[])
     pernotSubCacheInit();
 
   orionldServiceInit(restServiceVV, 9);
+
+  //
+  // The new per-tenant subscription cache. AFTER orionldServiceInit, which is
+  // where the @context cache is loaded from the database: caching a
+  // subscription resolves its @context, and a miss would DOWNLOAD, blocking
+  // startup before the port is open.
+  //
+  // Populated but not yet consulted - the legacy sub cache is still in use.
+  //
+  subCachesInit();
+
+
 
   if (mongocOnly == false)
   {

--- a/src/lib/orionld/common/orionldTenantCreate.cpp
+++ b/src/lib/orionld/common/orionldTenantCreate.cpp
@@ -34,6 +34,7 @@ extern "C"
 #include "orionld/mongoc/mongocIdIndexCreate.h"                // mongocIdIndexCreate
 #include "orionld/troe/pgDatabasePrepare.h"                    // pgDatabasePrepare
 #include "orionld/regCache/regCacheCreate.h"                   // regCacheCreate
+#include "orionld/subCache/subCacheCreate.h"                   // subCacheCreate
 #include "orionld/common/orionldState.h"                       // orionldState
 #include "orionld/common/tenantList.h"                         // tenantList
 #include "orionld/common/orionldTenantCreate.h"                // Own interface
@@ -83,7 +84,15 @@ OrionldTenant* orionldTenantCreate(const char* tenantName, bool scanRegs, bool r
   }
 
   if (regCache == true)
+  {
     tenantP->regCache = regCacheCreate(tenantP, scanRegs);
+
+    //
+    // The subscription cache is created for the same tenants, and populated
+    // under the same condition, as the registration cache.
+    //
+    tenantP->subCache = subCacheCreate(tenantP, scanRegs);
+  }
 
   return tenantP;
 }

--- a/src/lib/orionld/mongoc/CMakeLists.txt
+++ b/src/lib/orionld/mongoc/CMakeLists.txt
@@ -70,6 +70,7 @@ SET (SOURCES
     mongocRegistrationDelete.cpp
     mongocRegistrationReplace.cpp
     mongocRegistrationsIter.cpp
+    mongocSubscriptionsIter.cpp
     mongocAuxAttributesFilter.cpp
     mongocWriteLog.cpp
     mongocAttributeReplace.cpp

--- a/src/lib/orionld/mongoc/mongocSubscriptionsIter.cpp
+++ b/src/lib/orionld/mongoc/mongocSubscriptionsIter.cpp
@@ -1,0 +1,129 @@
+/*
+*
+* Copyright 2026 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+#include <mongoc/mongoc.h>                                       // MongoDB C Client Driver
+
+extern "C"
+{
+#include "ktrace/kTrace.h"                                       // trace messages - ktrace library
+#include "kjson/KjNode.h"                                        // KjNode
+}
+
+#include "orionld/types/SubCache.h"                              // SubCache
+#include "orionld/common/orionldState.h"                         // orionldState, mongocPool
+#include "orionld/common/orionldError.h"                         // orionldError
+#include "orionld/common/traceLevels.h"                          // KTrace levels
+#include "orionld/mongoc/mongocWriteLog.h"                       // MONGOC_RLOG
+#include "orionld/mongoc/mongocKjTreeFromBson.h"                 // mongocKjTreeFromBson
+#include "orionld/mongoc/mongocSubscriptionsIter.h"              // Own interface
+
+
+
+// -----------------------------------------------------------------------------
+//
+// mongocSubscriptionsIter -
+//
+// Twin of mongocRegistrationsIter, for the "csubs" collection.
+//
+int mongocSubscriptionsIter(SubCache* scP, SubCacheIterFunc callback)
+{
+  bson_t                mongoFilter;
+  const bson_t*         mongoDocP = NULL;
+  mongoc_cursor_t*      mongoCursorP;
+  bson_error_t          mongoError;
+  mongoc_read_prefs_t*  readPrefs = mongoc_read_prefs_new(MONGOC_READ_NEAREST);
+  char*                 title;
+  char*                 details;
+  int                   retVal    = 0;
+
+  bson_init(&mongoFilter);
+
+  //
+  // A client popped straight from the pool, NOT mongocConnectionGet().
+  //
+  // mongocConnectionGet() fills in the request-scoped orionldState.mongoc.*
+  // collection handles, and mongocConnectionRelease() pushes the client back
+  // while leaving those handles pointing at it. That is fine inside a request,
+  // where orionldState is per-request and torn down with it - but this runs at
+  // STARTUP, on the main thread, and it leaked file descriptors (caught by
+  // ngsild_issue_1441, the fd-leak test).
+  //
+  // This is the pattern the legacy mongocSubCachePopulateByTenant uses for the
+  // very same collection, and for the same reason.
+  //
+  mongoc_client_t*     connectionP     = mongoc_client_pool_pop(mongocPool);
+  mongoc_collection_t* subsCollectionP = mongoc_client_get_collection(connectionP, scP->tenantP->mongoDbName, "csubs");
+  if (subsCollectionP == NULL)
+    KT_X(1, "mongoc_client_get_collection failed for 'csubs' collection on tenant '%s'", scP->tenantP->mongoDbName);
+
+  MONGOC_RLOG("Query for all subs", scP->tenantP->mongoDbName, "csubs", NULL, NULL, StMongoc);
+  mongoCursorP = mongoc_collection_find_with_opts(subsCollectionP, &mongoFilter, NULL, readPrefs);
+  if (mongoCursorP == NULL)
+  {
+    orionldError(OrionldInternalError, "Database Error", "mongoc_collection_find_with_opts ERROR", 500);
+    mongoc_collection_destroy(subsCollectionP);
+    mongoc_client_pool_push(mongocPool, connectionP);
+    mongoc_read_prefs_destroy(readPrefs);
+    bson_destroy(&mongoFilter);
+    return 1;
+  }
+
+  int hits = 0;
+  while (mongoc_cursor_next(mongoCursorP, &mongoDocP))
+  {
+    char* json = bson_as_relaxed_extended_json(mongoDocP, NULL);
+    KT_T(StMongoc, "Found a subscription in the DB: '%s'", json);
+    bson_free(json);
+
+    KjNode* dbSubP = mongocKjTreeFromBson(mongoDocP, &title, &details);
+    if (dbSubP == NULL)
+    {
+      orionldError(OrionldInternalError, "Database Error", "unable to convert DB-Model subscription to API Format", 500);
+      continue;
+    }
+
+    if (callback(scP, dbSubP) != 0)
+    {
+      retVal = 2;
+      break;
+    }
+
+    ++hits;
+  }
+  KT_T(StMongoc, "Found %d hits in the db", hits);
+
+  if (mongoc_cursor_error(mongoCursorP, &mongoError))
+  {
+    retVal = 3;
+    orionldError(OrionldInternalError, "Database Error", mongoError.message, 500);
+  }
+
+  mongoc_cursor_destroy(mongoCursorP);
+  mongoc_collection_destroy(subsCollectionP);
+  mongoc_client_pool_push(mongocPool, connectionP);
+  mongoc_read_prefs_destroy(readPrefs);
+  bson_destroy(&mongoFilter);
+
+  return retVal;
+}

--- a/src/lib/orionld/mongoc/mongocSubscriptionsIter.h
+++ b/src/lib/orionld/mongoc/mongocSubscriptionsIter.h
@@ -1,0 +1,39 @@
+#ifndef SRC_LIB_ORIONLD_MONGOC_MONGOCSUBSCRIPTIONSITER_H_
+#define SRC_LIB_ORIONLD_MONGOC_MONGOCSUBSCRIPTIONSITER_H_
+
+/*
+*
+* Copyright 2026 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+#include "orionld/types/SubCache.h"                              // SubCache
+#include "orionld/types/SubCacheIterFunc.h"                       // SubCacheIterFunc
+
+
+
+// -----------------------------------------------------------------------------
+//
+// mongocSubscriptionsIter - invoke 'callback' for every subscription of the tenant
+//
+extern int mongocSubscriptionsIter(SubCache* scP, SubCacheIterFunc callback);
+
+#endif  // SRC_LIB_ORIONLD_MONGOC_MONGOCSUBSCRIPTIONSITER_H_

--- a/src/lib/orionld/subCache/CMakeLists.txt
+++ b/src/lib/orionld/subCache/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Copyright 2026 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+#
+# Author: Ken Zangelin
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
+
+SET (SOURCES
+    subCacheCreate.cpp
+    subCacheItemAdd.cpp
+    subCachesInit.cpp
+    apiModelToCacheSubscription.cpp
+)
+
+include_directories("${PROJECT_SOURCE_DIR}/src/lib")
+
+ADD_LIBRARY(orionld_subCache STATIC ${SOURCES})

--- a/src/lib/orionld/subCache/apiModelToCacheSubscription.cpp
+++ b/src/lib/orionld/subCache/apiModelToCacheSubscription.cpp
@@ -1,0 +1,58 @@
+/*
+*
+* Copyright 2026 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+extern "C"
+{
+#include "kjson/KjNode.h"                                        // KjNode
+}
+
+#include "orionld/subCache/apiModelToCacheSubscription.h"        // Own interface
+
+
+
+// -----------------------------------------------------------------------------
+//
+// apiModelToCacheSubscription -
+//
+// Adapts an API-model Subscription into the shape the cache wants, in place,
+// right before subCacheItemAdd clones it into the cache item.
+//
+// Nothing to adapt yet - the tree goes into the cache as it comes out of the API
+// model. This is the hook where the *compiled* matching state will be built, so
+// that matching an entity update never has to parse anything:
+//
+//   - 'q'          -> parsed QNode tree
+//   - 'geoQ'       -> OrionldGeoInfo + a prepared GEOS geometry
+//   - entity ids   -> compiled idPattern regexes
+//   - notification -> trigger bitmask, render format, endpoint split into
+//                     protocol/ip/port/rest
+//
+// Those live in CachedSubscription today and move here as the new cache takes
+// over. Keeping the hook in place from the start means the call sites do not
+// change again when they do.
+//
+void apiModelToCacheSubscription(KjNode* apiSubscriptionP)
+{
+  // Intentionally empty for now - see the comment above.
+}

--- a/src/lib/orionld/subCache/apiModelToCacheSubscription.h
+++ b/src/lib/orionld/subCache/apiModelToCacheSubscription.h
@@ -1,0 +1,44 @@
+#ifndef SRC_LIB_ORIONLD_SUBCACHE_APIMODELTOCACHESUBSCRIPTION_H_
+#define SRC_LIB_ORIONLD_SUBCACHE_APIMODELTOCACHESUBSCRIPTION_H_
+
+/*
+*
+* Copyright 2026 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+extern "C"
+{
+#include "kjson/KjNode.h"                                        // KjNode
+}
+
+
+
+// -----------------------------------------------------------------------------
+//
+// apiModelToCacheSubscription - adapt an API Subscription for use in the cache
+//
+// Twin of apiModelToCacheRegistration. Called on the API-model tree just before
+// it is handed to subCacheItemAdd.
+//
+extern void apiModelToCacheSubscription(KjNode* apiSubscriptionP);
+
+#endif  // SRC_LIB_ORIONLD_SUBCACHE_APIMODELTOCACHESUBSCRIPTION_H_

--- a/src/lib/orionld/subCache/subCacheCreate.cpp
+++ b/src/lib/orionld/subCache/subCacheCreate.cpp
@@ -29,6 +29,8 @@ extern "C"
 #include "kjson/kjLookup.h"                                      // kjLookup
 }
 
+#include "orionld/types/QNode.h"                                 // QNode
+#include "orionld/types/OrionldRenderFormat.h"                   // OrionldRenderFormat
 #include "orionld/types/OrionldTenant.h"                         // OrionldTenant
 #include "orionld/types/SubCache.h"                              // SubCache
 #include "orionld/common/orionldState.h"                         // orionldState
@@ -36,29 +38,58 @@ extern "C"
 #include "orionld/mongoc/mongocSubscriptionsIter.h"              // mongocSubscriptionsIter
 #include "orionld/dbModel/dbModelToApiSubscription.h"            // dbModelToApiSubscription
 #include "orionld/subCache/subCacheItemAdd.h"                    // subCacheItemAdd
+#include "orionld/subCache/apiModelToCacheSubscription.h"        // apiModelToCacheSubscription
 #include "orionld/subCache/subCacheCreate.h"                     // Own interface
 
 
 
-extern void apiModelToCacheSubscription(KjNode* apiSubscriptionP);
 // -----------------------------------------------------------------------------
 //
 // subIterFunc -
 //
 int subIterFunc(SubCache* scP, KjNode* dbSubP)
 {
-  // Convert DB Sub to API Sub
-  if (dbModelToApiSubscription(dbSubP, true, true) == false)
-    KT_RE(-1, "dbModelToApiSubscription failed");
+  //
+  // Convert DB Sub to API Sub.
+  //
+  // dbModelToApiSubscription hands back the pre-parsed pieces it had to look at
+  // anyway - the q tree, the geo coordinates, the render format, ... Those are
+  // exactly the "compiled" state the cache item wants, but SubCacheItem has no
+  // home for them yet, so for now they are taken and dropped.
+  // TODO: store these in the SubCacheItem (see apiModelToCacheSubscription).
+  //
+  QNode*               qNodeP       = NULL;
+  KjNode*              coordinatesP = NULL;
+  KjNode*              contextNodeP = NULL;
+  KjNode*              showChangesP = NULL;
+  KjNode*              sysAttrsP    = NULL;
+  OrionldRenderFormat  renderFormat = RF_NORMALIZED;
+  double               timeInterval = 0;
 
-  // The DB Subscription 'dbSubP' is now in API Subscription format (after calling dbModelToApiSubscription)
-  KjNode* apiSubP = dbSubP;
+  KjNode* apiSubP = dbModelToApiSubscription(dbSubP,
+                                             scP->tenantP->tenant,
+                                             true,
+                                             &qNodeP,
+                                             &coordinatesP,
+                                             &contextNodeP,
+                                             &showChangesP,
+                                             &sysAttrsP,
+                                             &renderFormat,
+                                             &timeInterval);
+  if (apiSubP == NULL)
+    KT_RE(-1, "dbModelToApiSubscription failed");
 
   // If a jsonldContext is given for the subscription, make sure it's valid
   OrionldContext* jsonldContextP = NULL;
-  KjNode*         jsonldContextNodeP = kjLookup(apiSubscriptionP, "jsonldContext");
+  KjNode*         jsonldContextNodeP = kjLookup(apiSubP, "jsonldContext");
   if (jsonldContextNodeP != NULL)
   {
+    //
+    // The @context was downloaded and persisted when the subscription was
+    // created (a subscription whose context cannot be fetched is never
+    // created), and the context cache is loaded from the database before this
+    // runs - so this resolves from the cache and does not go to the network.
+    //
     jsonldContextP = orionldContextFromUrl(jsonldContextNodeP->value.s, NULL);
 
     if (jsonldContextP == NULL)

--- a/src/lib/orionld/subCache/subCacheCreate.h
+++ b/src/lib/orionld/subCache/subCacheCreate.h
@@ -1,0 +1,42 @@
+#ifndef SRC_LIB_ORIONLD_SUBCACHE_SUBCACHECREATE_H_
+#define SRC_LIB_ORIONLD_SUBCACHE_SUBCACHECREATE_H_
+
+/*
+*
+* Copyright 2026 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+#include "orionld/types/OrionldTenant.h"                         // OrionldTenant
+#include "orionld/types/SubCache.h"                              // SubCache
+
+
+
+// -----------------------------------------------------------------------------
+//
+// subCacheCreate - create the subscription cache for a tenant
+//
+// If 'scanSubs' is true, the cache is populated from the tenant's "csubs"
+// collection. Twin of regCacheCreate.
+//
+extern SubCache* subCacheCreate(OrionldTenant* tenantP, bool scanSubs);
+
+#endif  // SRC_LIB_ORIONLD_SUBCACHE_SUBCACHECREATE_H_

--- a/src/lib/orionld/subCache/subCacheItemAdd.cpp
+++ b/src/lib/orionld/subCache/subCacheItemAdd.cpp
@@ -1,0 +1,149 @@
+/*
+*
+* Copyright 2026 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+#include <stdlib.h>                                              // calloc, free
+#include <string.h>                                              // strdup
+
+extern "C"
+{
+#include "ktrace/kTrace.h"                                       // KT_*
+#include "kjson/KjNode.h"                                        // KjNode
+#include "kjson/kjBuilder.h"                                     // kjChildAdd, kjInteger, kjFloat, kjString
+#include "kjson/kjClone.h"                                       // kjClone
+#include "kjson/kjLookup.h"                                      // kjLookup
+}
+
+#include "orionld/types/OrionldContext.h"                        // OrionldContext
+#include "orionld/types/SubCache.h"                              // SubCache
+#include "orionld/types/SubCacheItem.h"                          // SubCacheItem
+#include "orionld/common/traceLevels.h"                          // KTrace levels
+#include "orionld/subCache/subCacheItemAdd.h"                    // Own interface
+
+
+
+// -----------------------------------------------------------------------------
+//
+// subCounterAdd - seed a counter in the subscription tree, if not already there
+//
+static void subCounterAdd(KjNode* subP, const char* name)
+{
+  if (kjLookup(subP, name) == NULL)
+    kjChildAdd(subP, kjInteger(NULL, name, 0));
+}
+
+
+
+// -----------------------------------------------------------------------------
+//
+// subTimestampAdd - seed a timestamp in the subscription tree, if not already there
+//
+static void subTimestampAdd(KjNode* subP, const char* name)
+{
+  if (kjLookup(subP, name) == NULL)
+    kjChildAdd(subP, kjFloat(NULL, name, 0));
+}
+
+
+
+// -----------------------------------------------------------------------------
+//
+// subStringAdd - seed a string in the subscription tree, if not already there
+//
+static void subStringAdd(KjNode* subP, const char* name, const char* value)
+{
+  if (kjLookup(subP, name) == NULL)
+    kjChildAdd(subP, kjString(NULL, name, value));
+}
+
+
+
+// -----------------------------------------------------------------------------
+//
+// subCacheItemAdd -
+//
+SubCacheItem* subCacheItemAdd
+(
+  SubCache*        scP,
+  const char*      subscriptionId,
+  KjNode*          subP,
+  bool             fromDb,
+  OrionldContext*  jsonldContextP
+)
+{
+  SubCacheItem* sciP = (SubCacheItem*) calloc(1, sizeof(SubCacheItem));
+
+  if (sciP == NULL)
+    KT_X(1, "Out of memory attempting to allocate a Subscription Cache Item (%d bytes)", sizeof(SubCacheItem));
+
+  KT_T(KtSubCache, "Adding sub '%s' into the sub cache for tenant '%s'", subscriptionId, scP->tenantP->mongoDbName);
+
+  //
+  // Append - the cache keeps insertion order, exactly as the reg cache does.
+  //
+  if (scP->last == NULL)
+    scP->subList = sciP;
+  else
+    scP->last->next = sciP;
+  scP->last = sciP;
+
+  sciP->subId    = strdup(subscriptionId);
+  sciP->subTree  = kjClone(NULL, subP);
+  sciP->contextP = jsonldContextP;
+  sciP->dirty    = false;
+  sciP->next     = NULL;
+
+  //
+  // The deltas are what keeps mongo out of the notification path: every
+  // notification bumps them in RAM and they are flushed (added, not written)
+  // now and then. They always start at zero for a freshly cached item - what
+  // is already in the database is the database's business.
+  //
+  sciP->deltas.timesSent   = 0;
+  sciP->deltas.timesFailed = 0;
+  sciP->deltas.lastSuccess = 0;
+  sciP->deltas.lastFailure = 0;
+
+  KjNode* hostAliasP = kjLookup(sciP->subTree, "hostAlias");
+  if (hostAliasP != NULL)
+    sciP->hostAlias = strdup(hostAliasP->value.s);
+
+  //
+  // A subscription that arrives from an API request has none of the bookkeeping
+  // members yet - one coming from the database has them already.
+  //
+  if (fromDb == false)
+  {
+    subCounterAdd(sciP->subTree,   "timesSent");
+    subCounterAdd(sciP->subTree,   "timesFailed");
+    subTimestampAdd(sciP->subTree, "lastSuccess");
+    subTimestampAdd(sciP->subTree, "lastFailure");
+    subStringAdd(sciP->subTree,    "status", "active");
+  }
+
+  KjNode* modifiedAtP = kjLookup(sciP->subTree, "modifiedAt");
+  if (modifiedAtP != NULL)
+    sciP->modifiedAt = (modifiedAtP->type == KjFloat)? modifiedAtP->value.f : modifiedAtP->value.i;
+
+  return sciP;
+}

--- a/src/lib/orionld/subCache/subCacheItemAdd.h
+++ b/src/lib/orionld/subCache/subCacheItemAdd.h
@@ -1,0 +1,57 @@
+#ifndef SRC_LIB_ORIONLD_SUBCACHE_SUBCACHEITEMADD_H_
+#define SRC_LIB_ORIONLD_SUBCACHE_SUBCACHEITEMADD_H_
+
+/*
+*
+* Copyright 2026 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+extern "C"
+{
+#include "kjson/KjNode.h"                                        // KjNode
+}
+
+#include "orionld/types/OrionldContext.h"                        // OrionldContext
+#include "orionld/types/SubCache.h"                              // SubCache
+#include "orionld/types/SubCacheItem.h"                          // SubCacheItem
+
+
+
+// -----------------------------------------------------------------------------
+//
+// subCacheItemAdd - append a subscription to a tenant's subscription cache
+//
+// 'subP' is an API-model Subscription; it is cloned into the item, so the caller
+// keeps ownership of its own tree. 'fromDb' is false when the subscription comes
+// from an API request rather than from the database, in which case the counters
+// and 'status' are seeded. Twin of regCacheItemAdd.
+//
+extern SubCacheItem* subCacheItemAdd
+(
+  SubCache*        scP,
+  const char*      subscriptionId,
+  KjNode*          subP,
+  bool             fromDb,
+  OrionldContext*  jsonldContextP
+);
+
+#endif  // SRC_LIB_ORIONLD_SUBCACHE_SUBCACHEITEMADD_H_

--- a/src/lib/orionld/subCache/subCachesInit.cpp
+++ b/src/lib/orionld/subCache/subCachesInit.cpp
@@ -1,0 +1,53 @@
+/*
+*
+* Copyright 2026 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+extern "C"
+{
+#include "ktrace/kTrace.h"                                       // KT_*
+}
+
+#include "orionld/types/OrionldTenant.h"                         // OrionldTenant, tenant0
+#include "orionld/common/tenantList.h"                           // tenantList
+#include "orionld/common/traceLevels.h"                          // KTrace levels
+#include "orionld/subCache/subCacheCreate.h"                     // subCacheCreate
+#include "orionld/subCache/subCachesInit.h"                      // Own interface
+
+
+
+// -----------------------------------------------------------------------------
+//
+// subCachesInit -
+//
+void subCachesInit(void)
+{
+  KT_T(KtSubCache, "Creating subCache for default tenant");
+  tenant0.subCache = subCacheCreate(&tenant0, true);
+
+
+  for (OrionldTenant* tenantP = tenantList; tenantP != NULL; tenantP = tenantP->next)
+  {
+    KT_T(KtSubCache, "Creating subCache for tenant '%s'", tenantP->tenant);
+    tenantP->subCache = subCacheCreate(tenantP, true);
+  }
+}

--- a/src/lib/orionld/subCache/subCachesInit.h
+++ b/src/lib/orionld/subCache/subCachesInit.h
@@ -1,0 +1,40 @@
+#ifndef SRC_LIB_ORIONLD_SUBCACHE_SUBCACHESINIT_H_
+#define SRC_LIB_ORIONLD_SUBCACHE_SUBCACHESINIT_H_
+
+/*
+*
+* Copyright 2026 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+
+
+// -----------------------------------------------------------------------------
+//
+// subCachesInit - create and populate the subscription cache of every tenant
+//
+// Twin of regCacheInit. Named in the plural to stay clear of the legacy
+// subCacheInit(bool) of src/lib/cache while both caches coexist; it takes over
+// the name once the legacy cache is gone.
+//
+extern void subCachesInit(void);
+
+#endif  // SRC_LIB_ORIONLD_SUBCACHE_SUBCACHESINIT_H_

--- a/src/lib/orionld/types/OrionldTenant.h
+++ b/src/lib/orionld/types/OrionldTenant.h
@@ -50,6 +50,7 @@ typedef struct OrionldTenant
   char                   registrations[88];    // mongo registrations collection path.         E.g. "orion-openiot.registrations"
   char                   troeDbName[72];       // TRoE database name                           E.g. "orion_openiot"
   struct RegCache*       regCache;
+  struct SubCache*       subCache;
   struct OrionldTenant*  next;                 // Pointer to the next one in the linked list
 } OrionldTenant;
 

--- a/src/lib/orionld/types/SubCacheIterFunc.h
+++ b/src/lib/orionld/types/SubCacheIterFunc.h
@@ -1,0 +1,43 @@
+#ifndef SRC_LIB_ORIONLD_TYPES_SUBCACHEITERFUNC_H_
+#define SRC_LIB_ORIONLD_TYPES_SUBCACHEITERFUNC_H_
+
+/*
+*
+* Copyright 2026 FIWARE Foundation e.V.
+*
+* This file is part of Orion-LD Context Broker.
+*
+* Orion-LD Context Broker is free software: you can redistribute it and/or
+* modify it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* Orion-LD Context Broker is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+*
+* For those usages not covered by this license please contact with
+* orionld at fiware dot org
+*
+* Author: Ken Zangelin
+*/
+extern "C"
+{
+#include "kjson/KjNode.h"                                        // KjNode
+}
+
+#include "orionld/types/SubCache.h"                              // SubCache
+
+
+
+// -----------------------------------------------------------------------------
+//
+// SubCacheIterFunc - callback for mongocSubscriptionsIter
+//
+typedef int (*SubCacheIterFunc)(SubCache* scP, KjNode* dbSubP);
+
+#endif  // SRC_LIB_ORIONLD_TYPES_SUBCACHEITERFUNC_H_


### PR DESCRIPTION
First step of the new subscription cache — the long-standing reimplementation, and the prerequisite for HA cache synchronisation.

**It is built and populated, but nothing consults it yet.** The legacy cache of `src/lib/cache` still runs everything, so this changes no behaviour.

## Shape

Follows the registration cache, so that the synchronisation coming later is written **once against one design** rather than twice against two:

```
OrionldTenant.subCache -> SubCache     { tenantP, subList, last }
                       -> SubCacheItem { subId, subTree, deltas, ... }
```

Per-tenant, owned by the tenant — so the item carries no tenant back-pointer, exactly like `RegCacheItem`.

`SubCache.h`, `SubCacheItem.h` and `subCacheCreate.cpp` already existed in the tree, uncommitted and **never built** — no CMakeLists referenced the directory. This adds what was missing to make them real: `subCacheCreate.h`, `subCacheItemAdd`, `mongocSubscriptionsIter`, `subCachesInit` (twin of `regCacheInit`; the default tenant is a global and does not go through `orionldTenantCreate`), the directory's CMakeLists, and the tenant field. `SubCacheIterFunc` lives in `types/` with the rest.

All C — copied from the reg-cache, with no C++ carried over from the old subscription cache.

## Startup ordering

`subCachesInit()` runs **after** `orionldServiceInit()`, which is where the `@context` cache is loaded from the database.

Caching a subscription resolves its `@context`, and a cache miss makes `orionldContextFromUrl()` **download**. At startup that blocks the broker before it opens its port — one HTTP request per subscription — and a subscription whose context server is slow or gone would hang it indefinitely. This is easy to hit: a subscription created against core context v1.8 while the broker serves v1.9 misses the cache immediately.

## Two fixes to the existing `subCacheCreate.cpp`

**1. Wrong signature.** It called `dbModelToApiSubscription(dbSubP, true, true)`. The function takes the tenant plus seven out-parameters and returns the API tree. Those out-parameters — the parsed `q`, the geo coordinates, the render format — are precisely the compiled state the cache item will want, but `SubCacheItem` has no home for them yet, so they are taken and dropped with a TODO.

**2. A file-descriptor leak.** `mongocSubscriptionsIter` must **not** use `mongocConnectionGet()`/`mongocConnectionRelease()`. Those fill in the **request-scoped** `orionldState.mongoc.*` collection handles and then push the client back to the pool while those handles still point at it. Inside a request that is fine — `orionldState` is per-request and torn down with it — but this runs at **startup, on the main thread**, and it leaked fds: `ngsild_issue_1441` (the fd-leak test) went from **14 to 21** open descriptors.

It now pops a client straight from the pool and pushes it back — exactly what the legacy `mongocSubCachePopulateByTenant` does on this very collection.

## Next

`apiModelToCacheSubscription` is deliberately an empty hook. It is where the compiled matching state (q tree, GEOS geometry, idPattern regexes, trigger mask, render format, endpoint split) will be built, so the call sites do not move again when it is — and it is where those dropped out-parameters will land.

## Verification

Full functional suite, **1783 tests — no failures attributable to this change**.

- The fd-leak test passes (it caught the bug above; base passes, this failed, bisected to `subCachesInit()`, fixed, passes).
- All 25 DDS tests pass in sequence.
- The single test failing in a full run (`0876_attribute_dates`) passes twice in isolation, and a *different* test of that same directory failed on the previous run — load-related flakiness, not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
