### PR TITLE
test: build the functional-test venv with python3.12, not ubi8's 3.6.8

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+#
+# The docker images are built with "COPY . /opt/orion", so anything left in a
+# working copy ends up inside the image unless it is listed here.
+#
+# .venv is the one that actually breaks things: the functional test suite
+# creates it on the host, with bin/python symlinked to the HOST interpreter.
+# Copied into the image those symlinks point at a completely different Python,
+# and testHarness.sh - which only checks whether the directory exists - then
+# skips creating a working one. The result is a virtual environment whose pip
+# and python disagree, and every Flask/paho test fails on ModuleNotFoundError.
+#
+.venv
+
+#
+# Build output. Never useful inside the image, and copying it in is slow.
+#
+BUILD_DEBUG
+BUILD_RELEASE
+BUILD_COVERAGE

--- a/docker/Dockerfile-test
+++ b/docker/Dockerfile-test
@@ -10,6 +10,21 @@ WORKDIR ${PATH_TO_SRC}
 
 ENV LD_LIBRARY_PATH=/opt/paho.mqtt.c/build/output:/usr/local/lib64:/opt/prometheus-client-c/prom/build:/opt/prometheus-client-c/promhttp/build:/usr/local/lib
 # RUN echo LD_LIBRARY_PATH: $LD_LIBRARY_PATH
+
+#
+# The interpreter the functional test suite builds its virtual environment with.
+# ubi8's own python3 is 3.6.8 (end-of-life since December 2021), too old for a
+# current Flask, so the suite is pointed at the python3.12 from the AppStream.
+# testHarness.sh falls back to python3 when PYTHON is unset, which is what a
+# developer machine wants.
+#
+# Note that python2 is still installed below, and that bare 'python' still
+# refers to it: gmock 1.5.0 builds itself with gtest/scripts/fuse_gtest_files.py,
+# which is python2 source and dies with a SyntaxError on anything newer. That
+# is the only remaining python2 user in the image - the test suite no longer
+# has any.
+#
+ENV PYTHON=python3.12
 COPY docker/mongo.repo /etc/yum.repos.d/mongo.repo
 
 RUN  dnf config-manager --disable pgdg13 || true && \
@@ -22,14 +37,9 @@ RUN  dnf config-manager --disable pgdg13 || true && \
      yum install -y mongodb-database-tools mongodb-org-database-tools-extra \
                  mongodb-org-tools mongodb-org-shell mongodb-org-server \
                  mongodb-org-mongos mongodb-org && \
-     yum install -y python3 python2 virtualenv && \
+     yum install -y python3 python3.12 python3.12-pip python2 && \
      ln --force -s /usr/bin/python2 /usr/bin/python && \
      yum install -y openssl-devel libffi-devel netcat bc diffutils hostname procps gmock-devel gtest && \
-     wget https://bootstrap.pypa.io/pip/2.7/get-pip.py && \
-     python2.7 get-pip.py && \
-     pip2.7 install Flask && \
-     pip2.7 install paho-mqtt && \
-     pip2.7 install pyopenssl && \
      wget https://src.fedoraproject.org/repo/pkgs/gmock/gmock-1.5.0.tar.bz2/d738cfee341ad10ce0d7a0cc4209dd5e/gmock-1.5.0.tar.bz2 && \
      tar xfvj gmock-1.5.0.tar.bz2 && \
      cd gmock-1.5.0 && \

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,23 +1,12 @@
 # Requirements for the functional test suite.
 #
-# These have to install on TWO very different interpreters:
+# The suite builds its virtual environment with $PYTHON (see testHarness.sh),
+# which the CI test image sets to python3.12 and which falls back to python3 on
+# a developer machine. Both are 3.8+, so the Flask/Werkzeug lines need no
+# environment markers.
 #
-#   - the CI test image (fiware/orion-ld-base), which ships Python 3.6.8
-#   - a developer machine, which today means Python 3.12 / 3.13 / 3.14
-#
-# so the Flask/Werkzeug lines are split with environment markers rather than
-# pinned to one version. A single pin cannot satisfy both: Flask 2.0.3 calls
-# pkgutil.get_loader(), deprecated in Python 3.12 and REMOVED in 3.14, so
-# Flask(__name__) raises and accumulator-server.py cannot start at all; while
-# Flask 2.3+ requires Python 3.8+ and simply does not exist for 3.6.
-#
-# NOTE: Python 3.6 went end-of-life in December 2021. Refreshing the base image
-#       to a supported Python would let all of this collapse back to one line.
-#
-Flask==2.0.3;   python_version <  "3.8"
-Flask>=2.3;     python_version >= "3.8"
-Werkzeug<3.0;   python_version <  "3.8"
-Werkzeug>=2.3;  python_version >= "3.8"
+Flask>=2.3
+Werkzeug>=2.3
 
 # pyOpenSSL is NOT here on purpose: nothing imports it. The only reference in
 # the tree is a commented-out SSL.Context() in accumulator-server.py - the live

--- a/test/functionalTest/testHarness.sh
+++ b/test/functionalTest/testHarness.sh
@@ -76,9 +76,10 @@ export -f logMsg
 #
 if [ ! -d .venv ]
 then
-    pver=$(python3 --version)
+    pyExe=${PYTHON:-python3}
+    pver=$($pyExe --version)
     echo "Creating Virtual Environment for $pver for functional tests"
-    virtualenv -p python3 .venv
+    $pyExe -m venv .venv
     source .venv/bin/activate
     pip install -r scripts/requirements.txt
 fi


### PR DESCRIPTION
The test image installed Flask, paho-mqtt and pyOpenSSL with `pip2.7`, and the functional suite then built its virtual environment with ubi8's own `python3` — which is **3.6.8**, end-of-life since December 2021.

That is what forced `scripts/requirements.txt` to carry PEP 508 environment markers, so that one file could satisfy both 3.6 and a developer's 3.12+: Flask 2.0.3 calls `pkgutil.get_loader()`, removed in Python 3.14, while Flask 2.3+ does not exist for 3.6.

## What changed

- **`docker/Dockerfile-test`** — installs `python3.12` + `python3.12-pip` from the ubi8 AppStream (3.12.13 is there; no new base image and no ubi9 jump needed), and sets `ENV PYTHON=python3.12`. The three `pip2.7 install` lines and the `get-pip.py` download are gone — `requirements.txt` has installed those into the venv for a long time.
- **`test/functionalTest/testHarness.sh`** — `virtualenv -p python3 .venv` → `${PYTHON:-python3} -m venv .venv`. Unset on a developer machine, so local runs keep using their own `python3`.
- **`scripts/requirements.txt`** — markers collapse back to plain `Flask>=2.3` / `Werkzeug>=2.3` / `paho-mqtt==1.5.1`.
- **`.dockerignore`** (new) — see below.

`virtualenv` had to go along with python2: ubi8 ships **virtualenv 15.1.0**, which refuses to create an environment for anything newer than 3.10 and says so itself — *"Virtual environments created by virtualenv < 20 are not compatible with Python 3.11. Use `python3.12 -m venv` instead."*

## Why python2 stays

Nothing of ours needs it any more, but gmock 1.5.0 builds itself with `gtest/scripts/fuse_gtest_files.py`, python2 source that dies with `SyntaxError: Missing parentheses in call to 'print'` under python3 — the image build fails outright without it. And the unit tests link the gtest/gmock that tarball installs into `/usr/local/lib`, not the ones from `gmock-devel`: the `unit` job's own log says `Using /usr/local/lib/libgtest.so for Google Test`. Replacing that 2010 tarball with a current gtest would remove python2 entirely, but it is a separate change with its own risk.

## The `.dockerignore`

The images are built with `COPY . /opt/orion` and there was no `.dockerignore`, so a `.venv` left behind by a local test run was copied into the image with its `bin/python` symlinks pointing at the *host* interpreter — and `testHarness.sh`, which only checks whether the directory exists, then skipped creating a working one. The result is a venv whose `pip` and `python` disagree and every Flask/paho test fails on `ModuleNotFoundError`. CI never saw this, since `actions/checkout` starts from a clean tree.

## Verification

Built `docker/Dockerfile-test` locally and ran the harness venv block inside the resulting image:

```
PYTHON=python3.12
python     -> Python 2.7.18      (gmock only)
python3    -> Python 3.6.8
python3.12 -> Python 3.12.13
Creating Virtual Environment for Python 3.12.13 for functional tests
Flask 3.1.3 | Werkzeug 3.1.8 | paho-mqtt 1.5.1
accumulator-server Flask() OK
paho OK
```

Targets `feature/HA` rather than `develop`, per the "no more develop PRs until feature/HA lands" plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)