### PR TITLE
build(docker): kjson 0.12.0 in the base image

### DIFF
--- a/docker/build-ubi/04.install-k-libs.sh
+++ b/docker/build-ubi/04.install-k-libs.sh
@@ -55,7 +55,7 @@ do
         branch=release/0.1.0
     elif [ $kproj = "kjson" ]
     then
-        branch=release/0.11.2
+        branch=release/0.12.0
     elif [ $kproj = "kalloc" ]
     then
         branch=release/0.10.1


### PR DESCRIPTION
Bumps the kjson pin in `docker/build-ubi/04.install-k-libs.sh` from `release/0.11.2` to `release/0.12.0`.

kjson 0.12.0 adds `kjArraySort` (and `kjNodeCompare`), which the broker uses to give the `notUpdated` array of a 207 Multi-Status response a deterministic order. `kjSort` is unchanged - it still leaves every Array alone, as the order of an Array is part of the value in NGSI-LD.

**One file on purpose.** A PR that changes the base image is built and tested against the *old* base image, so nothing that needs the new kjson can ride along - the broker change and the `"kjson version": "0.12.0"` assertion in `ngsild_version.test` follow in a separate PR, once this one is merged and the new base image is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)