### PR TITLE
Base image: build kjson release/0.11.2

### DIFF
--- a/docker/build-ubi/04.install-k-libs.sh
+++ b/docker/build-ubi/04.install-k-libs.sh
@@ -55,7 +55,7 @@ do
         branch=release/0.1.0
     elif [ $kproj = "kjson" ]
     then
-        branch=release/0.11
+        branch=release/0.11.2
     elif [ $kproj = "kalloc" ]
     then
         branch=release/0.10.1


### PR DESCRIPTION
The docker base image builds kjson from `release/0.11`, while every other pin moved on to `0.11.1` some time ago. So every image built from `fiware/orion-ld-base` is missing eleven commits — three of them bug fixes:

- **`countIntSize`** under-counted the render buffer for every integer that divides down to exactly 10 (10, 100–109, 1000–1099, …). `kjFastRender` does not bounds-check, so it wrote past the buffer — 40 such values in one array under-count by **32 bytes**. This is what corrupted a subscription's `expression.coords`, after which *no* subscription of that tenant could be read back from the database.
- **`kjChildReplace`** did not update `container->lastChild` when replacing the tail.
- **`kjParseMember`**, on a path only websockets reach.

`release/0.11` is not ahead of `0.11.1` in a single commit, so this only adds.

### Why it went unnoticed

Every k-lib version in the functional suite is `REGEX`'d — 14 `"kjson version"` assertions, 14 of them REGEX, 0 literal. Nothing in the suite could see which kjson was linked. (A follow-up on another branch pins it literally in `ngsild_version.test`, next to `"kprom version"` which already was; since `Dockerfile-test` is `FROM fiware/orion-ld-base`, a stale base image then fails a test instead of shipping.)

### Scope

One line. kjson is cut as `release/0.11.2` (`0.11.1` plus the version bump) and pushed to gitlab, so nothing else is needed here — the base image picks it up on its next build.

Removing the third-party `repo.okay.com.mx` dependency from `02.install-mongo-driver.sh` was briefly part of this PR and has been split out, so that a one-line pin is not blocked by an unproven build change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)