### PR TITLE
Fix #1977: load the @context cache before the registration cache

### DIFF
--- a/src/app/orionld/orionld.cpp
+++ b/src/app/orionld/orionld.cpp
@@ -1329,16 +1329,23 @@ int main(int argC, char* argV[])
   // mongocInit calls mongocTenantsGet => it gets total number of tenants from there and can change dbPoolSize
   mongocInit(dbURI, dbHost, dbUser, dbPwd, dbAuthDb, rplSet, dbAuthMechanism, dbSSL, dbCertFile);
 
-  //
-  // Now that the DB is ready to be used, we can populate the regCache for the different tenants
-  // Note that regCacheInit uses the tenantList, so orionldTenantInit must be called before regCacheInit
-  //
-  regCacheInit();
-
   if (pernot == true)
     pernotSubCacheInit();
 
   orionldServiceInit(restServiceVV, 9);
+
+  //
+  // Now that the DB is ready to be used, we can populate the regCache for the different tenants
+  // Note that regCacheInit uses the tenantList, so orionldTenantInit must be called before regCacheInit
+  //
+  // It must also come AFTER orionldServiceInit, which is where the @context cache is loaded from the
+  // database (orionldContextInit): a registration with a "jsonldContext" in its "contextSourceInfo"
+  // resolves that @context as it enters the cache, and a cache MISS makes orionldContextFromUrl()
+  // DOWNLOAD it - contextDownloadAttempts tries, contextDownloadTimeout each, all of it before the
+  // broker opens its port. A broker with no route to the @context server therefore never started
+  // listening at all (issue #1977).
+  //
+  regCacheInit();
 
   if (mongocOnly == false)
   {

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_registration_context_not_downloaded_at_startup.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_registration_context_not_downloaded_at_startup.test
@@ -1,0 +1,235 @@
+# Copyright 2026 FIWARE Foundation e.V.
+#
+# This file is part of Orion-LD Context Broker.
+#
+# Orion-LD Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion-LD Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion-LD Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# orionld at fiware dot org
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+A Registration's jsonldContext is not downloaded at startup (issue #1977)
+
+--SHELL-INIT--
+dbInit CB
+orionldStart CB -mongocOnly
+
+--SHELL--
+
+#
+# A registration whose 'contextSourceInfo' carries a 'jsonldContext' resolves that
+# @context as it enters the registration cache - at STARTUP, for every
+# registration, before the broker opens its port. If that lookup misses, the
+# broker goes to the network right there.
+#
+# Issue #1977: regCacheInit() ran BEFORE orionldServiceInit(), which is where the
+# @context cache is loaded from the database, so the lookup always missed and a
+# download was always attempted. A broker with no route to the @context server
+# never got as far as listening on its port.
+#
+# The @context used here is one the BROKER ITSELF serves: POST /jsonldContexts
+# stores it and hands back a URL of the form
+#
+#   http://<host>:<port>/ngsi-ld/v1/jsonldContexts/<uuid>
+#
+# which is reachable while the broker runs - so the registration is created
+# normally - and NOT reachable while the broker is starting up, because the port
+# is not open yet. That is what makes this test discriminating: it does not need
+# an unreachable host, it needs the broker to not go to the network at startup.
+#
+# Without the fix, step 05 answers 404: regCacheCreate cannot resolve the
+# @context, warns, and silently drops the registration from the cache.
+#
+# 01. POST a @context - the broker stores it and serves it itself
+# 02. Create a registration whose contextSourceInfo::jsonldContext is that @context
+# 03. GET the registration - it is in the registration cache
+# 04. Restart the broker
+# 05. GET the registration - it is STILL in the cache (it was not re-downloaded)
+#
+
+echo "01. POST a @context - the broker stores it and serves it itself"
+echo "==============================================================="
+payload='{
+  "@context": {
+    "setDimmer": "urn:ngsi-ld:test:setDimmer"
+  }
+}'
+orionCurl --url /ngsi-ld/v1/jsonldContexts --payload "$payload" -H "Content-Type: application/ld+json"
+ctxUrl=$(echo "$_responseHeaders" | grep Location: | awk -F'Location: ' '{ print $2 }' | tr -d "\r\n")
+ctxUrl="http://localhost:${CB_PORT}${ctxUrl}"
+echo
+echo
+
+
+echo "02. Create a registration whose contextSourceInfo::jsonldContext is that @context"
+echo "================================================================================="
+payload='{
+  "id": "urn:ngsi-ld:ContextSourceRegistration:R1",
+  "type": "ContextSourceRegistration",
+  "information": [
+    {
+      "entities": [
+        {
+          "id": "urn:ngsi-ld:Device:lum-ip-001",
+          "type": "Device"
+        }
+      ],
+      "propertyNames": [ "setDimmer" ]
+    }
+  ],
+  "mode": "exclusive",
+  "operations": [ "updateOps" ],
+  "contextSourceInfo": [
+    {
+      "key": "jsonldContext",
+      "value": "'$ctxUrl'"
+    }
+  ],
+  "endpoint": "http://localhost:'$LISTENER_PORT'"
+}'
+orionCurl --url /ngsi-ld/v1/csourceRegistrations --payload "$payload"
+echo
+echo
+
+
+echo "03. GET the registration - it is in the registration cache"
+echo "=========================================================="
+orionCurl --url /ngsi-ld/v1/csourceRegistrations/urn:ngsi-ld:ContextSourceRegistration:R1
+echo
+echo
+
+
+echo "04. Restart the broker"
+echo "======================"
+brokerStop CB
+orionldStart CB -mongocOnly
+echo
+echo
+
+
+echo "05. GET the registration - it is STILL in the cache (it was not re-downloaded)"
+echo "=============================================================================="
+orionCurl --url /ngsi-ld/v1/csourceRegistrations/urn:ngsi-ld:ContextSourceRegistration:R1
+echo
+echo
+
+
+--REGEXPECT--
+01. POST a @context - the broker stores it and serves it itself
+===============================================================
+HTTP/1.1 201 Created
+Content-Length: REGEX(.*)
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/jsonldContexts/REGEX(.*)
+
+
+
+02. Create a registration whose contextSourceInfo::jsonldContext is that @context
+=================================================================================
+HTTP/1.1 201 Created
+Content-Length: REGEX(.*)
+Date: REGEX(.*)
+Location: /ngsi-ld/v1/csourceRegistrations/urn:ngsi-ld:ContextSourceRegistration:R1
+
+
+
+03. GET the registration - it is in the registration cache
+==========================================================
+HTTP/1.1 200 OK
+Content-Length: REGEX(.*)
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+{
+    "contextSourceInfo": [
+        {
+            "key": "jsonldContext",
+            "value": "REGEX(http://localhost:\d+/ngsi-ld/v1/jsonldContexts/.*)"
+        }
+    ],
+    "endpoint": "http://localhost:9997",
+    "id": "urn:ngsi-ld:ContextSourceRegistration:R1",
+    "information": [
+        {
+            "entities": [
+                {
+                    "id": "urn:ngsi-ld:Device:lum-ip-001",
+                    "type": "Device"
+                }
+            ],
+            "propertyNames": [
+                "setDimmer"
+            ]
+        }
+    ],
+    "mode": "exclusive",
+    "operations": [
+        "updateOps"
+    ],
+    "origin": "cache",
+    "status": "active",
+    "type": "ContextSourceRegistration"
+}
+
+
+04. Restart the broker
+======================
+
+
+05. GET the registration - it is STILL in the cache (it was not re-downloaded)
+==============================================================================
+HTTP/1.1 200 OK
+Content-Length: REGEX(.*)
+Content-Type: application/json
+Date: REGEX(.*)
+Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
+
+{
+    "contextSourceInfo": [
+        {
+            "key": "jsonldContext",
+            "value": "REGEX(http://localhost:\d+/ngsi-ld/v1/jsonldContexts/.*)"
+        }
+    ],
+    "endpoint": "http://localhost:9997",
+    "id": "urn:ngsi-ld:ContextSourceRegistration:R1",
+    "information": [
+        {
+            "entities": [
+                {
+                    "id": "urn:ngsi-ld:Device:lum-ip-001",
+                    "type": "Device"
+                }
+            ],
+            "propertyNames": [
+                "setDimmer"
+            ]
+        }
+    ],
+    "mode": "exclusive",
+    "operations": [
+        "updateOps"
+    ],
+    "origin": "cache",
+    "status": "active",
+    "type": "ContextSourceRegistration"
+}
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
Fixes #1977 — Orion-LD never opens its HTTP port after a restart when a registration carries `contextSourceInfo`.

## Cause

A registration whose `contextSourceInfo` holds a `jsonldContext` resolves that `@context` as it enters the registration cache. But `regCacheInit()` ran *before* `orionldServiceInit()`, and `orionldServiceInit()` is where the `@context` cache is loaded from the database:

```
orionldServiceInit -> orionldContextInit -> orionldContextCacheInit -> mongocContextCacheGet()
```

So at startup that lookup **always missed**, and a miss makes `orionldContextFromUrl()` go to the network — `contextDownloadAttempts` tries of `contextDownloadTimeout` each, per registration — all of it before `restStart()` binds the port.

With no route to the `@context` server, the broker therefore never starts listening: the process is up, nothing is bound to 1026, and `/version` answers `Connection reset by peer`. Exactly the reported symptoms.

This also explains the reporter's three observations:

| observation | why |
|---|---|
| only fails **after a restart** | at creation the `@context` is downloaded and the live cache still holds it |
| only with a device that has **commands** | that is the only case where the IoT Agent creates a registration carrying `contextSourceInfo.jsonldContext` |
| `$unset contextSourceInfo` fixes it | `regCacheItemContextCheck()` then returns early — no lookup, no download |

## Fix

Move `regCacheInit()` to after `orionldServiceInit()`. A `@context` that was persisted when the registration was created (`mongocContextCachePersist`) is then found in the cache, and no network request is made during startup. `regCacheInit()` still needs `orionldTenantInit()` and `mongocInit()` before it, and both still come first.

This mirrors what `subCachesInit()` already does on the `feature/HA` branch, for the same reason — caching a subscription also resolves its `@context`.

## Scope — what this does not do

This removes the startup download for any `@context` that is **in the persisted cache**, which is the reported scenario. It does not make startup immune to a `@context` that genuinely cannot be resolved (one never persisted, or a cache wiped independently of the registrations) — that case would still retry-and-timeout before the port opens.

The stronger guarantee is to not do network I/O before the port is bound at all, e.g. by resolving a registration's forwarding `@context` lazily on first use instead of at cache-load. Worth doing, but a bigger change than this fix, and deliberately not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)