### PR TITLE
Base image: drop the third-party repo needed for scons

### DIFF
--- a/docker/build-ubi/02.install-mongo-driver.sh
+++ b/docker/build-ubi/02.install-mongo-driver.sh
@@ -22,9 +22,33 @@
 
 set -e
 
-yum -y install --nogpgcheck http://repo.okay.com.mx/centos/8/x86_64/release/okay-release-1-5.el8.noarch.rpm
-yum -y install --nogpgcheck boost-devel
-yum -y install --nogpgcheck scons
+#
+# boost-devel and scons are needed to build the (legacy) mongo cxx driver.
+#
+# They used to come from a third-party mirror - one 'okay-release' RPM off
+# repo.okay.com.mx, added here and removed again at the end of this script. That
+# made every base-image build depend on a single host staying reachable, and it
+# times out (Curl error 28) often enough to matter.
+#
+# boost-devel is in AlmaLinux AppStream, which docker/other-places.repo already
+# enables, and scons comes from PyPI.
+#
+# It has to be a PYTHON 2 scons: mongo-cxx-driver's SConstruct is Python 2 source
+# (it uses backtick-repr), and scons runs SConstruct under whichever Python runs
+# scons. 3.1.2 is the last release that still supports Python 2. That is why
+# 01.install-build-dependencies.sh installs python2 alongside python3.
+#
+yum -y install --nogpgcheck boost-devel python2-pip
+python2 -m pip install --no-cache-dir "scons==3.1.2"
+
+#
+# scons ships with a '#!/usr/bin/env python' shebang and RHEL8 has no unversioned
+# 'python' on PATH - only python2 and python3 - so it must be pointed at python2.
+# The scons RPM this replaced pulled that in as a dependency, which is why the
+# problem never showed before.
+#
+alternatives --set python /usr/bin/python2 2>/dev/null || ln -sf /usr/bin/python2 /usr/bin/python
+python --version
 
 echo -e "\e[1;32m Builder: installing mongo cxx driver \e[0m"
 git clone https://github.com/FIWARE-Ops/mongo-cxx-driver ${ROOT_FOLDER}/mongo-cxx-driver
@@ -32,6 +56,4 @@ cd ${ROOT_FOLDER}/mongo-cxx-driver
 scons --disable-warnings-as-errors --use-sasl-client --ssl
 scons install --disable-warnings-as-errors --prefix=/usr/local --use-sasl-client --ssl
 cd ${ROOT_FOLDER} && rm -Rf mongo-cxx-driver
-
-yum remove -y okay-release  || true
 

--- a/docker/build-ubi/07.install-fastdds.sh
+++ b/docker/build-ubi/07.install-fastdds.sh
@@ -147,7 +147,25 @@ yum -y install lz4-devel libzstd-devel json-devel
 cd /opt/Fast-DDS
 git clone https://github.com/eProsima/FIWARE-DDS-Enabler.git
 cd FIWARE-DDS-Enabler
-git checkout append_action_infix
+
+#
+# Pinned by COMMIT, not by branch: this used to check out 'append_action_infix',
+# a branch eProsima asked us to use and has since deleted -
+#
+#   error: pathspec 'append_action_infix' did not match any file(s) known to git
+#
+# The work was merged to main as ad19575 "Append action infix to action topics"
+# (#29), which is what this commit is - the same code the branch gave us. It is
+# NOT in any release tag: v1.2.0 (2026-05-05) predates it, and main carries only
+# it plus three cosmetic commits.
+#
+# The infix is what builds the action topic names (ACTION_INFIX "/_action/" in
+# ddsenabler_participants/include/ddsenabler_participants/Constants.hpp), so a
+# tag would quietly break DDS actions rather than fail to build.
+#
+# Move this to a release tag once eProsima cuts one that contains ad19575.
+#
+git checkout ad19575
 
 # ./install_dds_module.sh
 


### PR DESCRIPTION
Building the base image installs an `okay-release` RPM off `repo.okay.com.mx`, uses it to get `boost-devel` and `scons` for the legacy mongo cxx driver, and removes it again at the end of the same script. Every base-image build therefore depends on one third-party host staying reachable — and it times out:

```
Curl error (28): Timeout was reached for
http://repo.okay.com.mx/centos/8/x86_64/release/okay-release-1-5.el8.noarch.rpm
[Connection timed out after 30000 milliseconds]
Error: building at STEP "RUN /tmp/build/02.install-mongo-driver.sh"
```

Neither package needs that repo. What it *was* quietly providing, though, is more than it looks:

- **`boost-devel`** — in AlmaLinux AppStream, which `docker/other-places.repo` already enables.
- **a Python 2 `scons`** — `mongo-cxx-driver`'s `SConstruct` is Python 2 source (it uses backtick-repr), and scons runs `SConstruct` under whichever Python runs scons. A python3 scons dies with `SyntaxError: invalid syntax`. 3.1.2 is the last release supporting Python 2. This is why `01.install-build-dependencies.sh` installs `python2` alongside `python3`.
- **an unversioned `/usr/bin/python`** — scons ships a `#!/usr/bin/env python` shebang and RHEL8 carries only `python2`/`python3`, so without it you get `env: 'python': No such file or directory`. The RPM pulled it in as a dependency; now it is set explicitly.

### Verified locally

Steps 01 and 02 of `Dockerfile-ubi-base` built on `registry.access.redhat.com/ubi8/ubi`, then inspected:

```
python      : Python 2.7.18
scons       : SCons 3.1.2
boost-devel : boost-devel-1.66.0-13.el8.x86_64
okay-release: package okay-release is not installed
cxx driver  : /usr/local/lib/libmongoclient.a
cxx headers : /usr/local/include/mongo/version.h
```

Split out of #1978 so that a one-line kjson pin is not blocked by a build change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)