### PR TITLE
fix(207): order the "notUpdated" array, so the response is deterministic

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,5 @@
 ## Fixed Issues
+  #XXXX - The 'notUpdated' array of a 207 Multi-Status response is now in a deterministic order. Both arrays of that response are sets - the order of their items carries no meaning - and with a distributed operation the order was simply the order in which the registrants answered, so two identical requests gave two different responses. 'updated' was already sorted; 'notUpdated' now is too
   #XXXX - Fixed relative references inside an "@context" array: per RFC 3986 clause 5 a String inside an "@context" array is an IRI *reference* and is resolved against the URL of the document that carries it. Previously such an entry was taken as-is, so a served or remote @context using relative references (e.g. "user-context.jsonld") failed to load
   #XXXX - Fixed an @context's own URL being confused with the reference it points to, which made a later lookup of that @context resolve to the wrong document
   #XXXX - TRoE: a failing SQL statement was silently dropped - no log entry, the transaction aborted, and COMMIT acted as ROLLBACK, so the temporal write was lost without a trace. Such errors are now logged (status, Postgres message and the offending statement) and the transaction is rolled back explicitly
@@ -128,6 +129,7 @@
   - Converted /v1/admin/* routes to /admin/* (dropped the v1 prefix)
 
 ## Library version updates
+  - Bumped kjson from 0.11.2 to 0.12.0 (new function kjArraySort, to order the elements of a JSON Array)
   - Replaced prometheus-client-c with kprom
   - Bumped PostgreSQL client packages from v13 to v17
   - Bumped PostgreSQL in installation guides from v12 to v17

--- a/src/lib/orionld/common/responseFix.cpp
+++ b/src/lib/orionld/common/responseFix.cpp
@@ -28,6 +28,7 @@ extern "C"
 #include "kjson/kjLookup.h"                                      // kjLookup
 #include "kjson/kjBuilder.h"                                     // kjChildRemove
 #include "kjson/kjStringArraySort.h"                             // kjStringArraySort
+#include "kjson/kjArraySort.h"                                   // kjArraySort
 #include "kjson/kjChildCount.h"                                  // kjChildCount
 }
 
@@ -83,8 +84,16 @@ void responseFix(KjNode* responseBody, DistOpType operation, int okCode, const c
   }
   else
   {
+    //
+    // Both arrays are SETS - the order of their items carries no meaning, and with
+    // distributed operations it is simply the order in which the answers came back.
+    // Sorting them makes the response deterministic.
+    //
     if (successes > 1)
-      kjStringArraySort(successArray);
+      kjStringArraySort(successArray);   // "updated" - an Array of attribute names
+
+    if (failures > 1)
+      kjArraySort(failureArray);         // "notUpdated" - an Array of objects
 
     orionldState.httpStatusCode = 207;
     orionldState.responseTree   = responseBody;

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_forward_post_entities-errors.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_forward_post_entities-errors.test
@@ -384,22 +384,21 @@ Location: /ngsi-ld/v1/entities/urn:E1
 {
     "entityId": "urn:E1",
     "notUpdated": [
-#SORT_START
-        {
-            "attributes": [
-                "P6"
-            ],
-            "detail": "Unable to connect to registrant",
-            "registrationId": "urn:R3",
-            "statusCode": 504,
-            "title": "Unable to send distributed request"
-        },
         {
             "attributes": [
                 "P3"
             ],
             "detail": "Unable to connect to registrant",
             "registrationId": "urn:R2",
+            "statusCode": 504,
+            "title": "Unable to send distributed request"
+        },
+        {
+            "attributes": [
+                "P6"
+            ],
+            "detail": "Unable to connect to registrant",
+            "registrationId": "urn:R3",
             "statusCode": 504,
             "title": "Unable to send distributed request"
         },
@@ -412,7 +411,6 @@ Location: /ngsi-ld/v1/entities/urn:E1
             "statusCode": 409,
             "title": "Error during Distributed Operation"
         }
-#SORT_END
     ],
     "updated": [
         "A1",

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_patch_attributes.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_patch_attributes.test
@@ -589,7 +589,7 @@ Link: <https://raw.githubusercontent.com/FIWARE/tutorials.NGSI-LD/master/app/pub
     "notUpdated": [
         {
             "attributes": [
-                "weight"
+                "noSuchAttr"
             ],
             "statusCode": 404,
             "title": "Attribute Not Found"
@@ -603,7 +603,7 @@ Link: <https://raw.githubusercontent.com/FIWARE/tutorials.NGSI-LD/master/app/pub
         },
         {
             "attributes": [
-                "noSuchAttr"
+                "weight"
             ],
             "statusCode": 404,
             "title": "Attribute Not Found"
@@ -782,7 +782,7 @@ Link: REGEX(.*)
     "notUpdated": [
         {
             "attributes": [
-                "weight"
+                "noSuchAttr"
             ],
             "statusCode": 404,
             "title": "Attribute Not Found"
@@ -796,7 +796,7 @@ Link: REGEX(.*)
         },
         {
             "attributes": [
-                "noSuchAttr"
+                "weight"
             ],
             "statusCode": 404,
             "title": "Attribute Not Found"

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_post_entity_with_forwarding.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_new_post_entity_with_forwarding.test
@@ -696,7 +696,6 @@ Date: REGEX(.*)
 Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
 
 {
-#SORT_START
     "notUpdated": [
         {
             "attributes": [
@@ -710,6 +709,16 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
                 "R5"
             ],
             "detail": "overwrite is not allowed",
+            "statusCode": 400,
+            "title": "attribute already exists"
+        },
+        {
+            "attributes": [
+                "P1",
+                "R1"
+            ],
+            "detail": "overwrite is not allowed",
+            "registrationId": "urn:R1",
             "statusCode": 400,
             "title": "attribute already exists"
         },
@@ -730,18 +739,7 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
             "registrationId": "urn:R2",
             "statusCode": 400,
             "title": "attribute already exists"
-        },
-        {
-            "attributes": [
-                "P1",
-                "R1"
-            ],
-            "detail": "overwrite is not allowed",
-            "registrationId": "urn:R1",
-            "statusCode": 400,
-            "title": "attribute already exists"
         }
-#SORT_END
     ],
     "updated": [
         "P4",

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_patch_entity_with_forwarding.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_patch_entity_with_forwarding.test
@@ -442,7 +442,6 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
 
 {
     "notUpdated": [
-#SORT_START
         {
             "attributes": [
                 "P3"
@@ -453,22 +452,6 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
         },
         {
             "attributes": [
-                "P6"
-            ],
-            "registrationId": "urn:ngsi-ld:registration:R4",
-            "statusCode": 404,
-            "title": "Attribute Not Found"
-        },
-        {
-            "attributes": [
-                "P7"
-            ],
-            "registrationId": "urn:ngsi-ld:registration:R4",
-            "statusCode": 404,
-            "title": "Attribute Not Found"
-        },
-        {
-            "attributes": [
                 "P3"
             ],
             "statusCode": 404,
@@ -478,6 +461,22 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
             "attributes": [
                 "P6"
             ],
+            "registrationId": "urn:ngsi-ld:registration:R4",
+            "statusCode": 404,
+            "title": "Attribute Not Found"
+        },
+        {
+            "attributes": [
+                "P6"
+            ],
+            "statusCode": 404,
+            "title": "Attribute Not Found"
+        },
+        {
+            "attributes": [
+                "P7"
+            ],
+            "registrationId": "urn:ngsi-ld:registration:R4",
             "statusCode": 404,
             "title": "Attribute Not Found"
         },
@@ -488,7 +487,6 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-contextREGEX(.*)
             "statusCode": 404,
             "title": "Attribute Not Found"
         }
-#SORT_END
     ],
     "updated": [
         "P1",

--- a/test/functionalTest/cases/0000_ld/ngsild/ngsild_version.test
+++ b/test/functionalTest/cases/0000_ld/ngsild/ngsild_version.test
@@ -23,6 +23,19 @@
 --NAME--
 Test of orionld version service, with branch name
 
+#
+# 'kjson version' is asserted LITERALLY here, unlike its neighbours.
+#
+# The k-libs are pinned per release branch in several different places, and they
+# drifted apart once already: the docker base image sat on kjson release/0.11
+# while everything else had moved to 0.11.1, so every image built from that base
+# was missing three bug fixes - and nothing noticed, because every k-lib version
+# in the test suite was REGEX'd. This one line is what notices.
+#
+# When kjson is bumped, this test fails and the pin in
+# docker/build-ubi/04.install-k-libs.sh is what to check.
+#
+
 --SHELL-INIT--
 dbInit CB
 orionldStart CB -troe
@@ -78,7 +91,7 @@ Date: REGEX(.*)
   "kalloc version": "REGEX(.*)",
   "kbase version": "REGEX(.*)",
   "khash version": "REGEX(.*)",
-  "kjson version": "REGEX(.*)",
+  "kjson version": "0.12.0",
   "kprom version": "0.1.0",
   "ktrace version": "REGEX(.*)",
   "libcurl version": REGEX(.*),

--- a/test/functionalTest/cases/0000_ld/troe/troe_new_exhaustive_patch_attributes.test
+++ b/test/functionalTest/cases/0000_ld/troe/troe_new_exhaustive_patch_attributes.test
@@ -736,7 +736,7 @@ Link: <https://raw.githubusercontent.com/FIWARE/tutorials.NGSI-LD/master/app/pub
     "notUpdated": [
         {
             "attributes": [
-                "weight"
+                "noSuchAttr"
             ],
             "statusCode": 404,
             "title": "Attribute Not Found"
@@ -750,7 +750,7 @@ Link: <https://raw.githubusercontent.com/FIWARE/tutorials.NGSI-LD/master/app/pub
         },
         {
             "attributes": [
-                "noSuchAttr"
+                "weight"
             ],
             "statusCode": 404,
             "title": "Attribute Not Found"
@@ -831,7 +831,7 @@ Link: <https://raw.githubusercontent.com/FIWARE/tutorials.NGSI-LD/master/app/pub
     "notUpdated": [
         {
             "attributes": [
-                "weight"
+                "noSuchAttr"
             ],
             "statusCode": 404,
             "title": "Attribute Not Found"
@@ -845,7 +845,7 @@ Link: <https://raw.githubusercontent.com/FIWARE/tutorials.NGSI-LD/master/app/pub
         },
         {
             "attributes": [
-                "noSuchAttr"
+                "weight"
             ],
             "statusCode": 404,
             "title": "Attribute Not Found"
@@ -927,7 +927,7 @@ Link: REGEX(.*)
     "notUpdated": [
         {
             "attributes": [
-                "weight"
+                "noSuchAttr"
             ],
             "statusCode": 404,
             "title": "Attribute Not Found"
@@ -941,7 +941,7 @@ Link: REGEX(.*)
         },
         {
             "attributes": [
-                "noSuchAttr"
+                "weight"
             ],
             "statusCode": 404,
             "title": "Attribute Not Found"
@@ -1022,7 +1022,7 @@ Link: <https://raw.githubusercontent.com/FIWARE/tutorials.NGSI-LD/master/app/pub
     "notUpdated": [
         {
             "attributes": [
-                "weight"
+                "noSuchAttr"
             ],
             "statusCode": 404,
             "title": "Attribute Not Found"
@@ -1036,7 +1036,7 @@ Link: <https://raw.githubusercontent.com/FIWARE/tutorials.NGSI-LD/master/app/pub
         },
         {
             "attributes": [
-                "noSuchAttr"
+                "weight"
             ],
             "statusCode": 404,
             "title": "Attribute Not Found"


### PR DESCRIPTION
Follow-up to #1981, which put kjson 0.12.0 in the base image. This is the part that needs it.

## The problem

Both arrays of a 207 Multi-Status response are *sets* - the order of their items carries no meaning. `updated` has been sorted for years (`kjStringArraySort`, it is an array of strings); `notUpdated` never was, because it is an array of objects and there was no tool for that.

With a distributed operation that order is simply the order in which the registrants answered, so two identical requests gave two different responses - and `ngsild_patch_entity_with_forwarding` flaked in a full run while passing on its own.

`#SORT_START`/`#SORT_END` cannot paper over it: it sorts *lines*, and the last element of a JSON array is the one without a trailing comma, so a different element order is a different set of lines.

## The fix

kjson 0.12.0 adds `kjArraySort` (and `kjNodeCompare`), called from `responseFix()` right beside the `kjStringArraySort` that already sorted `updated`:

```c
if (successes > 1)  kjStringArraySort(successArray);   // "updated"    - an Array of attribute names
if (failures  > 1)  kjArraySort(failureArray);         // "notUpdated" - an Array of objects
```

`kjSort` is deliberately **not** changed - it still leaves every Array alone. The order of an Array is part of the value in NGSI-LD, and `kjSort`'s other caller (`MongoCommonUpdate.cpp`) sorts and renders the old and the new value of a compound attribute to decide whether to notify: ordering arrays there would make `["a","b"]` -> `["b","a"]` compare equal and the notification would be lost. You have to name the array you want ordered.

## Worth knowing

The same `notUpdated` entry was being emitted with its members in three different orders, depending on where it was built:

```
statusCode, title, attributes                    - a local failure           (distOpFailure.cpp)
registrationId, statusCode, title, attributes    - local, behind a registration
statusCode, title, attributes, registrationId    - returned by a remote broker (distOpResponses.cpp)
```

No functest ever saw this - the harness pipes every response through `python3 -m json.tool --sort-keys` - and JSON member order is insignificant, so nothing was wrong. But elements are compared member by member, so the members must be canonical before the elements can be; `kjArraySort` calls `kjSort` on the way in for exactly that reason.

## Tests

- 4 expect files reordered. Verified to be a **pure reorder**: sorting each file before and after (minus the `#SORT` markers) gives an identical line multiset - no status code, title, detail or entry appeared or disappeared.
- 3 `#SORT_START`/`#SORT_END` blocks removed - the ones that existed only for a `notUpdated` array. The rest stay: they cover entity arrays in query responses, the geo-index listing and notification arrival order, none of which this touches.
- `ngsild_version.test` now asserts the kjson version **literally**. Every k-lib version in the suite was `REGEX(.*)`, which is how the base image sat on an old kjson for months without anything noticing.

**Full functional suite: 1787/1787, 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)