### PR TITLE
feat: default to the v1.9 core @context

### DIFF
--- a/src/app/orionld/orionld.cpp
+++ b/src/app/orionld/orionld.cpp
@@ -989,6 +989,7 @@ static char* coreContextUrlSetup(const char* version)
   else if (strcmp(version, "v1.6") == 0)    return ORIONLD_CORE_CONTEXT_URL_V1_6;
   else if (strcmp(version, "v1.7") == 0)    return ORIONLD_CORE_CONTEXT_URL_V1_7;
   else if (strcmp(version, "v1.8") == 0)    return ORIONLD_CORE_CONTEXT_URL_V1_8;
+  else if (strcmp(version, "v1.9") == 0)    return ORIONLD_CORE_CONTEXT_URL_V1_9;
 
   return NULL;
 }

--- a/src/lib/orionld/context/orionldCoreContext.h
+++ b/src/lib/orionld/context/orionldCoreContext.h
@@ -46,7 +46,8 @@ extern "C"
 #define ORIONLD_CORE_CONTEXT_URL_V1_6       (char*) "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.6.jsonld"
 #define ORIONLD_CORE_CONTEXT_URL_V1_7       (char*) "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.7.jsonld"
 #define ORIONLD_CORE_CONTEXT_URL_V1_8       (char*) "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld"
-#define ORIONLD_CORE_CONTEXT_URL_DEFAULT    (char*) "v1.8"
+#define ORIONLD_CORE_CONTEXT_URL_V1_9       (char*) "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld"
+#define ORIONLD_CORE_CONTEXT_URL_DEFAULT    (char*) "v1.9"
 
 
 

--- a/test/functionalTest/cases/0000_ld/dds/dds_action_full_roundtrip.test
+++ b/test/functionalTest/cases/0000_ld/dds/dds_action_full_roundtrip.test
@@ -295,7 +295,7 @@ HTTP/1.1 200 OK
 Content-Length: 92
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "ddsType": {
@@ -313,7 +313,7 @@ HTTP/1.1 200 OK
 Content-Length: 2
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 []
 
@@ -435,7 +435,7 @@ HTTP/1.1 200 OK
 Content-Length: 92
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "ddsType": {
@@ -453,7 +453,7 @@ HTTP/1.1 200 OK
 Content-Length: 2
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 []
 

--- a/test/functionalTest/cases/0000_ld/dds/dds_action_two_concurrent_goals.test
+++ b/test/functionalTest/cases/0000_ld/dds/dds_action_two_concurrent_goals.test
@@ -244,7 +244,7 @@ HTTP/1.1 200 OK
 Content-Length: 92
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "ddsType": {
@@ -262,7 +262,7 @@ HTTP/1.1 200 OK
 Content-Length: 2
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 []
 

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_batch_create_duplicate_ids.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_batch_create_duplicate_ids.test
@@ -111,7 +111,7 @@ HTTP/1.1 200 OK
 Content-Length: 80
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "P": {
@@ -129,7 +129,7 @@ HTTP/1.1 200 OK
 Content-Length: 77
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "P": {

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_batch_delete_duplicate_ids.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_batch_delete_duplicate_ids.test
@@ -167,7 +167,7 @@ HTTP/1.1 200 OK
 Content-Length: 34
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "id": "urn:ngsi-ld:E3",

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_batch_update_duplicate_ids.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_batch_update_duplicate_ids.test
@@ -149,7 +149,7 @@ HTTP/1.1 200 OK
 Content-Length: 203
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "A": {
@@ -186,7 +186,7 @@ HTTP/1.1 200 OK
 Content-Length: 161
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "P": {

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_batch_upsert_and_contexts.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_batch_upsert_and_contexts.test
@@ -740,13 +740,13 @@ Date: REGEX(.*)
       "type": "hash-table",
       "origin": "REGEX((Downloaded|FileCached))",
       "compactions": 5,
-      "expansions": 352,
+      "expansions": 410,
       "hash-table": {
         "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
+        "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
         "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
         "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
-        "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt",
-        "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList"
+        "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
       }
     }
   },
@@ -1010,13 +1010,13 @@ Date: REGEX(.*)
       "type": "hash-table",
       "origin": "REGEX((Downloaded|FileCached))",
       "compactions": 10,
-      "expansions": 357,
+      "expansions": 415,
       "hash-table": {
         "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
+        "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
         "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
         "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
-        "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt",
-        "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList"
+        "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
       }
     }
   },

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_batch_upsert_duplicate_ids.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_batch_upsert_duplicate_ids.test
@@ -129,7 +129,7 @@ HTTP/1.1 200 OK
 Content-Length: 81
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "P": {
@@ -147,7 +147,7 @@ HTTP/1.1 200 OK
 Content-Length: 77
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "P": {
@@ -177,7 +177,7 @@ HTTP/1.1 200 OK
 Content-Length: 151
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "A": {

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_batch_upsert_over_1000_entities.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_batch_upsert_over_1000_entities.test
@@ -133,7 +133,7 @@ HTTP/1.1 200 OK
 Content-Length: 75
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "P": {
@@ -151,7 +151,7 @@ HTTP/1.1 200 OK
 Content-Length: 75
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "P": {

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_complex_context_in_subscription_and_broker_restart.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_complex_context_in_subscription_and_broker_restart.test
@@ -54,7 +54,7 @@ payload='{
     "value": 23.4
   },
   "@context": [
-    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld",
     {
       "temperature": "https://mysite.com/api/ngsi-ld-attributes/temperature"
     }
@@ -93,7 +93,7 @@ payload='{
     }
   },
   "@context": [
-    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld",
     {
       "temperature": "https://mysite.com/api/ngsi-ld-attributes/temperature"
     }
@@ -112,7 +112,7 @@ payload='{
     "value": 8.5
   },
   "@context": [
-    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld",
     {
       "temperature": "https://mysite.com/api/ngsi-ld-attributes/temperature"
     }

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_context-delete-with-url.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_context-delete-with-url.test
@@ -70,20 +70,20 @@ echo
 
 echo "04. Attempt to DELETE the Core Context without ?reload - see error"
 echo "=================================================================="
-orionCurl --url '/ngsi-ld/v1/jsonldContexts/https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld' -X DELETE
+orionCurl --url '/ngsi-ld/v1/jsonldContexts/https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld' -X DELETE
 echo
 echo
 
 
 echo "05. Attempt to DELETE the Core Context, with ?reload=false - see error"
 echo "======================================================================"
-orionCurl --url '/ngsi-ld/v1/jsonldContexts/https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld?reload=false' -X DELETE
+orionCurl --url '/ngsi-ld/v1/jsonldContexts/https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld?reload=false' -X DELETE
 echo
 echo
 
 echo "06. DELETE the Core Context, with ?reload=true - OK"
 echo "==================================================="
-orionCurl --url '/ngsi-ld/v1/jsonldContexts/https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld?reload=true' -X DELETE
+orionCurl --url '/ngsi-ld/v1/jsonldContexts/https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld?reload=true' -X DELETE
 echo
 echo
 

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_context_and_subscriptions.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_context_and_subscriptions.test
@@ -179,12 +179,12 @@ Date: REGEX(.*)
         "createdAt": "202REGEX(.*)",
         "extraInfo": {
             "compactions": 1,
-            "expansions": 348,
+            "expansions": 406,
             "hash-table": {
+                "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
                 "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
                 "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
                 "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
-                "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList",
                 "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
             },
             "origin": "REGEX((Downloaded|FileCached))",

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_context_cache_ignores-protocol.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_context_cache_ignores-protocol.test
@@ -79,7 +79,7 @@ Content-Type: application/json
 Date: REGEX(.*)
 
 [
-    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld"
+    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld"
 ]
 
 

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_context_creation.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_context_creation.test
@@ -210,12 +210,12 @@ Date: REGEX(.*)
         "createdAt": "202REGEX(.*)",
         "extraInfo": {
             "compactions": 0,
-            "expansions": 347,
+            "expansions": 405,
             "hash-table": {
+                "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
                 "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
                 "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
                 "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
-                "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList",
                 "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
             },
             "origin": "REGEX((Downloaded|FileCached))",
@@ -353,12 +353,12 @@ Date: REGEX(.*)
         "createdAt": "202REGEX(.*)",
         "extraInfo": {
             "compactions": 0,
-            "expansions": 347,
+            "expansions": 405,
             "hash-table": {
+                "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
                 "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
                 "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
                 "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
-                "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList",
                 "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
             },
             "origin": "REGEX((Downloaded|FileCached))",

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_context_deletion.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_context_deletion.test
@@ -171,12 +171,12 @@ Date: REGEX(.*)
         "createdAt": "202REGEX(.*)",
         "extraInfo": {
             "compactions": 0,
-            "expansions": 347,
+            "expansions": 405,
             "hash-table": {
+                "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
                 "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
                 "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
                 "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
-                "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList",
                 "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
             },
             "origin": "REGEX((Downloaded|FileCached))",
@@ -305,12 +305,12 @@ Date: REGEX(.*)
         "createdAt": "202REGEX(.*)",
         "extraInfo": {
             "compactions": 0,
-            "expansions": 347,
+            "expansions": 405,
             "hash-table": {
+                "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
                 "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
                 "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
                 "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
-                "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList",
                 "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
             },
             "origin": "REGEX((Downloaded|FileCached))",

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_context_errors.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_context_errors.test
@@ -323,12 +323,12 @@ Date: REGEX(.*)
         "createdAt": "202REGEX(.*)",
         "extraInfo": {
             "compactions": 0,
-            "expansions": 347,
+            "expansions": 405,
             "hash-table": {
+                "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
                 "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
                 "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
                 "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
-                "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList",
                 "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
             },
             "origin": "REGEX((Downloaded|FileCached))",
@@ -367,12 +367,12 @@ Date: REGEX(.*)
         "createdAt": "202REGEX(.*)",
         "extraInfo": {
             "compactions": 0,
-            "expansions": 347,
+            "expansions": 405,
             "hash-table": {
+                "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
                 "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
                 "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
                 "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
-                "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList",
                 "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
             },
             "origin": "REGEX((Downloaded|FileCached))",
@@ -411,12 +411,12 @@ Date: REGEX(.*)
         "createdAt": "202REGEX(.*)",
         "extraInfo": {
             "compactions": 0,
-            "expansions": 347,
+            "expansions": 405,
             "hash-table": {
+                "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
                 "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
                 "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
                 "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
-                "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList",
                 "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
             },
             "origin": "REGEX((Downloaded|FileCached))",
@@ -456,12 +456,12 @@ Date: REGEX(.*)
         "createdAt": "202REGEX(.*)",
         "extraInfo": {
             "compactions": 0,
-            "expansions": 347,
+            "expansions": 405,
             "hash-table": {
+                "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
                 "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
                 "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
                 "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
-                "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList",
                 "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
             },
             "origin": "REGEX((Downloaded|FileCached))",
@@ -500,12 +500,12 @@ Date: REGEX(.*)
         "createdAt": "202REGEX(.*)",
         "extraInfo": {
             "compactions": 0,
-            "expansions": 347,
+            "expansions": 405,
             "hash-table": {
+                "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
                 "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
                 "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
                 "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
-                "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList",
                 "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
             },
             "origin": "REGEX((Downloaded|FileCached))",
@@ -544,12 +544,12 @@ Date: REGEX(.*)
         "createdAt": "202REGEX(.*)",
         "extraInfo": {
             "compactions": 0,
-            "expansions": 347,
+            "expansions": 405,
             "hash-table": {
+                "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
                 "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
                 "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
                 "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
-                "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList",
                 "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
             },
             "origin": "REGEX((Downloaded|FileCached))",
@@ -588,12 +588,12 @@ Date: REGEX(.*)
         "createdAt": "202REGEX(.*)",
         "extraInfo": {
             "compactions": 0,
-            "expansions": 347,
+            "expansions": 405,
             "hash-table": {
+                "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
                 "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
                 "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
                 "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
-                "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList",
                 "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
             },
             "origin": "REGEX((Downloaded|FileCached))",
@@ -632,12 +632,12 @@ Date: REGEX(.*)
         "createdAt": "202REGEX(.*)",
         "extraInfo": {
             "compactions": 0,
-            "expansions": 347,
+            "expansions": 405,
             "hash-table": {
+                "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
                 "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
                 "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
                 "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
-                "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList",
                 "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
             },
             "origin": "REGEX((Downloaded|FileCached))",
@@ -676,12 +676,12 @@ Date: REGEX(.*)
         "createdAt": "202REGEX(.*)",
         "extraInfo": {
             "compactions": 0,
-            "expansions": 347,
+            "expansions": 405,
             "hash-table": {
+                "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
                 "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
                 "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
                 "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
-                "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList",
                 "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
             },
             "origin": "REGEX((Downloaded|FileCached))",
@@ -720,12 +720,12 @@ Date: REGEX(.*)
         "createdAt": "202REGEX(.*)",
         "extraInfo": {
             "compactions": 0,
-            "expansions": 347,
+            "expansions": 405,
             "hash-table": {
+                "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
                 "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
                 "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
                 "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
-                "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList",
                 "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
             },
             "origin": "REGEX((Downloaded|FileCached))",

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_context_list_with_kind.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_context_list_with_kind.test
@@ -166,12 +166,12 @@ Date: REGEX(.*)
         "createdAt": "202REGEX(.*)",
         "extraInfo": {
             "compactions": 0,
-            "expansions": 347,
+            "expansions": 405,
             "hash-table": {
+                "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
                 "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
                 "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
                 "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
-                "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList",
                 "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
             },
             "origin": "REGEX((Downloaded|FileCached))",
@@ -367,12 +367,12 @@ Date: REGEX(.*)
         "createdAt": "202REGEX(.*)",
         "extraInfo": {
             "compactions": 0,
-            "expansions": 347,
+            "expansions": 405,
             "hash-table": {
+                "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
                 "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
                 "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
                 "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
-                "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList",
                 "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
             },
             "origin": "REGEX((Downloaded|FileCached))",

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_context_relative_reference.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_context_relative_reference.test
@@ -79,7 +79,7 @@ echo "==========================================================================
 payload='{
   "@context": [
     "'$rContextId'",
-    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld"
+    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld"
   ]
 }'
 orionCurl --url /ngsi-ld/v1/jsonldContexts --payload "$payload"
@@ -130,7 +130,7 @@ echo "=================================================================="
 payload='{
   "@context": [
     "'./$rContextId'",
-    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld"
+    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld"
   ]
 }'
 orionCurl --url /ngsi-ld/v1/jsonldContexts --payload "$payload"
@@ -167,7 +167,7 @@ echo "==========================================================================
 payload='{
   "@context": [
     "no-such-context-here",
-    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld"
+    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld"
   ]
 }'
 orionCurl --url /ngsi-ld/v1/jsonldContexts --payload "$payload"
@@ -268,7 +268,7 @@ HTTP/1.1 200 OK
 Content-Length: 101
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "id": "urn:ngsi-ld:entities:E1",
@@ -322,7 +322,7 @@ HTTP/1.1 200 OK
 Content-Length: 101
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "id": "urn:ngsi-ld:entities:E2",
@@ -386,7 +386,7 @@ HTTP/1.1 200 OK
 Content-Length: 125
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "https://ngsi-ld-test-suite/context#brandName": {

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_context_server_complex_user_context.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_context_server_complex_user_context.test
@@ -115,12 +115,12 @@ Date: REGEX(.*)
         "createdAt": "202REGEX(.*)",
         "extraInfo": {
             "compactions": 0,
-            "expansions": 347,
+            "expansions": 405,
             "hash-table": {
+                "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
                 "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
                 "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
                 "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
-                "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList",
                 "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
             },
             "origin": "REGEX((Downloaded|FileCached))",

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_core_contexts.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_core_contexts.test
@@ -32,7 +32,7 @@ orionldStart CB -experimental
 
 #
 # 01. Create an Entity
-# 02. GET all entities, see default Core Context in Link header (v1.8)
+# 02. GET all entities, see default Core Context in Link header (v1.9)
 # 03. Kill and restart the broker, now with v1.0 as Core Context
 # 04. GET all entities, see Core Context v1.0 in Link header
 # 05. Kill and restart the broker, now with v1.3 as Core Context
@@ -47,6 +47,8 @@ orionldStart CB -experimental
 # 14. GET all entities, see Core Context v1.7 in Link header
 # 15. Kill and restart the broker, now with v1.8 as Core Context
 # 16. GET all entities, see Core Context v1.8 in Link header
+# 17. Kill and restart the broker, now with v1.9 as Core Context
+# 18. GET all entities, see Core Context v1.9 in Link header
 #
 
 echo "01. Create an Entity"
@@ -186,6 +188,23 @@ echo
 echo
 
 
+echo "17. Kill and restart the broker, now with v1.9 as Core Context"
+echo "=============================================================="
+brokerStop CB
+orionldStart CB -experimental -coreContext v1.9
+sleep 0.2
+echo The broker is now running with v1.9 as Core Context
+echo
+echo
+
+
+echo "18. GET all entities, see Core Context v1.9 in Link header"
+echo "=========================================================="
+orionCurl --url /ngsi-ld/v1/entities?local=true
+echo
+echo
+
+
 --REGEXPECT--
 01. Create an Entity
 ====================
@@ -202,7 +221,7 @@ HTTP/1.1 200 OK
 Content-Length: 28
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 [
     {
@@ -350,6 +369,27 @@ Content-Length: 28
 Content-Type: application/json
 Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+
+[
+    {
+        "id": "urn:E1",
+        "type": "T"
+    }
+]
+
+
+17. Kill and restart the broker, now with v1.9 as Core Context
+==============================================================
+The broker is now running with v1.9 as Core Context
+
+
+18. GET all entities, see Core Context v1.9 in Link header
+==========================================================
+HTTP/1.1 200 OK
+Content-Length: 28
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 [
     {

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_issue_807.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_issue_807.test
@@ -145,12 +145,12 @@ Date: REGEX(.*)
         "createdAt": "202REGEX(.*)",
         "extraInfo": {
             "compactions": 0,
-            "expansions": 347,
+            "expansions": 405,
             "hash-table": {
+                "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
                 "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
                 "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
                 "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
-                "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList",
                 "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
             },
             "origin": "REGEX((Downloaded|FileCached))",

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_mixed_context.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_mixed_context.test
@@ -154,12 +154,12 @@ Date: REGEX(.*)
         "createdAt": "202REGEX(.*)",
         "extraInfo": {
             "compactions": 0,
-            "expansions": 347,
+            "expansions": 405,
             "hash-table": {
+                "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
                 "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
                 "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
                 "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
-                "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList",
                 "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
             },
             "origin": "REGEX((Downloaded|FileCached))",
@@ -186,7 +186,7 @@ Date: REGEX(.*)
         },
         "kind": "Cached",
         "lastUsage": "202REGEX(.*)",
-        "localId": "REGEX(.*)"
+        "localId": "REGEX(.*)",
         "numberOfHits": 1
     },
     {
@@ -203,7 +203,7 @@ Date: REGEX(.*)
         },
         "kind": "Cached",
         "lastUsage": "202REGEX(.*)",
-        "localId": "REGEX(.*)"
+        "localId": "REGEX(.*)",
         "numberOfHits": 1
     }
 ]

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_batch_upsert_and_contexts.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_batch_upsert_and_contexts.test
@@ -845,13 +845,13 @@ Date: REGEX(.*)
       "type": "hash-table",
       "origin": "REGEX((Downloaded|FileCached))",
       "compactions": 5,
-      "expansions": 352,
+      "expansions": 410,
       "hash-table": {
         "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
+        "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
         "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
         "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
-        "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt",
-        "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList"
+        "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
       }
     }
   },
@@ -1206,13 +1206,13 @@ Date: REGEX(.*)
       "type": "hash-table",
       "origin": "REGEX((Downloaded|FileCached))",
       "compactions": 10,
-      "expansions": 357,
+      "expansions": 415,
       "hash-table": {
         "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
+        "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
         "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
         "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
-        "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt",
-        "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList"
+        "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
       }
     }
   },

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_complex_context_in_subscription_and_broker_restart.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_complex_context_in_subscription_and_broker_restart.test
@@ -54,7 +54,7 @@ payload='{
     "value": 23.4
   },
   "@context": [
-    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld",
     {
       "temperature": "https://mysite.com/api/ngsi-ld-attributes/temperature"
     }
@@ -93,7 +93,7 @@ payload='{
     }
   },
   "@context": [
-    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld",
     {
       "temperature": "https://mysite.com/api/ngsi-ld-attributes/temperature"
     }
@@ -112,7 +112,7 @@ payload='{
     "value": 8.5
   },
   "@context": [
-    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld",
     {
       "temperature": "https://mysite.com/api/ngsi-ld-attributes/temperature"
     }

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_context_and_subscriptions.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_context_and_subscriptions.test
@@ -178,12 +178,12 @@ Date: REGEX(.*)
         "createdAt": "202REGEX(.*)",
         "extraInfo": {
             "compactions": 1,
-            "expansions": 348,
+            "expansions": 406,
             "hash-table": {
+                "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
                 "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
                 "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
                 "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
-                "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList",
                 "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
             },
             "origin": "REGEX((Downloaded|FileCached))",

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_context_http-link-header.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_context_http-link-header.test
@@ -86,13 +86,13 @@ Date: REGEX(.*)
       "type": "hash-table",
       "origin": "REGEX((Downloaded|FileCached))",
       "compactions": 0,
-      "expansions": 348,
+      "expansions": 406,
       "hash-table": {
         "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
+        "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
         "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
         "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
-        "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt",
-        "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList"
+        "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
       }
     }
   },

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_context_inline_array_with_mix-string-and-object.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_context_inline_array_with_mix-string-and-object.test
@@ -113,13 +113,13 @@ Date: REGEX(.*)
       "type": "hash-table",
       "origin": "REGEX((Downloaded|FileCached))",
       "compactions": 0,
-      "expansions": 347,
+      "expansions": 405,
       "hash-table": {
         "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
+        "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
         "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
         "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
-        "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt",
-        "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList"
+        "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
       }
     }
   },

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_context_inline_array_with_one_string_that_IS_the_core_context.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_context_inline_array_with_one_string_that_IS_the_core_context.test
@@ -47,7 +47,7 @@ payload='{
   "id": "http://a.b.c/entity/E1",
   "type": "T1",
   "@context": [
-    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld"
+    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld"
   ]
 }'
 orionCurl --url /ngsi-ld/v1/entities --payload "$payload" -H "Content-Type: application/ld+json"  --linkHeaderFix
@@ -89,13 +89,13 @@ Date: REGEX(.*)
       "type": "hash-table",
       "origin": "REGEX((Downloaded|FileCached))",
       "compactions": 0,
-      "expansions": 348,
+      "expansions": 406,
       "hash-table": {
         "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
+        "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
         "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
         "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
-        "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt",
-        "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList"
+        "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
       }
     }
   }

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_context_inline_array_with_one_string_that_is_not_the_core_context.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_context_inline_array_with_one_string_that_is_not_the_core_context.test
@@ -89,13 +89,13 @@ Date: REGEX(.*)
       "type": "hash-table",
       "origin": "REGEX((Downloaded|FileCached))",
       "compactions": 0,
-      "expansions": 348,
+      "expansions": 406,
       "hash-table": {
         "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
+        "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
         "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
         "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
-        "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt",
-        "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList"
+        "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
       }
     }
   },

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_context_inline_array_with_two_items_of_which_none_is_the_core_context.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_context_inline_array_with_two_items_of_which_none_is_the_core_context.test
@@ -96,13 +96,13 @@ Date: REGEX(.*)
       "type": "hash-table",
       "origin": "REGEX((Downloaded|FileCached))",
       "compactions": 0,
-      "expansions": 348,
+      "expansions": 406,
       "hash-table": {
         "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
+        "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
         "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
         "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
-        "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt",
-        "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList"
+        "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
       }
     }
   },

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_context_inline_array_with_two_items_of_which_one_is_the_core_context.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_context_inline_array_with_two_items_of_which_one_is_the_core_context.test
@@ -48,7 +48,7 @@ payload='{
   "type": "T1",
    "@context": [
      "https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext.jsonld",
-     "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld"
+     "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld"
    ]
 }'
 orionCurl --url /ngsi-ld/v1/entities --payload "$payload" -H "Content-Type: application/ld+json"  --linkHeaderFix
@@ -90,13 +90,13 @@ Date: REGEX(.*)
       "type": "hash-table",
       "origin": "REGEX((Downloaded|FileCached))",
       "compactions": 0,
-      "expansions": 348,
+      "expansions": 406,
       "hash-table": {
         "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
+        "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
         "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
         "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
-        "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt",
-        "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList"
+        "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
       }
     }
   },

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_context_inline_object.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_context_inline_object.test
@@ -89,13 +89,13 @@ Date: REGEX(.*)
       "type": "hash-table",
       "origin": "REGEX((Downloaded|FileCached))",
       "compactions": 0,
-      "expansions": 348,
+      "expansions": 406,
       "hash-table": {
         "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
+        "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
         "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
         "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
-        "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt",
-        "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList"
+        "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
       }
     }
   }

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_context_inline_string.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_context_inline_string.test
@@ -87,13 +87,13 @@ Date: REGEX(.*)
       "type": "hash-table",
       "origin": "REGEX((Downloaded|FileCached))",
       "compactions": 0,
-      "expansions": 348,
+      "expansions": 406,
       "hash-table": {
         "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
+        "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
         "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
         "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
-        "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt",
-        "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList"
+        "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
       }
     }
   },

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_distributed_subscription_creation.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_distributed_subscription_creation.test
@@ -657,7 +657,7 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
         ],
         "id": "urn:ngsi-ld:Subscription:S3:1",
         "isActive": true,
-        "jsonldContext": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+        "jsonldContext": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld",
         "notification": {
             "endpoint": {
                 "accept": "application/json",
@@ -678,7 +678,7 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
         ],
         "id": "urn:ngsi-ld:Subscription:S3:2",
         "isActive": true,
-        "jsonldContext": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+        "jsonldContext": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld",
         "notification": {
             "endpoint": {
                 "accept": "application/json",

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_issue_807.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_issue_807.test
@@ -146,12 +146,12 @@ Date: REGEX(.*)
         "createdAt": "202REGEX(.*)",
         "extraInfo": {
             "compactions": 0,
-            "expansions": 347,
+            "expansions": 405,
             "hash-table": {
+                "aggrParams": "https://uri.etsi.org/ngsi-ld/aggrParams",
                 "instanceId": "https://uri.etsi.org/ngsi-ld/instanceId",
                 "linkedMaps": "https://uri.etsi.org/ngsi-ld/linkedMaps",
                 "notifiedAt": "https://uri.etsi.org/ngsi-ld/notifiedAt",
-                "objectList": "https://uri.etsi.org/ngsi-ld/hasObjectList",
                 "observedAt": "https://uri.etsi.org/ngsi-ld/observedAt"
             },
             "origin": "REGEX((Downloaded|FileCached))",

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_patch_existing_datasetId_instance.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_patch_existing_datasetId_instance.test
@@ -100,7 +100,7 @@ HTTP/1.1 200 OK
 Content-Length: REGEX(\d+)
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "A": [

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_subscription_datasetId_projection.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_subscription_datasetId_projection.test
@@ -197,7 +197,7 @@ HTTP/1.1 200 OK
 Content-Length: 429
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "datasetId": [
@@ -211,7 +211,7 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="h
     ],
     "id": "urn:ngsi-ld:Sub1",
     "isActive": true,
-    "jsonldContext": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+    "jsonldContext": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld",
     "notification": {
         "endpoint": {
             "accept": "application/json",
@@ -245,7 +245,7 @@ User-Agent: orionld/REGEX(.*)
 Host: 127.0.0.1:9997
 Accept: application/json
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Ngsild-Attribute-Format: Normalized
 
 {
@@ -278,7 +278,7 @@ HTTP/1.1 200 OK
 Content-Length: 429
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "datasetId": [
@@ -292,7 +292,7 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="h
     ],
     "id": "urn:ngsi-ld:Sub1",
     "isActive": true,
-    "jsonldContext": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+    "jsonldContext": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld",
     "notification": {
         "endpoint": {
             "accept": "application/json",
@@ -340,7 +340,7 @@ User-Agent: orionld/REGEX(.*)
 Host: 127.0.0.1:9997
 Accept: application/json
 Content-Type: application/json
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 Ngsild-Attribute-Format: Normalized
 
 {

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_subscription_watchedAttributes_datasetId.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_subscription_watchedAttributes_datasetId.test
@@ -224,7 +224,7 @@ HTTP/1.1 200 OK
 Content-Length: 409
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "entities": [
@@ -235,7 +235,7 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="h
     ],
     "id": "urn:ngsi-ld:Sub1",
     "isActive": true,
-    "jsonldContext": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+    "jsonldContext": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld",
     "notification": {
         "endpoint": {
             "accept": "application/json",
@@ -259,7 +259,7 @@ HTTP/1.1 200 OK
 Content-Length: 392
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "entities": [
@@ -270,7 +270,7 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="h
     ],
     "id": "urn:ngsi-ld:Sub2",
     "isActive": true,
-    "jsonldContext": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+    "jsonldContext": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld",
     "notification": {
         "endpoint": {
             "accept": "application/json",
@@ -298,7 +298,7 @@ HTTP/1.1 200 OK
 Content-Length: 409
 Content-Type: application/json
 Date: REGEX(.*)
-Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
 
 {
     "entities": [
@@ -309,7 +309,7 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld>; rel="h
     ],
     "id": "urn:ngsi-ld:Sub1",
     "isActive": true,
-    "jsonldContext": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+    "jsonldContext": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld",
     "notification": {
         "endpoint": {
             "accept": "application/json",


### PR DESCRIPTION
The broker already ships `ldcontexts/ngsi-ld-core-context-v1.9.jsonld` but still defaulted to **v1.8**, and `-coreContext` could not even select v1.9. **v1.9 is what the current ETSI TTF targets** (confirmed by ETSI: *"v1.9 was the target for the current ttf, the next ttf will target the one in the DATA documents"*).

Two lines of code — the URL constant and the version string `coreContextUrlSetup()` maps. The `@context` file was already there.

## What v1.9 actually changes

Diffed against v1.8: **30 terms added, 2 removed, 3 changed**.

Added: the `Snapshot*` family, `aggrMethods`/`aggrParams`/`aggrPeriodDuration`, `orderBy`, `valueType`, `EntityMap`, `ngsildproof`, `lastN`, `collation`, `problemDetails`, …

**Neither removal costs us anything:**

- **`geometryProperty`** is a URL *parameter*, never a payload member (TS 104-176 clause 6 lists it in the parameter table), and URL parameters are not `@context`-expanded. Its removal is a correction.
- **`objectsLists` → `objectLists`** is a rename **and the IRI changed with it** (`ngsi-ld:hasObjectsLists` → `ngsi-ld:hasObjectLists`), so it is a genuine breaking change — anything stored under v1.8 sits at the old IRI. But it applies only to the **simplified temporal representation** of a ListRelationship (TS 104-175 clause 5), and Orion-LD implements neither List type. The everyday singular `objectList` is byte-identical in v1.8 and v1.9.

Changed: `attributeCount` and `attributeDetails` were mapped to *themselves* and are now `ngsi-ld:`-prefixed, so their expanded IRI changes; `entityMap` gains `@container: @index`.

## Tests

30 files carried the core `@context` URL. **22 of them also assert the `@context` cache's internal state** — the fixed-size sample of the term hash table (v1.9's extra terms change *which* five appear; `aggrParams` sorts first) and the `expansions` usage counter (347/348 → 405/406).

Those expects are refreshed, **each verified by running the test twice**, and every hand-written REGEX in them is preserved — no `--regen`, which would have stripped them.

`ngsild_core_contexts.test` walks `-coreContext` version by version. Step 02 asserts the **default** and moves to v1.9; **step 16 restarts with v1.8 explicitly and correctly still expects v1.8**. New steps 17/18 cover explicitly selecting v1.9.

## Verification

A full local run of the suite (1784 tests) reported **3 failures**: `ngsild_issue_807`, `ngsild_new_issue_807` and `ngsild_new_batch_delete-with-forwarding`. The two `807` tests were the term-table/counter shape described above and were fixed afterwards, each verified by two consecutive runs.

`ngsild_new_batch_delete-with-forwarding` **passes 3/3 in isolation** and only mentions the core `@context` in passing — a pre-existing ordering flake under full-suite load, unrelated to the `@context` version.

CI is the authoritative full-suite result for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)